### PR TITLE
Simplest CUDA half type conflict resolution implementation.

### DIFF
--- a/Half/half.h
+++ b/Half/half.h
@@ -86,7 +86,10 @@
 #define _HALF_H_
 
 #include "halfExport.h"    // for definition of HALF_EXPORT
+#include "../Imath/ImathNamespace.h"
 #include <iostream>
+
+IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 class half
 {
@@ -223,25 +226,6 @@ class half
     HALF_EXPORT static const uif              _toFloat[1 << 16];
     HALF_EXPORT static const unsigned short   _eLut[1 << 9];
 };
-
-
-
-//-----------
-// Stream I/O
-//-----------
-
-HALF_EXPORT std::ostream &      operator << (std::ostream &os, half  h);
-HALF_EXPORT std::istream &      operator >> (std::istream &is, half &h);
-
-
-//----------
-// Debugging
-//----------
-
-HALF_EXPORT void        printBits   (std::ostream &os, half  h);
-HALF_EXPORT void        printBits   (std::ostream &os, float f);
-HALF_EXPORT void        printBits   (char  c[19], half  h);
-HALF_EXPORT void        printBits   (char  c[35], float f);
 
 
 //-------------------------------------------------------------------------
@@ -745,5 +729,33 @@ half::setBits (unsigned short bits)
 {
     _h = bits;
 }
+
+
+IMATH_INTERNAL_NAMESPACE_HEADER_EXIT
+
+
+//-----------
+// Stream I/O
+//-----------
+
+HALF_EXPORT std::ostream &      operator << (std::ostream &os, IMATH_INTERNAL_NAMESPACE::half  h);
+HALF_EXPORT std::istream &      operator >> (std::istream &is, IMATH_INTERNAL_NAMESPACE::half &h);
+
+//----------
+// Debugging
+//----------
+
+HALF_EXPORT void        printBits   (std::ostream &os, IMATH_INTERNAL_NAMESPACE::half  h);
+HALF_EXPORT void        printBits   (std::ostream &os, float f);
+HALF_EXPORT void        printBits   (char  c[19], IMATH_INTERNAL_NAMESPACE::half  h);
+HALF_EXPORT void        printBits   (char  c[35], float f);
+
+
+#ifndef __CUDACC__
+    using half = IMATH_INTERNAL_NAMESPACE::half;
+    #else
+    #include <cuda_fp16.h>
+#endif
+
 
 #endif


### PR DESCRIPTION
This implementation will simply place half into a namespace if compiling for the cuda kernel to prevent conflicts with the identically named cuda half type. 

Note: A few definitions needed to be moved around to avoid placing functions within the namespace and breaking existing testing. (operator <<, >>, and printBits)

Issues moving forward:

1: Testing of the cuda::half type's behaviour can be added, however the cuda half type is more picky about comparison and type conversion. For instance:
> half h1;
> ...
> assert (h1 == 1); 

Will produce compiler errors if written with the cuda half (but not for imath::half). It must instead be written this way:

> half h1;
> ...
> assert(float(h1) == 1);

2: The cuda half type also can not be created on __host__ code and therefore printing using cout will not be trivial. Most tests use this heavily.

The bottom line: making the cuda::half behave just as the imath::half type requires considerable reworking and does not seem to be fully attainable for many reasons. 
Certainly testing can be done it will just not be the same as the testing already implemented under HalfTest/