### PR TITLE
Used macros to allow compilation with C++11 and constexpr

### DIFF
--- a/Imath/ImathBox.h
+++ b/Imath/ImathBox.h
@@ -84,9 +84,9 @@ class Box
     //	Constructors - an "empty" box is created by default
     //-----------------------------------------------------
 
-    constexpr Box (); 
-    constexpr Box (const T &point);
-    constexpr Box (const T &minT, const T &maxT);
+    IMATH_CONSTEXPR14 Box (); 
+    IMATH_CONSTEXPR14 Box (const T &point);
+    IMATH_CONSTEXPR14 Box (const T &minT, const T &maxT);
 
     //--------------------
     //  Operators:  ==, !=
@@ -145,14 +145,14 @@ typedef Box <V3d> Box3d;
 
 
 template <class T>
-constexpr inline Box<T>::Box()
+IMATH_CONSTEXPR14 inline Box<T>::Box()
 {
     makeEmpty();
 }
 
 
 template <class T>
-constexpr inline Box<T>::Box (const T &point)
+IMATH_CONSTEXPR14 inline Box<T>::Box (const T &point)
 {
     min = point;
     max = point;
@@ -160,7 +160,7 @@ constexpr inline Box<T>::Box (const T &point)
 
 
 template <class T>
-constexpr inline Box<T>::Box (const T &minT, const T &maxT)
+IMATH_CONSTEXPR14 inline Box<T>::Box (const T &minT, const T &maxT)
 {
     min = minT;
     max = maxT;
@@ -356,9 +356,9 @@ class Box<Vec2<T> >
     //  Constructors - an "empty" box is created by default
     //-----------------------------------------------------
 
-    constexpr Box(); 
-    constexpr Box (const Vec2<T> &point);
-    constexpr Box (const Vec2<T> &minT, const Vec2<T> &maxT);
+    IMATH_CONSTEXPR14 Box(); 
+    IMATH_CONSTEXPR14 Box (const Vec2<T> &point);
+    IMATH_CONSTEXPR14 Box (const Vec2<T> &minT, const Vec2<T> &maxT);
 
     //--------------------
     //  Operators:  ==, !=
@@ -402,14 +402,14 @@ class Box<Vec2<T> >
 //  Implementation
 
 template <class T>
-constexpr inline Box<Vec2<T> >::Box()
+IMATH_CONSTEXPR14 inline Box<Vec2<T> >::Box()
 {
     makeEmpty();
 }
 
 
 template <class T>
-constexpr inline Box<Vec2<T> >::Box (const Vec2<T> &point)
+IMATH_CONSTEXPR14 inline Box<Vec2<T> >::Box (const Vec2<T> &point)
 {
     min = point;
     max = point;
@@ -417,7 +417,7 @@ constexpr inline Box<Vec2<T> >::Box (const Vec2<T> &point)
 
 
 template <class T>
-constexpr inline Box<Vec2<T> >::Box (const Vec2<T> &minT, const Vec2<T> &maxT)
+IMATH_CONSTEXPR14 inline Box<Vec2<T> >::Box (const Vec2<T> &minT, const Vec2<T> &maxT)
 {
     min = minT;
     max = maxT;
@@ -578,7 +578,7 @@ Box<Vec2<T> >::majorAxis() const
 
     if (s[1] > s[major])
         major = 1;
-
+    
     return major;
 }
 
@@ -599,9 +599,9 @@ class Box<Vec3<T> >
     //  Constructors - an "empty" box is created by default
     //-----------------------------------------------------
 
-    constexpr Box(); 
-    constexpr Box (const Vec3<T> &point);
-    constexpr Box (const Vec3<T> &minT, const Vec3<T> &maxT);
+    IMATH_CONSTEXPR14 Box(); 
+    IMATH_CONSTEXPR14 Box (const Vec3<T> &point);
+    IMATH_CONSTEXPR14 Box (const Vec3<T> &minT, const Vec3<T> &maxT);
 
     //--------------------
     //  Operators:  ==, !=
@@ -646,14 +646,14 @@ class Box<Vec3<T> >
 
 
 template <class T>
-constexpr inline Box<Vec3<T> >::Box()
+IMATH_CONSTEXPR14 inline Box<Vec3<T> >::Box()
 {
     makeEmpty();
 }
 
 
 template <class T>
-constexpr inline Box<Vec3<T> >::Box (const Vec3<T> &point)
+IMATH_CONSTEXPR14 inline Box<Vec3<T> >::Box (const Vec3<T> &point)
 {
     min = point;
     max = point;
@@ -661,7 +661,7 @@ constexpr inline Box<Vec3<T> >::Box (const Vec3<T> &point)
 
 
 template <class T>
-constexpr inline Box<Vec3<T> >::Box (const Vec3<T> &minT, const Vec3<T> &maxT)
+IMATH_CONSTEXPR14 inline Box<Vec3<T> >::Box (const Vec3<T> &minT, const Vec3<T> &maxT)
 {
     min = minT;
     max = maxT;

--- a/Imath/ImathBoxAlgo.h
+++ b/Imath/ImathBoxAlgo.h
@@ -85,7 +85,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 
 template <class T>
-constexpr inline T
+IMATH_CONSTEXPR14 inline T
 clip (const T &p, const Box<T> &box)
 {
     //
@@ -118,7 +118,7 @@ closestPointInBox (const T &p, const Box<T> &box)
 
 
 template <class T>
-constexpr Vec3<T>
+IMATH_CONSTEXPR14 Vec3<T>
 closestPointOnBox (const Vec3<T> &p, const Box< Vec3<T> > &box)
 {
     //
@@ -161,7 +161,7 @@ closestPointOnBox (const Vec3<T> &p, const Box< Vec3<T> > &box)
 
 
 template <class S, class T>
-constexpr Box< Vec3<S> >
+IMATH_CONSTEXPR14 Box< Vec3<S> >
 transform (const Box< Vec3<S> > &box, const Matrix44<T> &m)
 {
     //
@@ -324,7 +324,7 @@ transform (const Box< Vec3<S> > &box,
 
 
 template <class S, class T>
-constexpr Box< Vec3<S> >
+IMATH_CONSTEXPR14 Box< Vec3<S> >
 affineTransform (const Box< Vec3<S> > &box, const Matrix44<T> &m)
 {
     //
@@ -434,7 +434,7 @@ affineTransform (const Box< Vec3<S> > &box,
 
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 findEntryAndExitPoints (const Line3<T> &r,
 			const Box<Vec3<T> > &b,
 			Vec3<T> &entry,
@@ -724,7 +724,7 @@ findEntryAndExitPoints (const Line3<T> &r,
 
 
 template<class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 intersects (const Box< Vec3<T> > &b, const Line3<T> &r, Vec3<T> &ip)
 {
     //
@@ -1003,7 +1003,7 @@ intersects (const Box< Vec3<T> > &b, const Line3<T> &r, Vec3<T> &ip)
 
 
 template<class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 intersects (const Box< Vec3<T> > &box, const Line3<T> &ray)
 {
     Vec3<T> ignored;

--- a/Imath/ImathColor.h
+++ b/Imath/ImathColor.h
@@ -73,7 +73,7 @@ class Color3: public Vec3 <T>
     constexpr Color3 (const Color3 &c);
     template <class S> constexpr Color3 (const Vec3<S> &v);
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Color3 &	operator = (const Color3 &c);
 
 
@@ -81,7 +81,7 @@ class Color3: public Vec3 <T>
     // Component-wise addition
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Color3 &	operator += (const Color3 &c);
     constexpr
     Color3		operator + (const Color3 &c) const;
@@ -91,7 +91,7 @@ class Color3: public Vec3 <T>
     // Component-wise subtraction
     //---------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Color3 &	operator -= (const Color3 &c);
     constexpr
     Color3		operator - (const Color3 &c) const;
@@ -103,7 +103,7 @@ class Color3: public Vec3 <T>
 
     constexpr
     Color3		operator - () const;
-    constexpr
+    IMATH_CONSTEXPR14
     const Color3 &	negate ();
 
 
@@ -111,9 +111,9 @@ class Color3: public Vec3 <T>
     // Component-wise multiplication
     //------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Color3 &	operator *= (const Color3 &c);
-    constexpr
+    IMATH_CONSTEXPR14
     const Color3 &	operator *= (T a);
     constexpr Color3	operator * (const Color3 &c) const;
     constexpr Color3	operator * (T a) const;
@@ -123,9 +123,9 @@ class Color3: public Vec3 <T>
     // Component-wise division
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Color3 &	operator /= (const Color3 &c);
-    constexpr
+    IMATH_CONSTEXPR14
     const Color3 &	operator /= (T a);
     constexpr Color3	operator / (const Color3 &c) const;
     constexpr Color3	operator / (T a) const;
@@ -150,9 +150,9 @@ template <class T> class Color4
     //-------------
 
     Color4 ();			    	// no initialization
-    constexpr
+    IMATH_CONSTEXPR14
     explicit Color4 (T a);		// (a a a a)
-    constexpr
+    IMATH_CONSTEXPR14
     Color4 (T a, T b, T c, T d);	// (a b c d)
     ~Color4 () = default;
 
@@ -160,10 +160,10 @@ template <class T> class Color4
     // Copy constructors and assignment
     //---------------------------------
 
-    constexpr Color4 (const Color4 &v);
-    template <class S> constexpr Color4 (const Color4<S> &v);
+    IMATH_CONSTEXPR14 Color4 (const Color4 &v);
+    template <class S> IMATH_CONSTEXPR14 Color4 (const Color4<S> &v);
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Color4 &	operator = (const Color4 &v);
 
 
@@ -202,7 +202,7 @@ template <class T> class Color4
     // Component-wise addition
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Color4 &	operator += (const Color4 &v);
     constexpr Color4	operator + (const Color4 &v) const;
 
@@ -211,7 +211,7 @@ template <class T> class Color4
     // Component-wise subtraction
     //---------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Color4 &	operator -= (const Color4 &v);
     constexpr Color4	operator - (const Color4 &v) const;
 
@@ -221,7 +221,7 @@ template <class T> class Color4
     //------------------------------------
 
     constexpr Color4	operator - () const;
-    constexpr
+    IMATH_CONSTEXPR14
     const Color4 &	negate ();
 
 
@@ -229,9 +229,9 @@ template <class T> class Color4
     // Component-wise multiplication
     //------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Color4 &	operator *= (const Color4 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Color4 &	operator *= (T a);
     constexpr Color4	operator * (const Color4 &v) const;
     constexpr Color4	operator * (T a) const;
@@ -241,9 +241,9 @@ template <class T> class Color4
     // Component-wise division
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Color4 &	operator /= (const Color4 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Color4 &	operator /= (T a);
     constexpr Color4	operator / (const Color4 &v) const;
     constexpr Color4	operator / (T a) const;
@@ -349,7 +349,7 @@ Color3<T>::Color3 (const Vec3<S> &v): Vec3 <T> (v)
 }
 
 template <class T>
-constexpr inline const Color3<T> &
+IMATH_CONSTEXPR14 inline const Color3<T> &
 Color3<T>::operator = (const Color3 &c)
 {
     *((Vec3<T> *) this) = c;
@@ -357,7 +357,7 @@ Color3<T>::operator = (const Color3 &c)
 }
 
 template <class T>
-constexpr inline const Color3<T> &
+IMATH_CONSTEXPR14 inline const Color3<T> &
 Color3<T>::operator += (const Color3 &c)
 {
     *((Vec3<T> *) this) += c;
@@ -372,7 +372,7 @@ Color3<T>::operator + (const Color3 &c) const
 }
 
 template <class T>
-constexpr inline const Color3<T> &
+IMATH_CONSTEXPR14 inline const Color3<T> &
 Color3<T>::operator -= (const Color3 &c)
 {
     *((Vec3<T> *) this) -= c;
@@ -394,7 +394,7 @@ Color3<T>::operator - () const
 }
 
 template <class T>
-constexpr inline const Color3<T> &
+IMATH_CONSTEXPR14 inline const Color3<T> &
 Color3<T>::negate ()
 {
     ((Vec3<T> *) this)->negate();
@@ -402,7 +402,7 @@ Color3<T>::negate ()
 }
 
 template <class T>
-constexpr inline const Color3<T> &
+IMATH_CONSTEXPR14 inline const Color3<T> &
 Color3<T>::operator *= (const Color3 &c)
 {
     *((Vec3<T> *) this) *= c;
@@ -410,7 +410,7 @@ Color3<T>::operator *= (const Color3 &c)
 }
 
 template <class T>
-constexpr inline const Color3<T> &
+IMATH_CONSTEXPR14 inline const Color3<T> &
 Color3<T>::operator *= (T a)
 {
     *((Vec3<T> *) this) *= a;
@@ -432,7 +432,7 @@ Color3<T>::operator * (T a) const
 }
 
 template <class T>
-constexpr inline const Color3<T> &
+IMATH_CONSTEXPR14 inline const Color3<T> &
 Color3<T>::operator /= (const Color3 &c)
 {
     *((Vec3<T> *) this) /= c;
@@ -440,7 +440,7 @@ Color3<T>::operator /= (const Color3 &c)
 }
 
 template <class T>
-constexpr inline const Color3<T> &
+IMATH_CONSTEXPR14 inline const Color3<T> &
 Color3<T>::operator /= (T a)
 {
     *((Vec3<T> *) this) /= a;
@@ -487,14 +487,14 @@ Color4<T>::Color4 ()
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Color4<T>::Color4 (T x)
 {
     r = g = b = a = x;
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Color4<T>::Color4 (T x, T y, T z, T w)
 {
     r = x;
@@ -504,7 +504,7 @@ Color4<T>::Color4 (T x, T y, T z, T w)
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Color4<T>::Color4 (const Color4 &v)
 {
     r = v.r;
@@ -515,7 +515,7 @@ Color4<T>::Color4 (const Color4 &v)
 
 template <class T>
 template <class S>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Color4<T>::Color4 (const Color4<S> &v)
 {
     r = T (v.r);
@@ -525,7 +525,7 @@ Color4<T>::Color4 (const Color4<S> &v)
 }
 
 template <class T>
-constexpr inline const Color4<T> &
+IMATH_CONSTEXPR14 inline const Color4<T> &
 Color4<T>::operator = (const Color4 &v)
 {
     r = v.r;
@@ -610,7 +610,7 @@ Color4<T>::operator != (const Color4<S> &v) const
 }
 
 template <class T>
-constexpr inline const Color4<T> &
+IMATH_CONSTEXPR14 inline const Color4<T> &
 Color4<T>::operator += (const Color4 &v)
 {
     r += v.r;
@@ -628,7 +628,7 @@ Color4<T>::operator + (const Color4 &v) const
 }
 
 template <class T>
-constexpr inline const Color4<T> &
+IMATH_CONSTEXPR14 inline const Color4<T> &
 Color4<T>::operator -= (const Color4 &v)
 {
     r -= v.r;
@@ -653,7 +653,7 @@ Color4<T>::operator - () const
 }
 
 template <class T>
-constexpr inline const Color4<T> &
+IMATH_CONSTEXPR14 inline const Color4<T> &
 Color4<T>::negate ()
 {
     r = -r;
@@ -664,7 +664,7 @@ Color4<T>::negate ()
 }
 
 template <class T>
-constexpr inline const Color4<T> &
+IMATH_CONSTEXPR14 inline const Color4<T> &
 Color4<T>::operator *= (const Color4 &v)
 {
     r *= v.r;
@@ -675,7 +675,7 @@ Color4<T>::operator *= (const Color4 &v)
 }
 
 template <class T>
-constexpr inline const Color4<T> &
+IMATH_CONSTEXPR14 inline const Color4<T> &
 Color4<T>::operator *= (T x)
 {
     r *= x;
@@ -700,7 +700,7 @@ Color4<T>::operator * (T x) const
 }
 
 template <class T>
-constexpr inline const Color4<T> &
+IMATH_CONSTEXPR14 inline const Color4<T> &
 Color4<T>::operator /= (const Color4 &v)
 {
     r /= v.r;
@@ -711,7 +711,7 @@ Color4<T>::operator /= (const Color4 &v)
 }
 
 template <class T>
-constexpr inline const Color4<T> &
+IMATH_CONSTEXPR14 inline const Color4<T> &
 Color4<T>::operator /= (T x)
 {
     r /= x;

--- a/Imath/ImathColorAlgo.h
+++ b/Imath/ImathColorAlgo.h
@@ -69,7 +69,7 @@ IMATH_EXPORT Color4<double>	rgb2hsv_d(const Color4<double> &rgb);
 //
 
 template<class T> 
-constexpr Vec3<T>  
+IMATH_CONSTEXPR14 Vec3<T>  
 hsv2rgb(const Vec3<T> &hsv)
 {
     if ( limits<T>::isIntegral() )
@@ -117,7 +117,7 @@ hsv2rgb(const Color4<T> &hsv)
 
 
 template<class T> 
-constexpr Vec3<T>  
+IMATH_CONSTEXPR14 Vec3<T>  
 rgb2hsv(const Vec3<T> &rgb)
 {
     if ( limits<T>::isIntegral() )
@@ -140,7 +140,7 @@ rgb2hsv(const Vec3<T> &rgb)
 
 
 template<class T> 
-constexpr Color4<T>  
+IMATH_CONSTEXPR14 Color4<T>  
 rgb2hsv(const Color4<T> &rgb)
 {
     if ( limits<T>::isIntegral() )
@@ -164,7 +164,7 @@ rgb2hsv(const Color4<T> &rgb)
 }
 
 template <class T>
-constexpr PackedColor
+IMATH_CONSTEXPR14 PackedColor
 rgb2packed(const Vec3<T> &c)
 {
     if ( limits<T>::isIntegral() )
@@ -183,7 +183,7 @@ rgb2packed(const Vec3<T> &c)
 }
 
 template <class T>
-constexpr PackedColor
+IMATH_CONSTEXPR14 PackedColor
 rgb2packed(const Color4<T> &c)
 {
     if ( limits<T>::isIntegral() )

--- a/Imath/ImathEuler.h
+++ b/Imath/ImathEuler.h
@@ -218,13 +218,13 @@ class Euler : public Vec3<T>
     //--------------------------------------------------------------------
 
     constexpr Euler();
-    constexpr Euler(const Euler&);
-    constexpr Euler(Order p);
-    constexpr Euler(const Vec3<T> &v, Order o = Default, InputLayout l = IJKLayout);
-    constexpr Euler(T i, T j, T k, Order o = Default, InputLayout l = IJKLayout);
-    constexpr Euler(const Euler<T> &euler, Order newp);
-    constexpr Euler(const Matrix33<T> &, Order o = Default);
-    constexpr Euler(const Matrix44<T> &, Order o = Default);
+    IMATH_CONSTEXPR14 Euler(const Euler&);
+    IMATH_CONSTEXPR14 Euler(Order p);
+    IMATH_CONSTEXPR14 Euler(const Vec3<T> &v, Order o = Default, InputLayout l = IJKLayout);
+    IMATH_CONSTEXPR14 Euler(T i, T j, T k, Order o = Default, InputLayout l = IJKLayout);
+    IMATH_CONSTEXPR14 Euler(const Euler<T> &euler, Order newp);
+    IMATH_CONSTEXPR14 Euler(const Matrix33<T> &, Order o = Default);
+    IMATH_CONSTEXPR14 Euler(const Matrix44<T> &, Order o = Default);
 
     //-------------
     //  Destructor
@@ -236,9 +236,9 @@ class Euler : public Vec3<T>
     //  Algebraic functions/ Operators
     //---------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Euler<T>&	operator=  (const Euler<T>&);
-    constexpr
+    IMATH_CONSTEXPR14
     const Euler<T>&	operator=  (const Vec3<T>&);
 
     //--------------------------------------------------------
@@ -252,7 +252,8 @@ class Euler : public Vec3<T>
 
     void		setXYZVector(const Vec3<T> &);
 
-    constexpr Order	order() const;
+    IMATH_CONSTEXPR14
+    Order	        order() const;
     void		setOrder(Order);
 
     void		set(Axis initial,
@@ -322,7 +323,7 @@ class Euler : public Vec3<T>
     //
     //-----------------------------------------------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     static float	angleMod (T angle);
     static void		simpleXYZRotation (Vec3<T> &xyzRot,
 					   const Vec3<T> &targetXyzRot);
@@ -416,7 +417,7 @@ constexpr Euler<T>::Euler() :
 {}
 
 template<class T>
-constexpr Euler<T>::Euler(typename Euler<T>::Order p) :
+IMATH_CONSTEXPR14 Euler<T>::Euler(typename Euler<T>::Order p) :
     Vec3<T>(0,0,0),
     _frameStatic(true),
     _initialRepeated(false),
@@ -427,7 +428,7 @@ constexpr Euler<T>::Euler(typename Euler<T>::Order p) :
 }
 
 template<class T>
-constexpr inline Euler<T>::Euler( const Vec3<T> &v, 
+IMATH_CONSTEXPR14 inline Euler<T>::Euler( const Vec3<T> &v, 
 			typename Euler<T>::Order p, 
 			typename Euler<T>::InputLayout l ) 
 {
@@ -437,13 +438,13 @@ constexpr inline Euler<T>::Euler( const Vec3<T> &v,
 }
 
 template<class T>
-constexpr inline Euler<T>::Euler(const Euler<T> &euler)
+IMATH_CONSTEXPR14 inline Euler<T>::Euler(const Euler<T> &euler)
 {
     operator=(euler);
 }
 
 template<class T>
-constexpr inline Euler<T>::Euler(const Euler<T> &euler,Order p)
+IMATH_CONSTEXPR14 inline Euler<T>::Euler(const Euler<T> &euler,Order p)
 {
     setOrder(p);
     Matrix33<T> M = euler.toMatrix33();
@@ -451,7 +452,7 @@ constexpr inline Euler<T>::Euler(const Euler<T> &euler,Order p)
 }
 
 template<class T>
-constexpr inline Euler<T>::Euler( T xi, T yi, T zi, 
+IMATH_CONSTEXPR14 inline Euler<T>::Euler( T xi, T yi, T zi, 
 			typename Euler<T>::Order p,
 			typename Euler<T>::InputLayout l)
 {
@@ -461,14 +462,14 @@ constexpr inline Euler<T>::Euler( T xi, T yi, T zi,
 }
 
 template<class T>
-constexpr inline Euler<T>::Euler( const Matrix33<T> &M, typename Euler::Order p )
+IMATH_CONSTEXPR14 inline Euler<T>::Euler( const Matrix33<T> &M, typename Euler::Order p )
 {
     setOrder(p);
     extract(M);
 }
 
 template<class T>
-constexpr inline Euler<T>::Euler( const Matrix44<T> &M, typename Euler::Order p )
+IMATH_CONSTEXPR14 inline Euler<T>::Euler( const Matrix44<T> &M, typename Euler::Order p )
 {
     setOrder(p);
     extract(M);
@@ -783,7 +784,7 @@ Euler<T>::legal(typename Euler<T>::Order order)
 }
 
 template<class T>
-constexpr typename Euler<T>::Order
+IMATH_CONSTEXPR14 typename Euler<T>::Order
 Euler<T>::order() const
 {
     int foo = (_initialAxis == Z ? 0x2000 : (_initialAxis == Y ? 0x1000 : 0));
@@ -817,7 +818,7 @@ void Euler<T>::set(typename Euler<T>::Axis axis,
 }
 
 template<class T>
-constexpr const Euler<T>& Euler<T>::operator= (const Euler<T> &euler)
+IMATH_CONSTEXPR14 const Euler<T>& Euler<T>::operator= (const Euler<T> &euler)
 {
     x = euler.x;
     y = euler.y;
@@ -830,7 +831,7 @@ constexpr const Euler<T>& Euler<T>::operator= (const Euler<T> &euler)
 }
 
 template<class T>
-constexpr const Euler<T>& Euler<T>::operator= (const Vec3<T> &v)
+IMATH_CONSTEXPR14 const Euler<T>& Euler<T>::operator= (const Vec3<T> &v)
 {
     x = v.x;
     y = v.y;
@@ -857,7 +858,7 @@ std::ostream& operator << (std::ostream &o, const Euler<T> &euler)
 }
 
 template <class T>
-constexpr float
+IMATH_CONSTEXPR14 float
 Euler<T>::angleMod (T angle)
 {
     const T pi = static_cast<T>(M_PI);

--- a/Imath/ImathFrustum.h
+++ b/Imath/ImathFrustum.h
@@ -68,17 +68,17 @@ template<class T>
 class Frustum
 {
   public:
-    constexpr Frustum();
-    constexpr Frustum(const Frustum &);
-    constexpr Frustum(T nearPlane, T farPlane, T left, T right, T top, T bottom, bool ortho=false);
-    constexpr Frustum(T nearPlane, T farPlane, T fovx, T fovy, T aspect);
+    IMATH_CONSTEXPR14 Frustum();
+    IMATH_CONSTEXPR14 Frustum(const Frustum &);
+    IMATH_CONSTEXPR14 Frustum(T nearPlane, T farPlane, T left, T right, T top, T bottom, bool ortho=false);
+    IMATH_CONSTEXPR14 Frustum(T nearPlane, T farPlane, T fovx, T fovy, T aspect);
     virtual ~Frustum();
 
     //--------------------
     // Assignment operator
     //--------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Frustum &     operator = (const Frustum &);
 
     //--------------------
@@ -183,7 +183,7 @@ class Frustum
 
 
 template<class T>
-constexpr inline Frustum<T>::Frustum()
+IMATH_CONSTEXPR14 inline Frustum<T>::Frustum()
 {
     set(T (0.1),
         T (1000.0),
@@ -195,19 +195,19 @@ constexpr inline Frustum<T>::Frustum()
 }
 
 template<class T>
-constexpr inline Frustum<T>::Frustum(const Frustum &f)
+IMATH_CONSTEXPR14 inline Frustum<T>::Frustum(const Frustum &f)
 {
     *this = f;
 }
 
 template<class T>
-constexpr inline Frustum<T>::Frustum(T n, T f, T l, T r, T t, T b, bool o)
+IMATH_CONSTEXPR14 inline Frustum<T>::Frustum(T n, T f, T l, T r, T t, T b, bool o)
 {
     set(n,f,l,r,t,b,o);
 }
 
 template<class T>
-constexpr inline Frustum<T>::Frustum(T nearPlane, T farPlane, T fovx, T fovy, T aspect)
+IMATH_CONSTEXPR14 inline Frustum<T>::Frustum(T nearPlane, T farPlane, T fovx, T fovy, T aspect)
 {
     set(nearPlane,farPlane,fovx,fovy,aspect);
 }
@@ -218,7 +218,7 @@ Frustum<T>::~Frustum()
 }
 
 template<class T>
-constexpr const Frustum<T> &
+IMATH_CONSTEXPR14 const Frustum<T> &
 Frustum<T>::operator = (const Frustum &f)
 {
     _nearPlane    = f._nearPlane;

--- a/Imath/ImathFun.h
+++ b/Imath/ImathFun.h
@@ -83,7 +83,7 @@ ulerp (T a, T b, Q t)
 
 
 template <class T>
-constexpr inline T
+IMATH_CONSTEXPR14 inline T
 lerpfactor(T m, T a, T b)
 {
     //

--- a/Imath/ImathLine.h
+++ b/Imath/ImathLine.h
@@ -64,7 +64,7 @@ class Line3
     //-------------------------------------------------------------
 
     constexpr Line3() {}
-    constexpr Line3(const Vec3<T>& point1, const Vec3<T>& point2);
+    IMATH_CONSTEXPR14 Line3(const Vec3<T>& point1, const Vec3<T>& point2);
 
     //------------------
     //	State Query/Set
@@ -84,9 +84,9 @@ class Line3
     //---------
 
     constexpr T			distanceTo(const Vec3<T>& point) const;
-    constexpr T			distanceTo(const Line3<T>& line) const;
+    IMATH_CONSTEXPR14 T	     	distanceTo(const Line3<T>& line) const;
     constexpr Vec3<T>  		closestPointTo(const Vec3<T>& point) const;
-    constexpr Vec3<T>		closestPointTo(const Line3<T>& line) const;
+    IMATH_CONSTEXPR14 Vec3<T>	closestPointTo(const Line3<T>& line) const;
 };
 
 
@@ -103,7 +103,7 @@ typedef Line3<double> Line3d;
 //---------------
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Line3<T>::Line3(const Vec3<T> &p0, const Vec3<T> &p1)
 {
     set(p0,p1);
@@ -138,7 +138,7 @@ Line3<T>::closestPointTo(const Vec3<T>& point) const
 }
 
 template <class T>
-constexpr inline T
+IMATH_CONSTEXPR14 inline T
 Line3<T>::distanceTo(const Line3<T>& line) const
 {
     T d = (dir % line.dir) ^ (line.pos - pos);
@@ -146,7 +146,7 @@ Line3<T>::distanceTo(const Line3<T>& line) const
 }
 
 template <class T>
-constexpr inline Vec3<T> 
+IMATH_CONSTEXPR14 inline Vec3<T> 
 Line3<T>::closestPointTo(const Line3<T>& line) const
 {
     // Assumes the lines are normalized

--- a/Imath/ImathLineAlgo.h
+++ b/Imath/ImathLineAlgo.h
@@ -80,7 +80,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 closestPoints
     (const Line3<T>& line1,
      const Line3<T>& line2,
@@ -120,7 +120,7 @@ closestPoints
 
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 intersect
     (const Line3<T> &line,
      const Vec3<T> &v0,
@@ -225,7 +225,7 @@ intersect
 
 
 template <class T>
-constexpr Vec3<T>
+IMATH_CONSTEXPR14 Vec3<T>
 closestVertex
     (const Vec3<T> &v0,
      const Vec3<T> &v1,
@@ -255,7 +255,7 @@ closestVertex
 
 
 template <class T>
-constexpr Vec3<T>
+IMATH_CONSTEXPR14 Vec3<T>
 rotatePoint (const Vec3<T> p, Line3<T> l, T angle)
 {
     //

--- a/Imath/ImathMatrix.h
+++ b/Imath/ImathMatrix.h
@@ -85,20 +85,19 @@ template <class T> class Matrix22
 
     Matrix22 (Uninitialized) {}
 
-    constexpr Matrix22 ();
+    IMATH_CONSTEXPR14 Matrix22 ();
                                 // 1 0
                                 // 0 1
 
-    constexpr Matrix22 (T a);
+    IMATH_CONSTEXPR14 Matrix22 (T a);
                                 // a a
                                 // a a
 
-    constexpr Matrix22 (const T a[2][2]);
+    IMATH_CONSTEXPR14 Matrix22 (const T a[2][2]);
                                 // a[0][0] a[0][1]
                                 // a[1][0] a[1][1]
 
-    constexpr Matrix22 (T a, T b, T c, T d);
-
+    IMATH_CONSTEXPR14 Matrix22 (T a, T b, T c, T d);
                                 // a b
                                 // c d
 
@@ -107,12 +106,12 @@ template <class T> class Matrix22
     // Copy constructor and assignment
     //--------------------------------
 
-    constexpr Matrix22 (const Matrix22 &v);
-    template <class S> constexpr explicit Matrix22 (const Matrix22<S> &v);
+    IMATH_CONSTEXPR14 Matrix22 (const Matrix22 &v);
+    template <class S> IMATH_CONSTEXPR14 explicit Matrix22 (const Matrix22<S> &v);
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    operator = (const Matrix22 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    operator = (T a);
 
 
@@ -132,11 +131,11 @@ template <class T> class Matrix22
     template <class S>
     void                getValue (Matrix22<S> &v) const;
     template <class S> \
-    constexpr
+    IMATH_CONSTEXPR14
     Matrix22 &          setValue (const Matrix22<S> &v);
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     Matrix22 &          setTheMatrix (const Matrix22<S> &v);
 
 
@@ -172,17 +171,18 @@ template <class T> class Matrix22
     //      abs (this[i] - v[i][j]) <= e * abs (this[i][j])
     //-----------------------------------------------------------------------
 
-    constexpr bool      equalWithAbsError (const Matrix22<T> &v, T e) const;
-    constexpr bool      equalWithRelError (const Matrix22<T> &v, T e) const;
-
+    IMATH_CONSTEXPR14
+    bool                equalWithAbsError (const Matrix22<T> &v, T e) const;
+    IMATH_CONSTEXPR14
+    bool                equalWithRelError (const Matrix22<T> &v, T e) const;
 
     //------------------------
     // Component-wise addition
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    operator += (const Matrix22 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    operator += (T a);
     constexpr Matrix22  operator + (const Matrix22 &v) const;
 
@@ -191,9 +191,9 @@ template <class T> class Matrix22
     // Component-wise subtraction
     //---------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    operator -= (const Matrix22 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    operator -= (T a);
     constexpr Matrix22  operator - (const Matrix22 &v) const;
 
@@ -203,7 +203,7 @@ template <class T> class Matrix22
     //------------------------------------
 
     constexpr Matrix22  operator - () const;
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    negate ();
 
 
@@ -211,7 +211,7 @@ template <class T> class Matrix22
     // Component-wise multiplication
     //------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    operator *= (T a);
     constexpr Matrix22  operator * (T a) const;
 
@@ -220,9 +220,10 @@ template <class T> class Matrix22
     // Matrix-times-matrix multiplication
     //-----------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    operator *= (const Matrix22 &v);
-    constexpr Matrix22  operator * (const Matrix22 &v) const;
+    IMATH_CONSTEXPR14
+    Matrix22            operator * (const Matrix22 &v) const;
 
 
     //-----------------------------------------------------------------
@@ -240,7 +241,7 @@ template <class T> class Matrix22
     // Component-wise division
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    operator /= (T a);
     constexpr Matrix22  operator / (T a) const;
 
@@ -249,7 +250,7 @@ template <class T> class Matrix22
     // Transposed matrix
     //------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    transpose ();
     constexpr Matrix22  transposed () const;
 
@@ -263,10 +264,10 @@ template <class T> class Matrix22
     //
     //------------------------------------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    invert (bool singExc = false);
 
-    constexpr
+    IMATH_CONSTEXPR14
     Matrix22<T>         inverse (bool singExc = false) const;
 
     //------------
@@ -280,7 +281,7 @@ template <class T> class Matrix22
     //-----------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    setRotation (S r);
 
 
@@ -289,7 +290,7 @@ template <class T> class Matrix22
     //-----------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    rotate (S r);
 
 
@@ -297,7 +298,7 @@ template <class T> class Matrix22
     // Set matrix to scale by given uniform factor
     //--------------------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    setScale (T s);
 
 
@@ -306,7 +307,7 @@ template <class T> class Matrix22
     //------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    setScale (const Vec2<S> &s);
 
 
@@ -315,7 +316,7 @@ template <class T> class Matrix22
     //----------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix22 &    scale (const Vec2<S> &s);
 
 
@@ -380,23 +381,22 @@ template <class T> class Matrix33
 
     Matrix33 (Uninitialized) {}
 
-    constexpr Matrix33 ();
+    IMATH_CONSTEXPR14 Matrix33 ();
                                 // 1 0 0
                                 // 0 1 0
                                 // 0 0 1
 
-    constexpr Matrix33 (T a);
+    IMATH_CONSTEXPR14 Matrix33 (T a);
                                 // a a a
                                 // a a a
                                 // a a a
 
-    constexpr Matrix33 (const T a[3][3]);
+    IMATH_CONSTEXPR14 Matrix33 (const T a[3][3]);
                                 // a[0][0] a[0][1] a[0][2]
                                 // a[1][0] a[1][1] a[1][2]
                                 // a[2][0] a[2][1] a[2][2]
 
-    constexpr Matrix33 (T a, T b, T c, T d, T e, T f, T g, T h, T i);
-
+    IMATH_CONSTEXPR14 Matrix33 (T a, T b, T c, T d, T e, T f, T g, T h, T i);
                                 // a b c
                                 // d e f
                                 // g h i
@@ -406,12 +406,12 @@ template <class T> class Matrix33
     // Copy constructor and assignment
     //--------------------------------
 
-    constexpr Matrix33 (const Matrix33 &v);
-    template <class S> constexpr explicit Matrix33 (const Matrix33<S> &v);
+    IMATH_CONSTEXPR14 Matrix33 (const Matrix33 &v);
+    template <class S> IMATH_CONSTEXPR14 explicit Matrix33 (const Matrix33<S> &v);
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    operator = (const Matrix33 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    operator = (T a);
 
 
@@ -431,11 +431,11 @@ template <class T> class Matrix33
     template <class S>
     void                getValue (Matrix33<S> &v) const;
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     Matrix33 &          setValue (const Matrix33<S> &v);
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     Matrix33 &          setTheMatrix (const Matrix33<S> &v);
 
 
@@ -471,17 +471,19 @@ template <class T> class Matrix33
     //      abs (this[i] - v[i][j]) <= e * abs (this[i][j])
     //-----------------------------------------------------------------------
 
-    constexpr bool      equalWithAbsError (const Matrix33<T> &v, T e) const;
-    constexpr bool      equalWithRelError (const Matrix33<T> &v, T e) const;
+    IMATH_CONSTEXPR14
+    bool                equalWithAbsError (const Matrix33<T> &v, T e) const;
+    IMATH_CONSTEXPR14
+    bool                equalWithRelError (const Matrix33<T> &v, T e) const;
 
 
     //------------------------
     // Component-wise addition
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    operator += (const Matrix33 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    operator += (T a);
     constexpr Matrix33  operator + (const Matrix33 &v) const;
 
@@ -490,9 +492,9 @@ template <class T> class Matrix33
     // Component-wise subtraction
     //---------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    operator -= (const Matrix33 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    operator -= (T a);
     constexpr Matrix33  operator - (const Matrix33 &v) const;
 
@@ -502,7 +504,7 @@ template <class T> class Matrix33
     //------------------------------------
 
     constexpr Matrix33  operator - () const;
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    negate ();
 
 
@@ -510,7 +512,7 @@ template <class T> class Matrix33
     // Component-wise multiplication
     //------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    operator *= (T a);
     constexpr Matrix33  operator * (T a) const;
 
@@ -519,9 +521,10 @@ template <class T> class Matrix33
     // Matrix-times-matrix multiplication
     //-----------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    operator *= (const Matrix33 &v);
-    constexpr Matrix33  operator * (const Matrix33 &v) const;
+    IMATH_CONSTEXPR14
+    Matrix33            operator * (const Matrix33 &v) const;
 
 
     //-----------------------------------------------------------------
@@ -547,7 +550,7 @@ template <class T> class Matrix33
     // Component-wise division
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    operator /= (T a);
     constexpr Matrix33  operator / (T a) const;
 
@@ -556,7 +559,7 @@ template <class T> class Matrix33
     // Transposed matrix
     //------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    transpose ();
     constexpr Matrix33  transposed () const;
 
@@ -575,16 +578,16 @@ template <class T> class Matrix33
     // 
     //------------------------------------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    invert (bool singExc = false);
 
-    constexpr
+    IMATH_CONSTEXPR14
     Matrix33<T>         inverse (bool singExc = false) const;
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    gjInvert (bool singExc = false);
 
-    constexpr
+    IMATH_CONSTEXPR14
     Matrix33<T>         gjInverse (bool singExc = false) const;
 
 
@@ -592,7 +595,7 @@ template <class T> class Matrix33
     // Calculate the matrix minor of the (r,c) element
     //------------------------------------------------
 
-    constexpr T         minorOf (const int r, const int c) const;
+    IMATH_CONSTEXPR14 T minorOf (const int r, const int c) const;
 
     //---------------------------------------------------
     // Build a minor using the specified rows and columns
@@ -612,7 +615,7 @@ template <class T> class Matrix33
     //-----------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    setRotation (S r);
 
 
@@ -621,7 +624,7 @@ template <class T> class Matrix33
     //-----------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    rotate (S r);
 
 
@@ -629,7 +632,7 @@ template <class T> class Matrix33
     // Set matrix to scale by given uniform factor
     //--------------------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    setScale (T s);
 
 
@@ -638,7 +641,7 @@ template <class T> class Matrix33
     //------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    setScale (const Vec2<S> &s);
 
 
@@ -647,7 +650,7 @@ template <class T> class Matrix33
     //----------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    scale (const Vec2<S> &s);
 
 
@@ -656,7 +659,7 @@ template <class T> class Matrix33
     //------------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    setTranslation (const Vec2<S> &t);
 
 
@@ -672,7 +675,7 @@ template <class T> class Matrix33
     //--------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    translate (const Vec2<S> &t);
 
 
@@ -681,7 +684,7 @@ template <class T> class Matrix33
     //-----------------------------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    setShear (const S &h);
 
 
@@ -691,7 +694,7 @@ template <class T> class Matrix33
     //-------------------------------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    setShear (const Vec2<S> &h);
 
 
@@ -700,7 +703,7 @@ template <class T> class Matrix33
     //-----------------------------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    shear (const S &xy);
 
 
@@ -710,7 +713,7 @@ template <class T> class Matrix33
     //-----------------------------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix33 &    shear (const Vec2<S> &h);
 
 
@@ -771,33 +774,33 @@ template <class T> class Matrix44
 
     constexpr Matrix44 (Uninitialized) {}
 
-    constexpr Matrix44 ();
+    IMATH_CONSTEXPR14 Matrix44 ();
                                 // 1 0 0 0
                                 // 0 1 0 0
                                 // 0 0 1 0
                                 // 0 0 0 1
 
-    constexpr Matrix44 (T a);
+    IMATH_CONSTEXPR14 Matrix44 (T a);
                                 // a a a a
                                 // a a a a
                                 // a a a a
                                 // a a a a
 
-    constexpr Matrix44 (const T a[4][4]) ;
+    IMATH_CONSTEXPR14 Matrix44 (const T a[4][4]) ;
                                 // a[0][0] a[0][1] a[0][2] a[0][3]
                                 // a[1][0] a[1][1] a[1][2] a[1][3]
                                 // a[2][0] a[2][1] a[2][2] a[2][3]
                                 // a[3][0] a[3][1] a[3][2] a[3][3]
 
-    constexpr Matrix44 (T a, T b, T c, T d, T e, T f, T g, T h,
-                        T i, T j, T k, T l, T m, T n, T o, T p);
+    IMATH_CONSTEXPR14 Matrix44 (T a, T b, T c, T d, T e, T f, T g, T h,
+                                T i, T j, T k, T l, T m, T n, T o, T p);
 
                                 // a b c d
                                 // e f g h
                                 // i j k l
                                 // m n o p
 
-    constexpr Matrix44 (Matrix33<T> r, Vec3<T> t);
+    IMATH_CONSTEXPR14 Matrix44 (Matrix33<T> r, Vec3<T> t);
                                 // r r r 0
                                 // r r r 0
                                 // r r r 0
@@ -813,12 +816,12 @@ template <class T> class Matrix44
     // Copy constructor and assignment
     //--------------------------------
 
-    constexpr Matrix44 (const Matrix44 &v);
-    template <class S> constexpr explicit Matrix44 (const Matrix44<S> &v);
+    IMATH_CONSTEXPR14 Matrix44 (const Matrix44 &v);
+    template <class S> IMATH_CONSTEXPR14 explicit Matrix44 (const Matrix44<S> &v);
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    operator = (const Matrix44 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    operator = (T a);
 
 
@@ -832,11 +835,11 @@ template <class T> class Matrix44
     template <class S>
     void                getValue (Matrix44<S> &v) const;
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     Matrix44 &          setValue (const Matrix44<S> &v);
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     Matrix44 &          setTheMatrix (const Matrix44<S> &v);
 
     //---------
@@ -871,17 +874,17 @@ template <class T> class Matrix44
     //      abs (this[i] - v[i][j]) <= e * abs (this[i][j])
     //-----------------------------------------------------------------------
 
-    constexpr bool      equalWithAbsError (const Matrix44<T> &v, T e) const;
-    constexpr bool      equalWithRelError (const Matrix44<T> &v, T e) const;
+    IMATH_CONSTEXPR14 bool  equalWithAbsError (const Matrix44<T> &v, T e) const;
+    IMATH_CONSTEXPR14 bool  equalWithRelError (const Matrix44<T> &v, T e) const;
 
 
     //------------------------
     // Component-wise addition
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    operator += (const Matrix44 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    operator += (T a);
     constexpr Matrix44  operator + (const Matrix44 &v) const;
 
@@ -890,9 +893,9 @@ template <class T> class Matrix44
     // Component-wise subtraction
     //---------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    operator -= (const Matrix44 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    operator -= (T a);
     constexpr Matrix44  operator - (const Matrix44 &v) const;
 
@@ -902,7 +905,7 @@ template <class T> class Matrix44
     //------------------------------------
 
     constexpr Matrix44  operator - () const;
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    negate ();
 
 
@@ -910,7 +913,7 @@ template <class T> class Matrix44
     // Component-wise multiplication
     //------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    operator *= (T a);
     constexpr Matrix44  operator * (T a) const;
 
@@ -919,9 +922,10 @@ template <class T> class Matrix44
     // Matrix-times-matrix multiplication
     //-----------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    operator *= (const Matrix44 &v);
-    constexpr Matrix44  operator * (const Matrix44 &v) const;
+    IMATH_CONSTEXPR14
+    Matrix44            operator * (const Matrix44 &v) const;
 
     static void         multiply (const Matrix44 &a,    // assumes that
                                   const Matrix44 &b,    // &a != &c and
@@ -951,7 +955,7 @@ template <class T> class Matrix44
     // Component-wise division
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    operator /= (T a);
     constexpr Matrix44  operator / (T a) const;
 
@@ -960,7 +964,7 @@ template <class T> class Matrix44
     // Transposed matrix
     //------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    transpose ();
     constexpr Matrix44  transposed () const;
 
@@ -979,16 +983,16 @@ template <class T> class Matrix44
     // 
     //------------------------------------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    invert (bool singExc = false);
 
-    constexpr
+    IMATH_CONSTEXPR14
     Matrix44<T>         inverse (bool singExc = false) const;
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    gjInvert (bool singExc = false);
 
-    constexpr
+    IMATH_CONSTEXPR14
     Matrix44<T>         gjInverse (bool singExc = false) const;
 
 
@@ -996,7 +1000,7 @@ template <class T> class Matrix44
     // Calculate the matrix minor of the (r,c) element
     //------------------------------------------------
 
-    constexpr T         minorOf (const int r, const int c) const;
+    IMATH_CONSTEXPR14 T minorOf (const int r, const int c) const;
 
     //---------------------------------------------------
     // Build a minor using the specified rows and columns
@@ -1009,14 +1013,14 @@ template <class T> class Matrix44
     // Determinant
     //------------
 
-    constexpr T         determinant() const;
+    IMATH_CONSTEXPR14 T determinant() const;
 
     //--------------------------------------------------------
     // Set matrix to rotation by XYZ euler angles (in radians)
     //--------------------------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    setEulerAngles (const Vec3<S>& r);
 
 
@@ -1025,7 +1029,7 @@ template <class T> class Matrix44
     //--------------------------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    setAxisAngle (const Vec3<S>& ax, S ang);
 
 
@@ -1034,7 +1038,7 @@ template <class T> class Matrix44
     //-------------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    rotate (const Vec3<S> &r);
 
 
@@ -1042,7 +1046,7 @@ template <class T> class Matrix44
     // Set matrix to scale by given uniform factor
     //--------------------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    setScale (T s);
 
 
@@ -1051,7 +1055,7 @@ template <class T> class Matrix44
     //------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    setScale (const Vec3<S> &s);
 
 
@@ -1060,7 +1064,7 @@ template <class T> class Matrix44
     //----------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    scale (const Vec3<S> &s);
 
 
@@ -1069,7 +1073,7 @@ template <class T> class Matrix44
     //------------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    setTranslation (const Vec3<S> &t);
 
 
@@ -1086,7 +1090,7 @@ template <class T> class Matrix44
     //--------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    translate (const Vec3<S> &t);
 
 
@@ -1098,7 +1102,7 @@ template <class T> class Matrix44
     //-------------------------------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    setShear (const Vec3<S> &h);
 
 
@@ -1113,7 +1117,7 @@ template <class T> class Matrix44
     //------------------------------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    setShear (const Shear6<S> &h);
 
 
@@ -1126,7 +1130,7 @@ template <class T> class Matrix44
     //--------------------------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    shear (const Vec3<S> &h);
 
     //--------------------------------------------------------
@@ -1150,7 +1154,7 @@ template <class T> class Matrix44
     //------------------------------------------------------------
 
     template <class S>
-    constexpr
+    IMATH_CONSTEXPR14
     const Matrix44 &    shear (const Shear6<S> &h);
 
 
@@ -1262,7 +1266,7 @@ Matrix22<T>::operator [] (int i) const
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix22<T>::Matrix22 ()
 {
     x[0][0] = 1;
@@ -1272,7 +1276,7 @@ Matrix22<T>::Matrix22 ()
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix22<T>::Matrix22 (T a)
 {
     x[0][0] = a;
@@ -1282,14 +1286,14 @@ Matrix22<T>::Matrix22 (T a)
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix22<T>::Matrix22 (const T a[2][2]) 
 {
     memcpy (x, a, sizeof (x));
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix22<T>::Matrix22 (T a, T b, T c, T d)
 {
     x[0][0] = a;
@@ -1299,7 +1303,7 @@ Matrix22<T>::Matrix22 (T a, T b, T c, T d)
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix22<T>::Matrix22 (const Matrix22 &v)
 {
     memcpy (x, v.x, sizeof (x));
@@ -1307,7 +1311,7 @@ Matrix22<T>::Matrix22 (const Matrix22 &v)
 
 template <class T>
 template <class S>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix22<T>::Matrix22 (const Matrix22<S> &v)
 {
     x[0][0] = T (v.x[0][0]);
@@ -1317,7 +1321,7 @@ Matrix22<T>::Matrix22 (const Matrix22<S> &v)
 }
 
 template <class T>
-constexpr inline const Matrix22<T> &
+IMATH_CONSTEXPR14 inline const Matrix22<T> &
 Matrix22<T>::operator = (const Matrix22 &v)
 {
     memcpy (x, v.x, sizeof (x));
@@ -1325,7 +1329,7 @@ Matrix22<T>::operator = (const Matrix22 &v)
 }
 
 template <class T>
-constexpr inline const Matrix22<T> &
+IMATH_CONSTEXPR14 inline const Matrix22<T> &
 Matrix22<T>::operator = (T a)
 {
     x[0][0] = a;
@@ -1369,7 +1373,7 @@ Matrix22<T>::getValue (Matrix22<S> &v) const
 
 template <class T>
 template <class S>
-constexpr inline Matrix22<T> &
+IMATH_CONSTEXPR14 inline Matrix22<T> &
 Matrix22<T>::setValue (const Matrix22<S> &v)
 {
     if (isSameType<S,T>::value)
@@ -1389,7 +1393,7 @@ Matrix22<T>::setValue (const Matrix22<S> &v)
 
 template <class T>
 template <class S>
-constexpr inline Matrix22<T> &
+IMATH_CONSTEXPR14 inline Matrix22<T> &
 Matrix22<T>::setTheMatrix (const Matrix22<S> &v)
 {
     if (isSameType<S,T>::value)
@@ -1438,7 +1442,7 @@ Matrix22<T>::operator != (const Matrix22 &v) const
 }
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 Matrix22<T>::equalWithAbsError (const Matrix22<T> &m, T e) const
 {
     for (int i = 0; i < 2; i++)
@@ -1450,7 +1454,7 @@ Matrix22<T>::equalWithAbsError (const Matrix22<T> &m, T e) const
 }
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 Matrix22<T>::equalWithRelError (const Matrix22<T> &m, T e) const
 {
     for (int i = 0; i < 2; i++)
@@ -1462,7 +1466,7 @@ Matrix22<T>::equalWithRelError (const Matrix22<T> &m, T e) const
 }
 
 template <class T>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::operator += (const Matrix22<T> &v)
 {
     x[0][0] += v.x[0][0];
@@ -1474,7 +1478,7 @@ Matrix22<T>::operator += (const Matrix22<T> &v)
 }
 
 template <class T>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::operator += (T a)
 {
     x[0][0] += a;
@@ -1496,7 +1500,7 @@ Matrix22<T>::operator + (const Matrix22<T> &v) const
 }
 
 template <class T>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::operator -= (const Matrix22<T> &v)
 {
     x[0][0] -= v.x[0][0];
@@ -1508,7 +1512,7 @@ Matrix22<T>::operator -= (const Matrix22<T> &v)
 }
 
 template <class T>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::operator -= (T a)
 {
     x[0][0] -= a;
@@ -1540,7 +1544,7 @@ Matrix22<T>::operator - () const
 }
 
 template <class T>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::negate ()
 {
     x[0][0] = -x[0][0];
@@ -1552,7 +1556,7 @@ Matrix22<T>::negate ()
 }
 
 template <class T>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::operator *= (T a)
 {
     x[0][0] *= a;
@@ -1581,7 +1585,7 @@ operator * (T a, const Matrix22<T> &v)
 }
 
 template <class T>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::operator *= (const Matrix22<T> &v)
 {
     Matrix22 tmp (T (0));
@@ -1596,7 +1600,7 @@ Matrix22<T>::operator *= (const Matrix22<T> &v)
 }
 
 template <class T>
-constexpr Matrix22<T>
+IMATH_CONSTEXPR14 Matrix22<T>
 Matrix22<T>::operator * (const Matrix22<T> &v) const
 {
     Matrix22 tmp (T (0));
@@ -1624,7 +1628,7 @@ Matrix22<T>::multDirMatrix(const Vec2<S> &src, Vec2<S> &dst) const
 }
 
 template <class T>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::operator /= (T a)
 {
     x[0][0] /= a;
@@ -1646,7 +1650,7 @@ Matrix22<T>::operator / (T a) const
 }
 
 template <class T>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::transpose ()
 {
     Matrix22 tmp (x[0][0],
@@ -1668,7 +1672,7 @@ Matrix22<T>::transposed () const
 }
 
 template <class T>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::invert (bool singExc)
 {
     *this = inverse (singExc);
@@ -1676,7 +1680,7 @@ Matrix22<T>::invert (bool singExc)
 }
 
 template <class T>
-constexpr Matrix22<T>
+IMATH_CONSTEXPR14 Matrix22<T>
 Matrix22<T>::inverse (bool singExc) const
 {
     Matrix22 s ( x[1][1],  -x[0][1],
@@ -1728,7 +1732,7 @@ Matrix22<T>::determinant () const
 
 template <class T>
 template <class S>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::setRotation (S r)
 {
     S cos_r, sin_r;
@@ -1747,7 +1751,7 @@ Matrix22<T>::setRotation (S r)
 
 template <class T>
 template <class S>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::rotate (S r)
 {
     *this *= Matrix22<T>().setRotation (r);
@@ -1755,7 +1759,7 @@ Matrix22<T>::rotate (S r)
 }
 
 template <class T>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::setScale (T s)
 {
     x[0][0] = s;
@@ -1768,7 +1772,7 @@ Matrix22<T>::setScale (T s)
 
 template <class T>
 template <class S>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::setScale (const Vec2<S> &s)
 {
     x[0][0] = s[0];
@@ -1781,7 +1785,7 @@ Matrix22<T>::setScale (const Vec2<S> &s)
 
 template <class T>
 template <class S>
-constexpr const Matrix22<T> &
+IMATH_CONSTEXPR14 const Matrix22<T> &
 Matrix22<T>::scale (const Vec2<S> &s)
 {
     x[0][0] *= s[0];
@@ -1818,7 +1822,7 @@ inline
 
 
 
-constexpr
+IMATH_CONSTEXPR14
 Matrix33<T>::Matrix33 ()
 {
     memset (x, 0, sizeof (x));
@@ -1828,7 +1832,7 @@ Matrix33<T>::Matrix33 ()
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix33<T>::Matrix33 (T a)
 {
     x[0][0] = a;
@@ -1843,14 +1847,14 @@ Matrix33<T>::Matrix33 (T a)
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix33<T>::Matrix33 (const T a[3][3]) 
 {
     memcpy (x, a, sizeof (x));
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix33<T>::Matrix33 (T a, T b, T c, T d, T e, T f, T g, T h, T i)
 {
     x[0][0] = a;
@@ -1865,7 +1869,7 @@ Matrix33<T>::Matrix33 (T a, T b, T c, T d, T e, T f, T g, T h, T i)
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix33<T>::Matrix33 (const Matrix33 &v)
 {
     memcpy (x, v.x, sizeof (x));
@@ -1873,7 +1877,7 @@ Matrix33<T>::Matrix33 (const Matrix33 &v)
 
 template <class T>
 template <class S>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix33<T>::Matrix33 (const Matrix33<S> &v)
 {
     x[0][0] = T (v.x[0][0]);
@@ -1888,7 +1892,7 @@ Matrix33<T>::Matrix33 (const Matrix33<S> &v)
 }
 
 template <class T>
-constexpr inline const Matrix33<T> &
+IMATH_CONSTEXPR14 inline const Matrix33<T> &
 Matrix33<T>::operator = (const Matrix33 &v)
 {
     memcpy (x, v.x, sizeof (x));
@@ -1896,7 +1900,7 @@ Matrix33<T>::operator = (const Matrix33 &v)
 }
 
 template <class T>
-constexpr inline const Matrix33<T> &
+IMATH_CONSTEXPR14 inline const Matrix33<T> &
 Matrix33<T>::operator = (T a)
 {
     x[0][0] = a;
@@ -1950,7 +1954,7 @@ Matrix33<T>::getValue (Matrix33<S> &v) const
 
 template <class T>
 template <class S>
-constexpr inline Matrix33<T> &
+IMATH_CONSTEXPR14 inline Matrix33<T> &
 Matrix33<T>::setValue (const Matrix33<S> &v)
 {
     if (isSameType<S,T>::value)
@@ -1975,7 +1979,7 @@ Matrix33<T>::setValue (const Matrix33<S> &v)
 
 template <class T>
 template <class S>
-constexpr inline Matrix33<T> &
+IMATH_CONSTEXPR14 inline Matrix33<T> &
 Matrix33<T>::setTheMatrix (const Matrix33<S> &v)
 {
     if (isSameType<S,T>::value)
@@ -2039,7 +2043,7 @@ Matrix33<T>::operator != (const Matrix33 &v) const
 }
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 Matrix33<T>::equalWithAbsError (const Matrix33<T> &m, T e) const
 {
     for (int i = 0; i < 3; i++)
@@ -2051,7 +2055,7 @@ Matrix33<T>::equalWithAbsError (const Matrix33<T> &m, T e) const
 }
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 Matrix33<T>::equalWithRelError (const Matrix33<T> &m, T e) const
 {
     for (int i = 0; i < 3; i++)
@@ -2063,7 +2067,7 @@ Matrix33<T>::equalWithRelError (const Matrix33<T> &m, T e) const
 }
 
 template <class T>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::operator += (const Matrix33<T> &v)
 {
     x[0][0] += v.x[0][0];
@@ -2080,7 +2084,7 @@ Matrix33<T>::operator += (const Matrix33<T> &v)
 }
 
 template <class T>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::operator += (T a)
 {
     x[0][0] += a;
@@ -2112,7 +2116,7 @@ Matrix33<T>::operator + (const Matrix33<T> &v) const
 }
 
 template <class T>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::operator -= (const Matrix33<T> &v)
 {
     x[0][0] -= v.x[0][0];
@@ -2129,7 +2133,7 @@ Matrix33<T>::operator -= (const Matrix33<T> &v)
 }
 
 template <class T>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::operator -= (T a)
 {
     x[0][0] -= a;
@@ -2176,7 +2180,7 @@ Matrix33<T>::operator - () const
 }
 
 template <class T>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::negate ()
 {
     x[0][0] = -x[0][0];
@@ -2193,7 +2197,7 @@ Matrix33<T>::negate ()
 }
 
 template <class T>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::operator *= (T a)
 {
     x[0][0] *= a;
@@ -2232,7 +2236,7 @@ constexpr operator * (T a, const Matrix33<T> &v)
 }
 
 template <class T>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::operator *= (const Matrix33<T> &v)
 {
     Matrix33 tmp (T (0));
@@ -2247,7 +2251,7 @@ Matrix33<T>::operator *= (const Matrix33<T> &v)
 }
 
 template <class T>
-constexpr Matrix33<T>
+IMATH_CONSTEXPR14 Matrix33<T>
 Matrix33<T>::operator * (const Matrix33<T> &v) const
 {
     Matrix33 tmp (T (0));
@@ -2290,7 +2294,7 @@ Matrix33<T>::multDirMatrix(const Vec2<S> &src, Vec2<S> &dst) const
 }
 
 template <class T>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::operator /= (T a)
 {
     x[0][0] /= a;
@@ -2322,7 +2326,7 @@ Matrix33<T>::operator / (T a) const
 }
 
 template <class T>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::transpose ()
 {
     Matrix33 tmp (x[0][0],
@@ -2354,7 +2358,7 @@ Matrix33<T>::transposed () const
 }
 
 template <class T>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::gjInvert (bool singExc)
 {
     *this = gjInverse (singExc);
@@ -2362,7 +2366,7 @@ Matrix33<T>::gjInvert (bool singExc)
 }
 
 template <class T>
-constexpr Matrix33<T>
+IMATH_CONSTEXPR14 Matrix33<T>
 Matrix33<T>::gjInverse (bool singExc) const
 {
     int i, j, k;
@@ -2466,7 +2470,7 @@ Matrix33<T>::gjInverse (bool singExc) const
 }
 
 template <class T>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::invert (bool singExc)
 {
     *this = inverse (singExc);
@@ -2474,7 +2478,7 @@ Matrix33<T>::invert (bool singExc)
 }
 
 template <class T>
-constexpr Matrix33<T>
+IMATH_CONSTEXPR14 Matrix33<T>
 Matrix33<T>::inverse (bool singExc) const
 {
     if (x[0][2] != 0 || x[1][2] != 0 || x[2][2] != 1)
@@ -2585,7 +2589,7 @@ Matrix33<T>::inverse (bool singExc) const
 }
 
 template <class T>
-constexpr inline T
+IMATH_CONSTEXPR14 inline T
 Matrix33<T>::minorOf (const int r, const int c) const
 {
     int r0 = 0 + (r < 1 ? 1 : 0);
@@ -2615,7 +2619,7 @@ Matrix33<T>::determinant () const
 
 template <class T>
 template <class S>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::setRotation (S r)
 {
     S cos_r, sin_r;
@@ -2640,7 +2644,7 @@ Matrix33<T>::setRotation (S r)
 
 template <class T>
 template <class S>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::rotate (S r)
 {
     *this *= Matrix33<T>().setRotation (r);
@@ -2648,7 +2652,7 @@ Matrix33<T>::rotate (S r)
 }
 
 template <class T>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::setScale (T s)
 {
     memset (x, 0, sizeof (x));
@@ -2661,7 +2665,7 @@ Matrix33<T>::setScale (T s)
 
 template <class T>
 template <class S>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::setScale (const Vec2<S> &s)
 {
     memset (x, 0, sizeof (x));
@@ -2674,7 +2678,7 @@ Matrix33<T>::setScale (const Vec2<S> &s)
 
 template <class T>
 template <class S>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::scale (const Vec2<S> &s)
 {
     x[0][0] *= s[0];
@@ -2690,7 +2694,7 @@ Matrix33<T>::scale (const Vec2<S> &s)
 
 template <class T>
 template <class S>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::setTranslation (const Vec2<S> &t)
 {
     x[0][0] = 1;
@@ -2717,7 +2721,7 @@ Matrix33<T>::translation () const
 
 template <class T>
 template <class S>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::translate (const Vec2<S> &t)
 {
     x[2][0] += t[0] * x[0][0] + t[1] * x[1][0];
@@ -2729,7 +2733,7 @@ Matrix33<T>::translate (const Vec2<S> &t)
 
 template <class T>
 template <class S>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::setShear (const S &xy)
 {
     x[0][0] = 1;
@@ -2749,7 +2753,7 @@ Matrix33<T>::setShear (const S &xy)
 
 template <class T>
 template <class S>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::setShear (const Vec2<S> &h)
 {
     x[0][0] = 1;
@@ -2769,7 +2773,7 @@ Matrix33<T>::setShear (const Vec2<S> &h)
 
 template <class T>
 template <class S>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::shear (const S &xy)
 {
     //
@@ -2787,7 +2791,7 @@ Matrix33<T>::shear (const S &xy)
 
 template <class T>
 template <class S>
-constexpr const Matrix33<T> &
+IMATH_CONSTEXPR14 const Matrix33<T> &
 Matrix33<T>::shear (const Vec2<S> &h)
 {
     Matrix33<T> P (*this);
@@ -2823,7 +2827,7 @@ Matrix44<T>::operator [] (int i) const
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix44<T>::Matrix44 ()
 {
     memset (x, 0, sizeof (x));
@@ -2834,7 +2838,7 @@ Matrix44<T>::Matrix44 ()
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix44<T>::Matrix44 (T a)
 {
     x[0][0] = a;
@@ -2856,14 +2860,14 @@ Matrix44<T>::Matrix44 (T a)
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix44<T>::Matrix44 (const T a[4][4]) 
 {
     memcpy (x, a, sizeof (x));
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix44<T>::Matrix44 (T a, T b, T c, T d, T e, T f, T g, T h,
                        T i, T j, T k, T l, T m, T n, T o, T p)
 {
@@ -2887,7 +2891,7 @@ Matrix44<T>::Matrix44 (T a, T b, T c, T d, T e, T f, T g, T h,
 
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix44<T>::Matrix44 (Matrix33<T> r, Vec3<T> t)
 {
     x[0][0] = r[0][0];
@@ -2909,7 +2913,7 @@ Matrix44<T>::Matrix44 (Matrix33<T> r, Vec3<T> t)
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix44<T>::Matrix44 (const Matrix44 &v)
 {
     x[0][0] = v.x[0][0];
@@ -2932,7 +2936,7 @@ Matrix44<T>::Matrix44 (const Matrix44 &v)
 
 template <class T>
 template <class S>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Matrix44<T>::Matrix44 (const Matrix44<S> &v)
 {
     x[0][0] = T (v.x[0][0]);
@@ -2954,7 +2958,7 @@ Matrix44<T>::Matrix44 (const Matrix44<S> &v)
 }
 
 template <class T>
-constexpr inline const Matrix44<T> &
+IMATH_CONSTEXPR14 inline const Matrix44<T> &
 Matrix44<T>::operator = (const Matrix44 &v)
 {
     x[0][0] = v.x[0][0];
@@ -2977,7 +2981,7 @@ Matrix44<T>::operator = (const Matrix44 &v)
 }
 
 template <class T>
-constexpr inline const Matrix44<T> &
+IMATH_CONSTEXPR14 inline const Matrix44<T> &
 Matrix44<T>::operator = (T a)
 {
     x[0][0] = a;
@@ -3045,7 +3049,7 @@ Matrix44<T>::getValue (Matrix44<S> &v) const
 
 template <class T>
 template <class S>
-constexpr inline Matrix44<T> &
+IMATH_CONSTEXPR14 inline Matrix44<T> &
 Matrix44<T>::setValue (const Matrix44<S> &v)
 {
     if (isSameType<S,T>::value)
@@ -3077,7 +3081,7 @@ Matrix44<T>::setValue (const Matrix44<S> &v)
 
 template <class T>
 template <class S>
-constexpr inline Matrix44<T> &
+IMATH_CONSTEXPR14 inline Matrix44<T> &
 Matrix44<T>::setTheMatrix (const Matrix44<S> &v)
 {
     if (isSameType<S,T>::value)
@@ -3163,7 +3167,7 @@ Matrix44<T>::operator != (const Matrix44 &v) const
 }
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 Matrix44<T>::equalWithAbsError (const Matrix44<T> &m, T e) const
 {
     for (int i = 0; i < 4; i++)
@@ -3175,7 +3179,7 @@ Matrix44<T>::equalWithAbsError (const Matrix44<T> &m, T e) const
 }
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 Matrix44<T>::equalWithRelError (const Matrix44<T> &m, T e) const
 {
     for (int i = 0; i < 4; i++)
@@ -3187,7 +3191,7 @@ Matrix44<T>::equalWithRelError (const Matrix44<T> &m, T e) const
 }
 
 template <class T>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::operator += (const Matrix44<T> &v)
 {
     x[0][0] += v.x[0][0];
@@ -3211,7 +3215,7 @@ Matrix44<T>::operator += (const Matrix44<T> &v)
 }
 
 template <class T>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::operator += (T a)
 {
     x[0][0] += a;
@@ -3257,7 +3261,7 @@ Matrix44<T>::operator + (const Matrix44<T> &v) const
 }
 
 template <class T>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::operator -= (const Matrix44<T> &v)
 {
     x[0][0] -= v.x[0][0];
@@ -3281,7 +3285,7 @@ Matrix44<T>::operator -= (const Matrix44<T> &v)
 }
 
 template <class T>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::operator -= (T a)
 {
     x[0][0] -= a;
@@ -3349,7 +3353,7 @@ Matrix44<T>::operator - () const
 }
 
 template <class T>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::negate ()
 {
     x[0][0] = -x[0][0];
@@ -3373,7 +3377,7 @@ Matrix44<T>::negate ()
 }
 
 template <class T>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::operator *= (T a)
 {
     x[0][0] *= a;
@@ -3426,7 +3430,7 @@ operator * (T a, const Matrix44<T> &v)
 }
 
 template <class T>
-constexpr inline const Matrix44<T> &
+IMATH_CONSTEXPR14 inline const Matrix44<T> &
 Matrix44<T>::operator *= (const Matrix44<T> &v)
 {
     Matrix44 tmp (T (0));
@@ -3437,7 +3441,7 @@ Matrix44<T>::operator *= (const Matrix44<T> &v)
 }
 
 template <class T>
-constexpr inline Matrix44<T>
+IMATH_CONSTEXPR14 inline Matrix44<T>
 Matrix44<T>::operator * (const Matrix44<T> &v) const
 {
     Matrix44 tmp (T (0));
@@ -3531,7 +3535,7 @@ Matrix44<T>::multDirMatrix(const Vec3<S> &src, Vec3<S> &dst) const
 }
 
 template <class T>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::operator /= (T a)
 {
     x[0][0] /= a;
@@ -3577,7 +3581,7 @@ Matrix44<T>::operator / (T a) const
 }
 
 template <class T>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::transpose ()
 {
     Matrix44 tmp (x[0][0],
@@ -3623,7 +3627,7 @@ Matrix44<T>::transposed () const
 }
 
 template <class T>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::gjInvert (bool singExc)
 {
     *this = gjInverse (singExc);
@@ -3631,7 +3635,7 @@ Matrix44<T>::gjInvert (bool singExc)
 }
 
 template <class T>
-constexpr Matrix44<T>
+IMATH_CONSTEXPR14 Matrix44<T>
 Matrix44<T>::gjInverse (bool singExc) const
 {
     int i, j, k;
@@ -3735,7 +3739,7 @@ Matrix44<T>::gjInverse (bool singExc) const
 }
 
 template <class T>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::invert (bool singExc)
 {
     *this = inverse (singExc);
@@ -3743,7 +3747,7 @@ Matrix44<T>::invert (bool singExc)
 }
 
 template <class T>
-constexpr Matrix44<T>
+IMATH_CONSTEXPR14 Matrix44<T>
 Matrix44<T>::inverse (bool singExc) const
 {
     if (x[0][3] != 0 || x[1][3] != 0 || x[2][3] != 0 || x[3][3] != 1)
@@ -3822,7 +3826,7 @@ Matrix44<T>::fastMinor( const int r0, const int r1, const int r2,
 }
 
 template <class T>
-constexpr inline T
+IMATH_CONSTEXPR14 inline T
 Matrix44<T>::minorOf (const int r, const int c) const
 {
     int r0 = 0 + (r < 1 ? 1 : 0);
@@ -3840,7 +3844,7 @@ Matrix44<T>::minorOf (const int r, const int c) const
 }
 
 template <class T>
-constexpr inline T
+IMATH_CONSTEXPR14 inline T
 Matrix44<T>::determinant () const
 {
     T sum = (T)0;
@@ -3855,11 +3859,11 @@ Matrix44<T>::determinant () const
 
 template <class T>
 template <class S>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::setEulerAngles (const Vec3<S>& r)
 {
     S cos_rz, sin_rz, cos_ry, sin_ry, cos_rx, sin_rx;
-    
+
     cos_rz = Math<T>::cos (r[2]);
     cos_ry = Math<T>::cos (r[1]);
     cos_rx = Math<T>::cos (r[0]);
@@ -3893,7 +3897,7 @@ Matrix44<T>::setEulerAngles (const Vec3<S>& r)
 
 template <class T>
 template <class S>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::setAxisAngle (const Vec3<S>& axis, S angle)
 {
     Vec3<S> unit (axis.normalized());
@@ -3925,7 +3929,7 @@ Matrix44<T>::setAxisAngle (const Vec3<S>& axis, S angle)
 
 template <class T>
 template <class S>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::rotate (const Vec3<S> &r)
 {
     S cos_rz, sin_rz, cos_ry, sin_ry, cos_rx, sin_rx;
@@ -3972,7 +3976,7 @@ Matrix44<T>::rotate (const Vec3<S> &r)
 }
 
 template <class T>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::setScale (T s)
 {
     memset (x, 0, sizeof (x));
@@ -3986,7 +3990,7 @@ Matrix44<T>::setScale (T s)
 
 template <class T>
 template <class S>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::setScale (const Vec3<S> &s)
 {
     memset (x, 0, sizeof (x));
@@ -4000,7 +4004,7 @@ Matrix44<T>::setScale (const Vec3<S> &s)
 
 template <class T>
 template <class S>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::scale (const Vec3<S> &s)
 {
     x[0][0] *= s[0];
@@ -4023,7 +4027,7 @@ Matrix44<T>::scale (const Vec3<S> &s)
 
 template <class T>
 template <class S>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::setTranslation (const Vec3<S> &t)
 {
     x[0][0] = 1;
@@ -4058,7 +4062,7 @@ Matrix44<T>::translation () const
 
 template <class T>
 template <class S>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::translate (const Vec3<S> &t)
 {
     x[3][0] += t[0] * x[0][0] + t[1] * x[1][0] + t[2] * x[2][0];
@@ -4071,7 +4075,7 @@ Matrix44<T>::translate (const Vec3<S> &t)
 
 template <class T>
 template <class S>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::setShear (const Vec3<S> &h)
 {
     x[0][0] = 1;
@@ -4099,7 +4103,7 @@ Matrix44<T>::setShear (const Vec3<S> &h)
 
 template <class T>
 template <class S>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::setShear (const Shear6<S> &h)
 {
     x[0][0] = 1;
@@ -4127,7 +4131,7 @@ Matrix44<T>::setShear (const Shear6<S> &h)
 
 template <class T>
 template <class S>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::shear (const Vec3<S> &h)
 {
     //
@@ -4147,7 +4151,7 @@ Matrix44<T>::shear (const Vec3<S> &h)
 
 template <class T>
 template <class S>
-constexpr const Matrix44<T> &
+IMATH_CONSTEXPR14 const Matrix44<T> &
 Matrix44<T>::shear (const Shear6<S> &h)
 {
     Matrix44<T> P (*this);

--- a/Imath/ImathMatrixAlgo.cpp
+++ b/Imath/ImathMatrixAlgo.cpp
@@ -630,7 +630,7 @@ swapColumns (IMATH_INTERNAL_NAMESPACE::Matrix33<T>& A, int j, int k)
 }
 
 template <typename T>
-constexpr T
+IMATH_CONSTEXPR14 T
 maxOffDiag (const IMATH_INTERNAL_NAMESPACE::Matrix33<T>& A)
 {
     T result = 0;
@@ -644,7 +644,7 @@ maxOffDiag (const IMATH_INTERNAL_NAMESPACE::Matrix33<T>& A)
 }
 
 template <typename T>
-constexpr T
+IMATH_CONSTEXPR14 T
 maxOffDiag (const IMATH_INTERNAL_NAMESPACE::Matrix44<T>& A)
 {
     T result = 0;
@@ -1090,7 +1090,7 @@ jacobiRotation (Matrix44<T>& A,
 }
 
 template <typename TM>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 typename TM::BaseType
 maxOffDiagSymm (const TM& A)
 {

--- a/Imath/ImathPlane.h
+++ b/Imath/ImathPlane.h
@@ -68,11 +68,11 @@ class Plane3
     T				distance;
 
     constexpr Plane3() {}
-    constexpr Plane3(const Vec3<T> &normal, T distance);
-    constexpr Plane3(const Vec3<T> &point, const Vec3<T> &normal);
-    constexpr Plane3(const Vec3<T> &point1,
-	             const Vec3<T> &point2,
-	             const Vec3<T> &point3);
+    IMATH_CONSTEXPR14 Plane3(const Vec3<T> &normal, T distance);
+    IMATH_CONSTEXPR14 Plane3(const Vec3<T> &point, const Vec3<T> &normal);
+    IMATH_CONSTEXPR14 Plane3(const Vec3<T> &point1,
+	                     const Vec3<T> &point2,
+	                     const Vec3<T> &point3);
 
     //----------------------
     //	Various set methods
@@ -92,10 +92,10 @@ class Plane3
     //	Utilities
     //----------------------
 
-    constexpr bool              intersect(const Line3<T> &line,
+    IMATH_CONSTEXPR14 bool      intersect(const Line3<T> &line,
                                            Vec3<T> &intersection) const;
 
-    constexpr bool              intersectT(const Line3<T> &line,
+    IMATH_CONSTEXPR14 bool      intersectT(const Line3<T> &line,
 					   T &parameter) const;
 
     constexpr T		     	distanceTo(const Vec3<T> &) const;
@@ -118,7 +118,7 @@ typedef Plane3<double> Plane3d;
 //---------------
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Plane3<T>::Plane3(const Vec3<T> &p0,
 			 const Vec3<T> &p1,
 			 const Vec3<T> &p2)
@@ -127,14 +127,14 @@ Plane3<T>::Plane3(const Vec3<T> &p0,
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Plane3<T>::Plane3(const Vec3<T> &n, T d)
 {
     set(n, d);
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Plane3<T>::Plane3(const Vec3<T> &p, const Vec3<T> &n)
 {
     set(p, n);
@@ -190,7 +190,7 @@ Plane3<T>::reflectVector(const Vec3<T> &v) const
 
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Plane3<T>::intersect(const Line3<T>& line, Vec3<T>& point) const
 {
     T d = normal ^ line.dir;
@@ -201,7 +201,7 @@ Plane3<T>::intersect(const Line3<T>& line, Vec3<T>& point) const
 }
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Plane3<T>::intersectT(const Line3<T>& line, T &t) const
 {
     T d = normal ^ line.dir;
@@ -218,7 +218,7 @@ std::ostream &operator<< (std::ostream &o, const Plane3<T> &plane)
 }
 
 template<class T>
-constexpr Plane3<T>
+IMATH_CONSTEXPR14 Plane3<T>
 operator* (const Plane3<T> &plane, const Matrix44<T> &M)
 {
     //                        T

--- a/Imath/ImathQuat.h
+++ b/Imath/ImathQuat.h
@@ -95,7 +95,7 @@ class Quat
     // Copy constructor
     //-------------------
 
-    constexpr Quat (const Quat &q);
+    IMATH_CONSTEXPR14 Quat (const Quat &q);
 
     //-------------
     // Destructor
@@ -119,21 +119,21 @@ class Quat
     //	a 4D vector when one of the operands is scalar
     //-------------------------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Quat<T> &	operator =	(const Quat<T> &q);
-    constexpr
+    IMATH_CONSTEXPR14
     const Quat<T> &	operator *=	(const Quat<T> &q);
-    constexpr
+    IMATH_CONSTEXPR14
     const Quat<T> &	operator *=	(T t);
-    constexpr
+    IMATH_CONSTEXPR14
     const Quat<T> &	operator /=	(const Quat<T> &q);
-    constexpr
+    IMATH_CONSTEXPR14
     const Quat<T> &	operator /=	(T t);
-    constexpr
+    IMATH_CONSTEXPR14
     const Quat<T> &	operator +=	(const Quat<T> &q);
-    constexpr
+    IMATH_CONSTEXPR14
     const Quat<T> &	operator -=	(const Quat<T> &q);
-    constexpr
+    IMATH_CONSTEXPR14
     T &			operator []	(int index);	// as 4D vector
     constexpr
     T			operator []	(int index) const;
@@ -141,10 +141,14 @@ class Quat
     template <class S> constexpr bool operator == (const Quat<S> &q) const;
     template <class S> constexpr bool operator != (const Quat<S> &q) const;
 
-    constexpr Quat<T> &	invert ();		// this -> 1 / this
-    constexpr Quat<T>	inverse () const;
-    constexpr Quat<T> &	normalize ();		// returns this
-    constexpr Quat<T>	normalized () const;
+    IMATH_CONSTEXPR14
+    Quat<T> &	        invert ();		// this -> 1 / this
+    IMATH_CONSTEXPR14
+    Quat<T>	        inverse () const;
+    IMATH_CONSTEXPR14
+    Quat<T> &	        normalize ();		// returns this
+    IMATH_CONSTEXPR14
+    Quat<T>	        normalized () const;
     constexpr T	 	length () const;	// in R4
     constexpr Vec3<T>   rotateVector(const Vec3<T> &original) const;
     constexpr T         euclideanInnerProduct(const Quat<T> &q) const;
@@ -153,9 +157,11 @@ class Quat
     //	Rotation conversion
     //-----------------------
 
-    constexpr Quat<T> &	setAxisAngle (const Vec3<T> &axis, T radians);
+    IMATH_CONSTEXPR14
+    Quat<T> &	        setAxisAngle (const Vec3<T> &axis, T radians);
 
-    constexpr Quat<T> &	setRotation (const Vec3<T> &fromDirection,
+    IMATH_CONSTEXPR14
+    Quat<T> &	        setRotation (const Vec3<T> &fromDirection,
 				     const Vec3<T> &toDirection);
 
     constexpr T		angle () const;
@@ -178,8 +184,8 @@ class Quat
 };
 
 
-template<class T>
-constexpr Quat<T>	slerp (const Quat<T> &q1, const Quat<T> &q2, T t);
+template<class T> IMATH_CONSTEXPR14
+Quat<T>	                slerp (const Quat<T> &q1, const Quat<T> &q2, T t);
 
 template<class T>
 constexpr Quat<T>	slerpShortestArc
@@ -233,8 +239,8 @@ constexpr Quat<T>	operator ~ (const Quat<T> &q);
 template<class T>
 constexpr Quat<T>	operator - (const Quat<T> &q);
 
-template<class T>
-constexpr Vec3<T>	operator * (const Vec3<T> &v, const Quat<T> &q);
+template<class T> IMATH_CONSTEXPR14
+Vec3<T>	                operator * (const Vec3<T> &v, const Quat<T> &q);
 
 
 //--------------------
@@ -282,7 +288,7 @@ Quat<T>::Quat (T s, Vec3<T> d): r (s), v (d)
 }
 
 template<class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Quat<T>::Quat(const Quat<T> &q)
 {
 	operator=(q);
@@ -296,7 +302,7 @@ Quat<T>::identity ()
 }
 
 template<class T>
-constexpr inline const Quat<T> &
+IMATH_CONSTEXPR14 inline const Quat<T> &
 Quat<T>::operator = (const Quat<T> &q)
 {
     r = q.r;
@@ -306,7 +312,7 @@ Quat<T>::operator = (const Quat<T> &q)
 
 
 template<class T>
-constexpr inline const Quat<T> &
+IMATH_CONSTEXPR14 inline const Quat<T> &
 Quat<T>::operator *= (const Quat<T> &q)
 {
     T rtmp = r * q.r - (v ^ q.v);
@@ -317,7 +323,7 @@ Quat<T>::operator *= (const Quat<T> &q)
 
 
 template<class T>
-constexpr inline const Quat<T> &
+IMATH_CONSTEXPR14 inline const Quat<T> &
 Quat<T>::operator *= (T t)
 {
     r *= t;
@@ -327,7 +333,7 @@ Quat<T>::operator *= (T t)
 
 
 template<class T>
-constexpr inline const Quat<T> &
+IMATH_CONSTEXPR14 inline const Quat<T> &
 Quat<T>::operator /= (const Quat<T> &q)
 {
     *this = *this * q.inverse();
@@ -336,7 +342,7 @@ Quat<T>::operator /= (const Quat<T> &q)
 
 
 template<class T>
-constexpr inline const Quat<T> &
+IMATH_CONSTEXPR14 inline const Quat<T> &
 Quat<T>::operator /= (T t)
 {
     r /= t;
@@ -346,7 +352,7 @@ Quat<T>::operator /= (T t)
 
 
 template<class T>
-constexpr inline const Quat<T> &
+IMATH_CONSTEXPR14 inline const Quat<T> &
 Quat<T>::operator += (const Quat<T> &q)
 {
     r += q.r;
@@ -356,7 +362,7 @@ Quat<T>::operator += (const Quat<T> &q)
 
 
 template<class T>
-constexpr inline const Quat<T> &
+IMATH_CONSTEXPR14 inline const Quat<T> &
 Quat<T>::operator -= (const Quat<T> &q)
 {
     r -= q.r;
@@ -366,7 +372,7 @@ Quat<T>::operator -= (const Quat<T> &q)
 
 
 template<class T>
-constexpr inline T &
+IMATH_CONSTEXPR14 inline T &
 Quat<T>::operator [] (int index)
 {
     return index ? v[index - 1] : r;
@@ -416,7 +422,7 @@ Quat<T>::length () const
 
 
 template <class T>
-constexpr inline Quat<T> &
+IMATH_CONSTEXPR14 inline Quat<T> &
 Quat<T>::normalize ()
 {
     if (T l = length())
@@ -435,7 +441,7 @@ Quat<T>::normalize ()
 
 
 template <class T>
-constexpr inline Quat<T>
+IMATH_CONSTEXPR14 inline Quat<T>
 Quat<T>::normalized () const
 {
     if (T l = length())
@@ -446,7 +452,7 @@ Quat<T>::normalized () const
 
 
 template<class T>
-constexpr inline Quat<T>
+IMATH_CONSTEXPR14 inline Quat<T>
 Quat<T>::inverse () const
 {
     //
@@ -461,7 +467,7 @@ Quat<T>::inverse () const
 
 
 template<class T>
-constexpr inline Quat<T> &
+IMATH_CONSTEXPR14 inline Quat<T> &
 Quat<T>::invert ()
 {
     T qdot = (*this) ^ (*this);
@@ -501,7 +507,7 @@ Quat<T>::euclideanInnerProduct (const Quat<T> &q) const
 
 
 template<class T>
-constexpr T
+IMATH_CONSTEXPR14 T
 angle4D (const Quat<T> &q1, const Quat<T> &q2)
 {
     //
@@ -520,7 +526,7 @@ angle4D (const Quat<T> &q1, const Quat<T> &q2)
 
 
 template<class T>
-constexpr Quat<T>
+IMATH_CONSTEXPR14 Quat<T>
 slerp (const Quat<T> &q1, const Quat<T> &q2, T t)
 {
     //
@@ -718,7 +724,7 @@ Quat<T>::axis () const
 
 
 template <class T>
-constexpr inline Quat<T> &
+IMATH_CONSTEXPR14 inline Quat<T> &
 Quat<T>::setAxisAngle (const Vec3<T> &axis, T radians)
 {
     r = Math<T>::cos (radians / 2);
@@ -728,7 +734,7 @@ Quat<T>::setAxisAngle (const Vec3<T> &axis, T radians)
 
 
 template <class T>
-constexpr Quat<T> &
+IMATH_CONSTEXPR14 Quat<T> &
 Quat<T>::setRotation (const Vec3<T> &from, const Vec3<T> &to)
 {
     //
@@ -976,7 +982,7 @@ operator - (const Quat<T> &q)
 
 
 template<class T>
-constexpr inline Vec3<T>
+IMATH_CONSTEXPR14 inline Vec3<T>
 operator * (const Vec3<T> &v, const Quat<T> &q)
 {
     Vec3<T> a = q.v % v;

--- a/Imath/ImathRoots.h
+++ b/Imath/ImathRoots.h
@@ -82,10 +82,14 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 //
 //--------------------------------------------------------------------------
 
-template <class T> constexpr int	solveLinear (T a, T b, T &x);
-template <class T> constexpr int	solveQuadratic (T a, T b, T c, T x[2]);
-template <class T> constexpr int	solveNormalizedCubic (T r, T s, T t, T x[3]);
-template <class T> constexpr int	solveCubic (T a, T b, T c, T d, T x[3]);
+template <class T>
+IMATH_CONSTEXPR14 int	                solveLinear (T a, T b, T &x);
+template <class T>
+IMATH_CONSTEXPR14 int	                solveQuadratic (T a, T b, T c, T x[2]);
+template <class T>
+IMATH_CONSTEXPR14 int	                solveNormalizedCubic (T r, T s, T t, T x[3]);
+template <class T>
+IMATH_CONSTEXPR14 int	                solveCubic (T a, T b, T c, T d, T x[3]);
 
 
 //---------------
@@ -93,7 +97,7 @@ template <class T> constexpr int	solveCubic (T a, T b, T c, T d, T x[3]);
 //---------------
 
 template <class T>
-constexpr int
+IMATH_CONSTEXPR14 int
 solveLinear (T a, T b, T &x)
 {
     if (a != 0)
@@ -113,7 +117,7 @@ solveLinear (T a, T b, T &x)
 
 
 template <class T>
-constexpr int
+IMATH_CONSTEXPR14 int
 solveQuadratic (T a, T b, T c, T x[2])
 {
     if (a == 0)
@@ -147,7 +151,7 @@ solveQuadratic (T a, T b, T c, T x[2])
 
 
 template <class T>
-constexpr int
+IMATH_CONSTEXPR14 int
 solveNormalizedCubic (T r, T s, T t, T x[3])
 {
     T p  = (3 * s - r * r) / 3;
@@ -201,7 +205,7 @@ solveNormalizedCubic (T r, T s, T t, T x[3])
 
 
 template <class T>
-constexpr int
+IMATH_CONSTEXPR14 int
 solveCubic (T a, T b, T c, T d, T x[3])
 {
     if (a == 0)

--- a/Imath/ImathShear.h
+++ b/Imath/ImathShear.h
@@ -62,7 +62,8 @@ template <class T> class Shear6
 
     T			xy, xz, yz, yx, zx, zy;
 
-    constexpr T &	operator [] (int i);
+    IMATH_CONSTEXPR14
+    T &	                operator [] (int i);
     constexpr
     const T &		operator [] (int i) const;
 
@@ -71,14 +72,15 @@ template <class T> class Shear6
     // Constructors
     //-------------
 
-    constexpr Shear6 ();	   // (0 0 0 0 0 0)
-    constexpr
+    IMATH_CONSTEXPR14
+    Shear6 ();	                   // (0 0 0 0 0 0)
+    IMATH_CONSTEXPR14
     Shear6 (T XY, T XZ, T YZ);	   // (XY XZ YZ 0 0 0)
-    constexpr
+    IMATH_CONSTEXPR14
     Shear6 (const Vec3<T> &v);     // (v.x v.y v.z 0 0 0)
     template <class S>             // (v.x v.y v.z 0 0 0)
-	constexpr Shear6 (const Vec3<S> &v);
-    constexpr
+        IMATH_CONSTEXPR14 Shear6 (const Vec3<S> &v);
+    IMATH_CONSTEXPR14
     Shear6 (T XY, T XZ, T YZ,      // (XY XZ YZ YX ZX ZY)
 	    T YX, T ZX, T ZY);	
 
@@ -87,10 +89,10 @@ template <class T> class Shear6
     // Copy constructors and assignment
     //---------------------------------
 
-    constexpr Shear6 (const Shear6 &h);
-    template <class S> constexpr Shear6 (const Shear6<S> &h);
+    IMATH_CONSTEXPR14 Shear6 (const Shear6 &h);
+    template <class S> IMATH_CONSTEXPR14 Shear6 (const Shear6<S> &h);
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Shear6 &	operator = (const Shear6 &h);
     template <class S> 
 	constexpr
@@ -159,7 +161,7 @@ template <class T> class Shear6
     // Component-wise addition
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Shear6 &	operator += (const Shear6 &h);
     constexpr Shear6	operator + (const Shear6 &h) const;
 
@@ -168,7 +170,7 @@ template <class T> class Shear6
     // Component-wise subtraction
     //---------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Shear6 &	operator -= (const Shear6 &h);
     constexpr Shear6	operator - (const Shear6 &h) const;
 
@@ -178,7 +180,7 @@ template <class T> class Shear6
     //------------------------------------
 
     constexpr Shear6	operator - () const;
-    constexpr
+    IMATH_CONSTEXPR14
     const Shear6 &	negate ();
 
 
@@ -186,9 +188,9 @@ template <class T> class Shear6
     // Component-wise multiplication
     //------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Shear6 &	operator *= (const Shear6 &h);
-    constexpr
+    IMATH_CONSTEXPR14
     const Shear6 &	operator *= (T a);
     constexpr Shear6	operator * (const Shear6 &h) const;
     constexpr Shear6	operator * (T a) const;
@@ -198,9 +200,9 @@ template <class T> class Shear6
     // Component-wise division
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Shear6 &	operator /= (const Shear6 &h);
-    constexpr
+    IMATH_CONSTEXPR14
     const Shear6 &	operator /= (T a);
     constexpr Shear6	operator / (const Shear6 &h) const;
     constexpr Shear6	operator / (T a) const;
@@ -266,7 +268,7 @@ typedef Shear6 <double> Shear6d;
 //-----------------------
 
 template <class T>
-constexpr inline T &
+IMATH_CONSTEXPR14 inline T &
 Shear6<T>::operator [] (int i)
 {
     return (&xy)[i]; // NOSONAR - suppress SonarCloud bug report.
@@ -280,14 +282,14 @@ Shear6<T>::operator [] (int i) const
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Shear6<T>::Shear6 ()
 {
     xy = xz = yz = yx = zx = zy = 0;
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Shear6<T>::Shear6 (T XY, T XZ, T YZ)
 {
     xy = XY;
@@ -299,7 +301,7 @@ Shear6<T>::Shear6 (T XY, T XZ, T YZ)
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Shear6<T>::Shear6 (const Vec3<T> &v)
 {
     xy = v.x;
@@ -312,7 +314,7 @@ Shear6<T>::Shear6 (const Vec3<T> &v)
 
 template <class T>
 template <class S>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Shear6<T>::Shear6 (const Vec3<S> &v)
 {
     xy = T (v.x);
@@ -324,7 +326,7 @@ Shear6<T>::Shear6 (const Vec3<S> &v)
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Shear6<T>::Shear6 (T XY, T XZ, T YZ, T YX, T ZX, T ZY)
 {
     xy = XY;
@@ -336,7 +338,7 @@ Shear6<T>::Shear6 (T XY, T XZ, T YZ, T YX, T ZX, T ZY)
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Shear6<T>::Shear6 (const Shear6 &h)
 {
     xy = h.xy;
@@ -349,7 +351,7 @@ Shear6<T>::Shear6 (const Shear6 &h)
 
 template <class T>
 template <class S>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Shear6<T>::Shear6 (const Shear6<S> &h)
 {
     xy = T (h.xy);
@@ -361,7 +363,7 @@ Shear6<T>::Shear6 (const Shear6<S> &h)
 }
 
 template <class T>
-constexpr inline const Shear6<T> &
+IMATH_CONSTEXPR14 inline const Shear6<T> &
 Shear6<T>::operator = (const Shear6 &h)
 {
     xy = h.xy;
@@ -495,7 +497,7 @@ Shear6<T>::equalWithRelError (const Shear6<T> &h, T e) const
 
 
 template <class T>
-constexpr inline const Shear6<T> &
+IMATH_CONSTEXPR14 inline const Shear6<T> &
 Shear6<T>::operator += (const Shear6 &h)
 {
     xy += h.xy;
@@ -516,7 +518,7 @@ Shear6<T>::operator + (const Shear6 &h) const
 }
 
 template <class T>
-constexpr inline const Shear6<T> &
+IMATH_CONSTEXPR14 inline const Shear6<T> &
 Shear6<T>::operator -= (const Shear6 &h)
 {
     xy -= h.xy;
@@ -544,7 +546,7 @@ Shear6<T>::operator - () const
 }
 
 template <class T>
-constexpr inline const Shear6<T> &
+IMATH_CONSTEXPR14 inline const Shear6<T> &
 Shear6<T>::negate ()
 {
     xy = -xy;
@@ -557,7 +559,7 @@ Shear6<T>::negate ()
 }
 
 template <class T>
-constexpr inline const Shear6<T> &
+IMATH_CONSTEXPR14 inline const Shear6<T> &
 Shear6<T>::operator *= (const Shear6 &h)
 {
     xy *= h.xy;
@@ -570,7 +572,7 @@ Shear6<T>::operator *= (const Shear6 &h)
 }
 
 template <class T>
-constexpr inline const Shear6<T> &
+IMATH_CONSTEXPR14 inline const Shear6<T> &
 Shear6<T>::operator *= (T a)
 {
     xy *= a;
@@ -599,7 +601,7 @@ Shear6<T>::operator * (T a) const
 }
 
 template <class T>
-constexpr inline const Shear6<T> &
+IMATH_CONSTEXPR14 inline const Shear6<T> &
 Shear6<T>::operator /= (const Shear6 &h)
 {
     xy /= h.xy;
@@ -612,7 +614,7 @@ Shear6<T>::operator /= (const Shear6 &h)
 }
 
 template <class T>
-constexpr inline const Shear6<T> &
+IMATH_CONSTEXPR14 inline const Shear6<T> &
 Shear6<T>::operator /= (T a)
 {
     xy /= a;

--- a/Imath/ImathVec.h
+++ b/Imath/ImathVec.h
@@ -75,7 +75,8 @@ template <class T> class Vec2
 
     T			x, y;
 
-    constexpr T &	operator [] (int i);
+    IMATH_CONSTEXPR14
+    T &	                operator [] (int i);
     constexpr
     const T &		operator [] (int i) const;
 
@@ -85,18 +86,18 @@ template <class T> class Vec2
     //-------------
 
     Vec2 ();                        // no initialization
-    constexpr explicit Vec2 (T a);  // (a a)
-    constexpr Vec2 (T a, T b);      // (a b)
+    IMATH_CONSTEXPR14 explicit Vec2 (T a);  // (a a)
+    IMATH_CONSTEXPR14 Vec2 (T a, T b);      // (a b)
 
 
     //---------------------------------
     // Copy constructors and assignment
     //---------------------------------
 
-    constexpr Vec2 (const Vec2 &v);
-    template <class S> constexpr Vec2 (const Vec2<S> &v);
+    IMATH_CONSTEXPR14 Vec2 (const Vec2 &v);
+    template <class S> IMATH_CONSTEXPR14 Vec2 (const Vec2<S> &v);
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec2 &	operator = (const Vec2 &v);
 
     //------------
@@ -154,8 +155,10 @@ template <class T> class Vec2
     //      abs (this[i] - v[i]) <= e * abs (this[i])
     //-----------------------------------------------------------------------
 
-    constexpr bool	equalWithAbsError (const Vec2<T> &v, T e) const;
-    constexpr bool	equalWithRelError (const Vec2<T> &v, T e) const;
+    IMATH_CONSTEXPR14
+    bool	        equalWithAbsError (const Vec2<T> &v, T e) const;
+    IMATH_CONSTEXPR14
+    bool  	        equalWithRelError (const Vec2<T> &v, T e) const;
 
     //------------
     // Dot product
@@ -178,7 +181,7 @@ template <class T> class Vec2
     // Component-wise addition
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec2 &	operator += (const Vec2 &v);
     constexpr Vec2	operator + (const Vec2 &v) const;
 
@@ -187,7 +190,7 @@ template <class T> class Vec2
     // Component-wise subtraction
     //---------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec2 &	operator -= (const Vec2 &v);
     constexpr Vec2	operator - (const Vec2 &v) const;
 
@@ -197,7 +200,7 @@ template <class T> class Vec2
     //------------------------------------
 
     constexpr Vec2	operator - () const;
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec2 &	negate ();
 
 
@@ -205,9 +208,9 @@ template <class T> class Vec2
     // Component-wise multiplication
     //------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec2 &	operator *= (const Vec2 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec2 &	operator *= (T a);
     constexpr Vec2	operator * (const Vec2 &v) const;
     constexpr Vec2	operator * (T a) const;
@@ -217,9 +220,9 @@ template <class T> class Vec2
     // Component-wise division
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec2 &	operator /= (const Vec2 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec2 &	operator /= (T a);
     constexpr Vec2	operator / (const Vec2 &v) const;
     constexpr Vec2	operator / (T a) const;
@@ -234,20 +237,22 @@ template <class T> class Vec2
     // is 0.0, the result is undefined.
     //----------------------------------------------------------------
 
-    constexpr T		length () const;
+    IMATH_CONSTEXPR14 T	length () const;
     constexpr T		length2 () const;
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec2 &	normalize ();           // modifies *this
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec2 &	normalizeExc ();
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec2 &	normalizeNonNull ();
 
-    constexpr Vec2<T>	normalized () const;	// does not modify *this
-    constexpr Vec2<T>	normalizedExc () const;
-    constexpr Vec2<T>	normalizedNonNull () const;
-
+    IMATH_CONSTEXPR14
+    Vec2<T>	        normalized () const;	// does not modify *this
+    IMATH_CONSTEXPR14
+    Vec2<T>	        normalizedExc () const;
+    IMATH_CONSTEXPR14
+    Vec2<T>	        normalizedNonNull () const;
 
     //--------------------------------------------------------
     // Number of dimensions, i.e. number of elements in a Vec2
@@ -276,7 +281,7 @@ template <class T> class Vec2
 
   private:
 
-    constexpr T		lengthTiny () const;
+    IMATH_CONSTEXPR14 T	lengthTiny () const;
 };
 
 
@@ -290,7 +295,8 @@ template <class T> class Vec3
 
     T			x, y, z;
 
-    constexpr T &	operator [] (int i);
+    IMATH_CONSTEXPR14
+    T &	                operator [] (int i);
     constexpr
     const T &		operator [] (int i) const;
 
@@ -300,9 +306,9 @@ template <class T> class Vec3
     //-------------
 
     constexpr Vec3 ();		   // no initialization
-    constexpr
+    IMATH_CONSTEXPR14
     explicit Vec3 (T a);           // (a a a)
-    constexpr
+    IMATH_CONSTEXPR14
     Vec3 (T a, T b, T c);	   // (a b c)
 
 
@@ -310,10 +316,10 @@ template <class T> class Vec3
     // Copy constructors and assignment
     //---------------------------------
 
-    constexpr Vec3 (const Vec3 &v);
-    template <class S> constexpr Vec3 (const Vec3<S> &v);
+    IMATH_CONSTEXPR14 Vec3 (const Vec3 &v);
+    template <class S> IMATH_CONSTEXPR14 Vec3 (const Vec3<S> &v);
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec3 &	operator = (const Vec3 &v);
 
     //-----------
@@ -333,8 +339,8 @@ template <class T> class Vec3
     // if w is zero or if division by w would overflow.
     //---------------------------------------------------------
 
-    template <class S> explicit constexpr Vec3 (const Vec4<S> &v);
-    template <class S> explicit constexpr Vec3 (const Vec4<S> &v, InfException);
+    template <class S> explicit IMATH_CONSTEXPR14 Vec3 (const Vec4<S> &v);
+    template <class S> explicit IMATH_CONSTEXPR14 Vec3 (const Vec4<S> &v, InfException);
 
 
     //----------------------
@@ -385,8 +391,10 @@ template <class T> class Vec3
     //      abs (this[i] - v[i]) <= e * abs (this[i])
     //-----------------------------------------------------------------------
 
-    constexpr bool	equalWithAbsError (const Vec3<T> &v, T e) const;
-    constexpr bool	equalWithRelError (const Vec3<T> &v, T e) const;
+    IMATH_CONSTEXPR14
+    bool	        equalWithAbsError (const Vec3<T> &v, T e) const;
+    IMATH_CONSTEXPR14
+    bool	        equalWithRelError (const Vec3<T> &v, T e) const;
 
     //------------
     // Dot product
@@ -401,7 +409,7 @@ template <class T> class Vec3
     //---------------------------
 
     constexpr Vec3	cross (const Vec3 &v) const;
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec3 &	operator %= (const Vec3 &v);
     constexpr Vec3	operator % (const Vec3 &v) const;
 
@@ -410,7 +418,7 @@ template <class T> class Vec3
     // Component-wise addition
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec3 &	operator += (const Vec3 &v);
     constexpr Vec3	operator + (const Vec3 &v) const;
 
@@ -419,7 +427,7 @@ template <class T> class Vec3
     // Component-wise subtraction
     //---------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec3 &	operator -= (const Vec3 &v);
     constexpr Vec3	operator - (const Vec3 &v) const;
 
@@ -429,7 +437,7 @@ template <class T> class Vec3
     //------------------------------------
 
     constexpr Vec3	operator - () const;
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec3 &	negate ();
 
 
@@ -437,9 +445,9 @@ template <class T> class Vec3
     // Component-wise multiplication
     //------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec3 &	operator *= (const Vec3 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec3 &	operator *= (T a);
     constexpr Vec3	operator * (const Vec3 &v) const;
     constexpr Vec3	operator * (T a) const;
@@ -449,9 +457,9 @@ template <class T> class Vec3
     // Component-wise division
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec3 &	operator /= (const Vec3 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec3 &	operator /= (T a);
     constexpr Vec3	operator / (const Vec3 &v) const;
     constexpr Vec3	operator / (T a) const;
@@ -463,22 +471,26 @@ template <class T> class Vec3
     // v.normalizedExc() throw a std::domain_error.
     // v.normalizeNonNull() and v.normalizedNonNull() are slightly
     // faster than the other normalization routines, but if v.length()
+
     // is 0.0, the result is undefined.
     //----------------------------------------------------------------
 
-    constexpr T		length () const;
+    IMATH_CONSTEXPR14 T	length () const;
     constexpr T		length2 () const;
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec3 &	normalize ();           // modifies *this
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec3 &	normalizeExc ();
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec3 &	normalizeNonNull ();
 
-    constexpr Vec3<T>	normalized () const;	// does not modify *this
-    constexpr Vec3<T>	normalizedExc () const;
-    constexpr Vec3<T>	normalizedNonNull () const;
+    IMATH_CONSTEXPR14
+    Vec3<T>	        normalized () const;	// does not modify *this
+    IMATH_CONSTEXPR14
+    Vec3<T>	        normalizedExc () const;
+    IMATH_CONSTEXPR14
+    Vec3<T>	        normalizedNonNull () const;
 
 
     //--------------------------------------------------------
@@ -508,7 +520,7 @@ template <class T> class Vec3
 
   private:
 
-    constexpr T		lengthTiny () const;
+    IMATH_CONSTEXPR14 T lengthTiny () const;
 };
 
 
@@ -523,7 +535,8 @@ template <class T> class Vec4
 
     T               x, y, z, w; 
 
-    constexpr T &   operator [] (int i);
+    IMATH_CONSTEXPR14
+    T &             operator [] (int i);
     constexpr
     const T &       operator [] (int i) const;
 
@@ -533,9 +546,9 @@ template <class T> class Vec4
     //-------------
 
     constexpr Vec4 ();		   // no initialization
-    constexpr
+    IMATH_CONSTEXPR14
     explicit Vec4 (T a);           // (a a a a)
-    constexpr
+    IMATH_CONSTEXPR14
     Vec4 (T a, T b, T c, T d);	   // (a b c d)
 
 
@@ -543,10 +556,10 @@ template <class T> class Vec4
     // Copy constructors and assignment
     //---------------------------------
 
-    constexpr Vec4 (const Vec4 &v);
-    template <class S> constexpr Vec4 (const Vec4<S> &v);
+    IMATH_CONSTEXPR14 Vec4 (const Vec4 &v);
+    template <class S> IMATH_CONSTEXPR14 Vec4 (const Vec4<S> &v);
 
-    constexpr const Vec4 &    operator = (const Vec4 &v);
+    IMATH_CONSTEXPR14 const Vec4 &    operator = (const Vec4 &v);
 
     //-----------
     // Destructor
@@ -558,7 +571,7 @@ template <class T> class Vec4
     // Vec3 to Vec4 conversion, sets w to 1
     //-------------------------------------
 
-    template <class S> explicit constexpr Vec4 (const Vec3<S> &v);
+    template <class S> explicit IMATH_CONSTEXPR14 Vec4 (const Vec3<S> &v);
 
 
     //---------
@@ -590,8 +603,10 @@ template <class T> class Vec4
     //      abs (this[i] - v[i]) <= e * abs (this[i])
     //-----------------------------------------------------------------------
 
-    constexpr bool      equalWithAbsError (const Vec4<T> &v, T e) const;
-    constexpr bool	equalWithRelError (const Vec4<T> &v, T e) const;
+    IMATH_CONSTEXPR14
+    bool                equalWithAbsError (const Vec4<T> &v, T e) const;
+    IMATH_CONSTEXPR14
+    bool	        equalWithRelError (const Vec4<T> &v, T e) const;
 
 
     //------------
@@ -610,7 +625,7 @@ template <class T> class Vec4
     // Component-wise addition
     //------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec4 &    operator += (const Vec4 &v);
     constexpr Vec4  operator + (const Vec4 &v) const;
 
@@ -619,7 +634,7 @@ template <class T> class Vec4
     // Component-wise subtraction
     //---------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec4 &    operator -= (const Vec4 &v);
     constexpr Vec4  operator - (const Vec4 &v) const;
 
@@ -629,7 +644,7 @@ template <class T> class Vec4
     //------------------------------------
 
     constexpr Vec4  operator - () const;
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec4 &    negate ();
 
 
@@ -637,9 +652,9 @@ template <class T> class Vec4
     // Component-wise multiplication
     //------------------------------
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec4 &    operator *= (const Vec4 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec4 &    operator *= (T a);
     constexpr Vec4  operator * (const Vec4 &v) const;
     constexpr Vec4  operator * (T a) const;
@@ -649,9 +664,10 @@ template <class T> class Vec4
     // Component-wise division
     //------------------------
 
-    constexpr
+
+    IMATH_CONSTEXPR14
     const Vec4 &    operator /= (const Vec4 &v);
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec4 &    operator /= (T a);
     constexpr Vec4  operator / (const Vec4 &v) const;
     constexpr Vec4  operator / (T a) const;
@@ -666,21 +682,22 @@ template <class T> class Vec4
     // is 0.0, the result is undefined.
     //----------------------------------------------------------------
 
-    constexpr T     length () const;
+    IMATH_CONSTEXPR14
+    T               length () const;
     constexpr T     length2 () const;
 
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec4 &    normalize ();           // modifies *this
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec4 &    normalizeExc ();
-    constexpr
+    IMATH_CONSTEXPR14
     const Vec4 &    normalizeNonNull ();
 
-    constexpr
+    IMATH_CONSTEXPR14
     Vec4<T>         normalized () const;	// does not modify *this
-    constexpr
+    IMATH_CONSTEXPR14
     Vec4<T>         normalizedExc () const;
-    constexpr
+    IMATH_CONSTEXPR14
     Vec4<T>         normalizedNonNull () const;
 
 
@@ -711,7 +728,7 @@ template <class T> class Vec4
 
   private:
 
-    constexpr T		lengthTiny () const;
+    IMATH_CONSTEXPR14 T	lengthTiny () const;
 };
 
 
@@ -907,7 +924,7 @@ Vec4<int>::normalizedNonNull () const;
 //------------------------
 
 template <class T>
-constexpr inline T &
+IMATH_CONSTEXPR14 inline T &
 Vec2<T>::operator [] (int i)
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
@@ -928,14 +945,14 @@ Vec2<T>::Vec2 ()
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec2<T>::Vec2 (T a)
 {
     x = y = a;
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec2<T>::Vec2 (T a, T b)
 {
     x = a;
@@ -943,7 +960,7 @@ Vec2<T>::Vec2 (T a, T b)
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec2<T>::Vec2 (const Vec2 &v)
 {
     x = v.x;
@@ -952,7 +969,7 @@ Vec2<T>::Vec2 (const Vec2 &v)
 
 template <class T>
 template <class S>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec2<T>::Vec2 (const Vec2<S> &v)
 {
     x = T (v.x);
@@ -960,7 +977,7 @@ Vec2<T>::Vec2 (const Vec2<S> &v)
 }
 
 template <class T>
-constexpr inline const Vec2<T> &
+IMATH_CONSTEXPR14 inline const Vec2<T> &
 Vec2<T>::operator = (const Vec2 &v)
 {
     x = v.x;
@@ -1035,7 +1052,7 @@ Vec2<T>::operator != (const Vec2<S> &v) const
 }
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 Vec2<T>::equalWithAbsError (const Vec2<T> &v, T e) const
 {
     for (int i = 0; i < 2; i++)
@@ -1046,7 +1063,7 @@ Vec2<T>::equalWithAbsError (const Vec2<T> &v, T e) const
 }
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 Vec2<T>::equalWithRelError (const Vec2<T> &v, T e) const
 {
     for (int i = 0; i < 2; i++)
@@ -1086,7 +1103,7 @@ Vec2<T>::operator % (const Vec2 &v) const
 }
 
 template <class T>
-constexpr inline const Vec2<T> &
+IMATH_CONSTEXPR14 inline const Vec2<T> &
 Vec2<T>::operator += (const Vec2 &v)
 {
     x += v.x;
@@ -1102,7 +1119,7 @@ Vec2<T>::operator + (const Vec2 &v) const
 }
 
 template <class T>
-constexpr inline const Vec2<T> &
+IMATH_CONSTEXPR14 inline const Vec2<T> &
 Vec2<T>::operator -= (const Vec2 &v)
 {
     x -= v.x;
@@ -1125,7 +1142,7 @@ Vec2<T>::operator - () const
 }
 
 template <class T>
-constexpr inline const Vec2<T> &
+IMATH_CONSTEXPR14 inline const Vec2<T> &
 Vec2<T>::negate ()
 {
     x = -x;
@@ -1134,7 +1151,7 @@ Vec2<T>::negate ()
 }
 
 template <class T>
-constexpr inline const Vec2<T> &
+IMATH_CONSTEXPR14 inline const Vec2<T> &
 Vec2<T>::operator *= (const Vec2 &v)
 {
     x *= v.x;
@@ -1143,7 +1160,7 @@ Vec2<T>::operator *= (const Vec2 &v)
 }
 
 template <class T>
-constexpr inline const Vec2<T> &
+IMATH_CONSTEXPR14 inline const Vec2<T> &
 Vec2<T>::operator *= (T a)
 {
     x *= a;
@@ -1166,7 +1183,7 @@ Vec2<T>::operator * (T a) const
 }
 
 template <class T>
-constexpr inline const Vec2<T> &
+IMATH_CONSTEXPR14 inline const Vec2<T> &
 Vec2<T>::operator /= (const Vec2 &v)
 {
     x /= v.x;
@@ -1175,7 +1192,7 @@ Vec2<T>::operator /= (const Vec2 &v)
 }
 
 template <class T>
-constexpr inline const Vec2<T> &
+IMATH_CONSTEXPR14 inline const Vec2<T> &
 Vec2<T>::operator /= (T a)
 {
     x /= a;
@@ -1198,7 +1215,7 @@ Vec2<T>::operator / (T a) const
 }
 
 template <class T>
-constexpr T
+IMATH_CONSTEXPR14 T
 Vec2<T>::lengthTiny () const
 {
     T absX = (x >= T (0))? x: -x;
@@ -1225,7 +1242,7 @@ Vec2<T>::lengthTiny () const
 }
 
 template <class T>
-constexpr inline T
+IMATH_CONSTEXPR14 inline T
 Vec2<T>::length () const
 {
     T length2 = dot (*this);
@@ -1244,7 +1261,7 @@ Vec2<T>::length2 () const
 }
 
 template <class T>
-constexpr const Vec2<T> &
+IMATH_CONSTEXPR14 const Vec2<T> &
 Vec2<T>::normalize ()
 {
     T l = length();
@@ -1265,7 +1282,7 @@ Vec2<T>::normalize ()
 }
 
 template <class T>
-constexpr const Vec2<T> &
+IMATH_CONSTEXPR14 const Vec2<T> &
 Vec2<T>::normalizeExc ()
 {
     T l = length();
@@ -1279,7 +1296,7 @@ Vec2<T>::normalizeExc ()
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 const Vec2<T> &
 Vec2<T>::normalizeNonNull ()
 {
@@ -1290,7 +1307,7 @@ Vec2<T>::normalizeNonNull ()
 }
 
 template <class T>
-constexpr Vec2<T>
+IMATH_CONSTEXPR14 Vec2<T>
 Vec2<T>::normalized () const
 {
     T l = length();
@@ -1302,7 +1319,7 @@ Vec2<T>::normalized () const
 }
 
 template <class T>
-constexpr Vec2<T>
+IMATH_CONSTEXPR14 Vec2<T>
 Vec2<T>::normalizedExc () const
 {
     T l = length();
@@ -1314,7 +1331,7 @@ Vec2<T>::normalizedExc () const
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec2<T>
 Vec2<T>::normalizedNonNull () const
 {
@@ -1328,7 +1345,7 @@ Vec2<T>::normalizedNonNull () const
 //-----------------------
 
 template <class T>
-constexpr inline T &
+IMATH_CONSTEXPR14 inline T &
 Vec3<T>::operator [] (int i)
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
@@ -1349,14 +1366,14 @@ Vec3<T>::Vec3 ()
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec3<T>::Vec3 (T a)
 {
     x = y = z = a;
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec3<T>::Vec3 (T a, T b, T c)
 {
     x = a;
@@ -1365,7 +1382,7 @@ Vec3<T>::Vec3 (T a, T b, T c)
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec3<T>::Vec3 (const Vec3 &v)
 {
     x = v.x;
@@ -1375,7 +1392,7 @@ Vec3<T>::Vec3 (const Vec3 &v)
 
 template <class T>
 template <class S>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec3<T>::Vec3 (const Vec3<S> &v)
 {
     x = T (v.x);
@@ -1384,7 +1401,7 @@ Vec3<T>::Vec3 (const Vec3<S> &v)
 }
 
 template <class T>
-constexpr inline const Vec3<T> &
+IMATH_CONSTEXPR14 inline const Vec3<T> &
 Vec3<T>::operator = (const Vec3 &v)
 {
     x = v.x;
@@ -1395,7 +1412,7 @@ Vec3<T>::operator = (const Vec3 &v)
 
 template <class T>
 template <class S>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec3<T>::Vec3 (const Vec4<S> &v)
 {
     x = T (v.x / v.w);
@@ -1405,7 +1422,7 @@ Vec3<T>::Vec3 (const Vec4<S> &v)
 
 template <class T>
 template <class S>
-constexpr Vec3<T>::Vec3 (const Vec4<S> &v, InfException)
+IMATH_CONSTEXPR14 Vec3<T>::Vec3 (const Vec4<S> &v, InfException)
 {
     T vx = T (v.x);
     T vy = T (v.y);
@@ -1498,7 +1515,7 @@ Vec3<T>::operator != (const Vec3<S> &v) const
 }
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 Vec3<T>::equalWithAbsError (const Vec3<T> &v, T e) const
 {
     for (int i = 0; i < 3; i++)
@@ -1509,7 +1526,7 @@ Vec3<T>::equalWithAbsError (const Vec3<T> &v, T e) const
 }
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 Vec3<T>::equalWithRelError (const Vec3<T> &v, T e) const
 {
     for (int i = 0; i < 3; i++)
@@ -1543,7 +1560,7 @@ Vec3<T>::cross (const Vec3 &v) const
 }
 
 template <class T>
-constexpr inline const Vec3<T> &
+IMATH_CONSTEXPR14 inline const Vec3<T> &
 Vec3<T>::operator %= (const Vec3 &v)
 {
     T a = y * v.z - z * v.y;
@@ -1565,7 +1582,7 @@ Vec3<T>::operator % (const Vec3 &v) const
 }
 
 template <class T>
-constexpr inline const Vec3<T> &
+IMATH_CONSTEXPR14 inline const Vec3<T> &
 Vec3<T>::operator += (const Vec3 &v)
 {
     x += v.x;
@@ -1582,7 +1599,7 @@ Vec3<T>::operator + (const Vec3 &v) const
 }
 
 template <class T>
-constexpr inline const Vec3<T> &
+IMATH_CONSTEXPR14 inline const Vec3<T> &
 Vec3<T>::operator -= (const Vec3 &v)
 {
     x -= v.x;
@@ -1606,7 +1623,7 @@ Vec3<T>::operator - () const
 }
 
 template <class T>
-constexpr inline const Vec3<T> &
+IMATH_CONSTEXPR14 inline const Vec3<T> &
 Vec3<T>::negate ()
 {
     x = -x;
@@ -1616,7 +1633,7 @@ Vec3<T>::negate ()
 }
 
 template <class T>
-constexpr inline const Vec3<T> &
+IMATH_CONSTEXPR14 inline const Vec3<T> &
 Vec3<T>::operator *= (const Vec3 &v)
 {
     x *= v.x;
@@ -1626,7 +1643,7 @@ Vec3<T>::operator *= (const Vec3 &v)
 }
 
 template <class T>
-constexpr inline const Vec3<T> &
+IMATH_CONSTEXPR14 inline const Vec3<T> &
 Vec3<T>::operator *= (T a)
 {
     x *= a;
@@ -1650,7 +1667,7 @@ Vec3<T>::operator * (T a) const
 }
 
 template <class T>
-constexpr inline const Vec3<T> &
+IMATH_CONSTEXPR14 inline const Vec3<T> &
 Vec3<T>::operator /= (const Vec3 &v)
 {
     x /= v.x;
@@ -1660,7 +1677,7 @@ Vec3<T>::operator /= (const Vec3 &v)
 }
 
 template <class T>
-constexpr inline const Vec3<T> &
+IMATH_CONSTEXPR14 inline const Vec3<T> &
 Vec3<T>::operator /= (T a)
 {
     x /= a;
@@ -1684,7 +1701,7 @@ Vec3<T>::operator / (T a) const
 }
 
 template <class T>
-constexpr T
+IMATH_CONSTEXPR14 T
 Vec3<T>::lengthTiny () const
 {
     T absX = (x >= T (0))? x: -x;
@@ -1716,7 +1733,7 @@ Vec3<T>::lengthTiny () const
 }
 
 template <class T>
-constexpr inline T
+IMATH_CONSTEXPR14 inline T
 Vec3<T>::length () const
 {
     T length2 = dot (*this);
@@ -1735,7 +1752,7 @@ Vec3<T>::length2 () const
 }
 
 template <class T>
-constexpr const Vec3<T> &
+IMATH_CONSTEXPR14 const Vec3<T> &
 Vec3<T>::normalize ()
 {
     T l = length();
@@ -1757,7 +1774,7 @@ Vec3<T>::normalize ()
 }
 
 template <class T>
-constexpr const Vec3<T> &
+IMATH_CONSTEXPR14 const Vec3<T> &
 Vec3<T>::normalizeExc ()
 {
     T l = length();
@@ -1773,7 +1790,7 @@ Vec3<T>::normalizeExc ()
 
 template <class T>
 inline
-constexpr const Vec3<T> &
+IMATH_CONSTEXPR14 const Vec3<T> &
 Vec3<T>::normalizeNonNull ()
 {
     T l = length();
@@ -1784,7 +1801,7 @@ Vec3<T>::normalizeNonNull ()
 }
 
 template <class T>
-constexpr Vec3<T>
+IMATH_CONSTEXPR14 Vec3<T>
 Vec3<T>::normalized () const
 {
     T l = length();
@@ -1796,7 +1813,7 @@ Vec3<T>::normalized () const
 }
 
 template <class T>
-constexpr Vec3<T>
+IMATH_CONSTEXPR14 Vec3<T>
 Vec3<T>::normalizedExc () const
 {
     T l = length();
@@ -1809,7 +1826,7 @@ Vec3<T>::normalizedExc () const
 
 template <class T>
 inline
-constexpr Vec3<T>
+IMATH_CONSTEXPR14 Vec3<T>
 Vec3<T>::normalizedNonNull () const
 {
     T l = length();
@@ -1822,7 +1839,7 @@ Vec3<T>::normalizedNonNull () const
 //-----------------------
 
 template <class T>
-constexpr inline T &
+IMATH_CONSTEXPR14 inline T &
 Vec4<T>::operator [] (int i)
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
@@ -1843,14 +1860,14 @@ Vec4<T>::Vec4 ()
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec4<T>::Vec4 (T a)
 {
     x = y = z = w = a;
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec4<T>::Vec4 (T a, T b, T c, T d)
 {
     x = a;
@@ -1860,7 +1877,7 @@ Vec4<T>::Vec4 (T a, T b, T c, T d)
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec4<T>::Vec4 (const Vec4 &v)
 {
     x = v.x;
@@ -1871,7 +1888,7 @@ Vec4<T>::Vec4 (const Vec4 &v)
 
 template <class T>
 template <class S>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec4<T>::Vec4 (const Vec4<S> &v)
 {
     x = T (v.x);
@@ -1881,7 +1898,7 @@ Vec4<T>::Vec4 (const Vec4<S> &v)
 }
 
 template <class T>
-constexpr inline const Vec4<T> &
+IMATH_CONSTEXPR14 inline const Vec4<T> &
 Vec4<T>::operator = (const Vec4 &v)
 {
     x = v.x;
@@ -1893,7 +1910,7 @@ Vec4<T>::operator = (const Vec4 &v)
 
 template <class T>
 template <class S>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 Vec4<T>::Vec4 (const Vec3<S> &v)
 {
     x = T (v.x);
@@ -1919,7 +1936,7 @@ Vec4<T>::operator != (const Vec4<S> &v) const
 }
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 Vec4<T>::equalWithAbsError (const Vec4<T> &v, T e) const
 {
     for (int i = 0; i < 4; i++)
@@ -1930,7 +1947,7 @@ Vec4<T>::equalWithAbsError (const Vec4<T> &v, T e) const
 }
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 Vec4<T>::equalWithRelError (const Vec4<T> &v, T e) const
 {
     for (int i = 0; i < 4; i++)
@@ -1956,7 +1973,7 @@ Vec4<T>::operator ^ (const Vec4 &v) const
 
 
 template <class T>
-constexpr inline const Vec4<T> &
+IMATH_CONSTEXPR14 inline const Vec4<T> &
 Vec4<T>::operator += (const Vec4 &v)
 {
     x += v.x;
@@ -1974,7 +1991,7 @@ Vec4<T>::operator + (const Vec4 &v) const
 }
 
 template <class T>
-constexpr inline const Vec4<T> &
+IMATH_CONSTEXPR14 inline const Vec4<T> &
 Vec4<T>::operator -= (const Vec4 &v)
 {
     x -= v.x;
@@ -1999,7 +2016,7 @@ Vec4<T>::operator - () const
 }
 
 template <class T>
-constexpr inline const Vec4<T> &
+IMATH_CONSTEXPR14 inline const Vec4<T> &
 Vec4<T>::negate ()
 {
     x = -x;
@@ -2010,7 +2027,7 @@ Vec4<T>::negate ()
 }
 
 template <class T>
-constexpr inline const Vec4<T> &
+IMATH_CONSTEXPR14 inline const Vec4<T> &
 Vec4<T>::operator *= (const Vec4 &v)
 {
     x *= v.x;
@@ -2021,7 +2038,7 @@ Vec4<T>::operator *= (const Vec4 &v)
 }
 
 template <class T>
-constexpr inline const Vec4<T> &
+IMATH_CONSTEXPR14 inline const Vec4<T> &
 Vec4<T>::operator *= (T a)
 {
     x *= a;
@@ -2046,7 +2063,7 @@ Vec4<T>::operator * (T a) const
 }
 
 template <class T>
-constexpr inline const Vec4<T> &
+IMATH_CONSTEXPR14 inline const Vec4<T> &
 Vec4<T>::operator /= (const Vec4 &v)
 {
     x /= v.x;
@@ -2057,7 +2074,7 @@ Vec4<T>::operator /= (const Vec4 &v)
 }
 
 template <class T>
-constexpr inline const Vec4<T> &
+IMATH_CONSTEXPR14 inline const Vec4<T> &
 Vec4<T>::operator /= (T a)
 {
     x /= a;
@@ -2082,7 +2099,7 @@ Vec4<T>::operator / (T a) const
 }
 
 template <class T>
-constexpr T
+IMATH_CONSTEXPR14 T
 Vec4<T>::lengthTiny () const
 {
     T absX = (x >= T (0))? x: -x;
@@ -2120,7 +2137,7 @@ Vec4<T>::lengthTiny () const
 }
 
 template <class T>
-constexpr inline T
+IMATH_CONSTEXPR14 inline T
 Vec4<T>::length () const
 {
     T length2 = dot (*this);
@@ -2139,7 +2156,7 @@ Vec4<T>::length2 () const
 }
 
 template <class T>
-constexpr const Vec4<T> &
+IMATH_CONSTEXPR14 const Vec4<T> &
 Vec4<T>::normalize ()
 {
     T l = length();
@@ -2162,7 +2179,7 @@ Vec4<T>::normalize ()
 }
 
 template <class T>
-constexpr const Vec4<T> &
+IMATH_CONSTEXPR14 const Vec4<T> &
 Vec4<T>::normalizeExc ()
 {
     T l = length();
@@ -2178,7 +2195,7 @@ Vec4<T>::normalizeExc ()
 }
 
 template <class T>
-constexpr inline
+IMATH_CONSTEXPR14 inline
 const Vec4<T> &
 Vec4<T>::normalizeNonNull ()
 {
@@ -2191,7 +2208,7 @@ Vec4<T>::normalizeNonNull ()
 }
 
 template <class T>
-constexpr Vec4<T>
+IMATH_CONSTEXPR14 Vec4<T>
 Vec4<T>::normalized () const
 {
     T l = length();
@@ -2203,7 +2220,7 @@ Vec4<T>::normalized () const
 }
 
 template <class T>
-constexpr Vec4<T>
+IMATH_CONSTEXPR14 Vec4<T>
 Vec4<T>::normalizedExc () const
 {
     T l = length();
@@ -2216,7 +2233,7 @@ Vec4<T>::normalizedExc () const
 
 template <class T>
 inline
-constexpr Vec4<T>
+IMATH_CONSTEXPR14 Vec4<T>
 Vec4<T>::normalizedNonNull () const
 {
     T l = length();

--- a/Imath/ImathVecAlgo.h
+++ b/Imath/ImathVecAlgo.h
@@ -58,7 +58,8 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 // Find the projection of vector t onto vector s (Vec2, Vec3, Vec4)
 //-----------------------------------------------------------------
 
-template <class Vec> constexpr Vec        project (const Vec &s, const Vec &t);
+template <class Vec>
+IMATH_CONSTEXPR14 Vec                     project (const Vec &s, const Vec &t);
 
 
 //------------------------------------------------
@@ -82,7 +83,8 @@ template <class Vec> constexpr Vec        reflect (const Vec &s, const Vec &t);
 // (Vec2, Vec3, Vec4)
 //--------------------------------------------------------------------
 
-template <class Vec> constexpr Vec        closestVertex (const Vec &v0,
+template <class Vec>
+IMATH_CONSTEXPR14 Vec                     closestVertex (const Vec &v0,
                                                          const Vec &v1,
                                                          const Vec &v2, 
                                                          const Vec &p);
@@ -92,7 +94,7 @@ template <class Vec> constexpr Vec        closestVertex (const Vec &v0,
 //---------------
 
 template <class Vec>
-constexpr Vec
+IMATH_CONSTEXPR14 Vec
 project (const Vec &s, const Vec &t)
 {
     Vec sNormalized = s.normalized();
@@ -114,7 +116,7 @@ reflect (const Vec &s, const Vec &t)
 }
 
 template <class Vec>
-constexpr Vec
+IMATH_CONSTEXPR14 Vec
 closestVertex(const Vec &v0,
               const Vec &v1,
               const Vec &v2, 

--- a/config/ImathConfig.h.in
+++ b/config/ImathConfig.h.in
@@ -50,4 +50,13 @@
                              (uint32_t(IMATH_VERSION_MINOR) << 16) | \
                              (uint32_t(IMATH_VERSION_PATCH) <<  8))
 
+//
+// Constexpr C++14 conditional definition
+//
+#if(__cplusplus >= 201402L)
+  #define IMATH_CONSTEXPR14 constexpr
+#else
+  #define IMATH_CONSTEXPR14 /* can not be constexpr before c++14 */
+#endif
+
 #endif // INCLUDED_IMATH_CONFIG_H


### PR DESCRIPTION
Changes were alluded to in a previous pull request. Getting this through early is beneficial as changes needed for CUDA integration will have a lot of conflicts with this PR if not done on top of them.

Previously, compilation with C++11 was not possible because of limited utility of constexpr. IMATH_CONSTEXPR14 is now used primarily on methods which are not return statements. It is defined under the condition that the compiler exceeds C++14, and is specified in config/ImathConfig.h.in