### PR TITLE
Added CI testing and made necessary changes to pass those tests.

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+#
+# GitHub Actions workflow file
+# https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
+
+name: Analysis
+
+on:
+  schedule:
+    # Weekly Sunday build
+    - cron: "0 0 * * 0"
+
+jobs:
+
+  # ---------------------------------------------------------------------------
+  # SonarCloud static analysis
+  # ---------------------------------------------------------------------------
+
+  linux_sonarcloud:
+    name: 'SonarCloud Linux CentOS 7 VFX CY2020 <GCC 6.3.1>'
+    # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
+    runs-on: ubuntu-latest
+    container:
+      # DockerHub: https://hub.docker.com/u/aswf
+      # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
+      image: aswf/ci-openexr:2020
+    env:
+      CXX: g++
+      CC: gcc
+    steps:
+      # TODO: Remove this workaround following resolution of:
+      #       https://github.com/AcademySoftwareFoundation/aswf-docker/issues/43
+      - name: Setup container
+        run: sudo rm -rf /usr/local/lib64/cmake/glew
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - name: Create build directories
+        run: |
+          mkdir _install
+          mkdir _build
+      - name: Configure
+        run: |
+          cmake ../. \
+                -DCMAKE_INSTALL_PREFIX=../_install \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_CXX_STANDARD=11 \
+                -DCMAKE_CXX_FLAGS="-g -O0 -fprofile-arcs -ftest-coverage" \
+                -DCMAKE_CXX_OUTPUT_EXTENSION_REPLACE=ON \
+                -DCMAKE_EXE_LINKER_FLAGS="-lgcov" \
+                -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
+                -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} \                
+                -DPYTHON='ON'\
+                -DPYTHON_EXECUTABLE=$(which python)
+        working-directory: _build
+      - name: Build OpenEXR with build-wrapper
+        shell: bash
+        run: |
+          export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PWD}/Half:${PWD}/Imath
+          echo ${PWD}
+          echo ${LD_LIBRARY_PATH}
+          build-wrapper-linux-x86-64 --out-dir bw_output make clean all
+        working-directory: _build
+      - name: Test
+        run: |
+          ctest -T Test \
+                -C Release \
+                -E python.*_Python2 \
+                --timeout 7200 \
+                --output-on-failure \
+                -VV
+        working-directory: _build
+      - name: Generate code coverage report
+        run: share/ci/scripts/linux/run_gcov.sh
+        shell: bash
+      - name: Run sonar-scanner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: sonar-scanner -X -Dsonar.login=$SONAR_TOKEN
+
+  # ------------------------------------------------------------------------------
+  #  Valgrind memcheck test
+  # ------------------------------------------------------------------------------
+  linux_valgrind:
+    name: 'Valgrind Linux CentOS 7 VFX CY2020 <GCC 6.3.1>'
+    # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
+    runs-on: ubuntu-latest
+    container:
+      # DockerHub: https://hub.docker.com/u/aswf
+      # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
+      image: aswf/ci-openexr:2020
+    env:
+      CXX: g++
+      CC: gcc
+    steps:
+      # TODO: Remove this workaround following resolution of:
+      #       https://github.com/AcademySoftwareFoundation/aswf-docker/issues/43
+      - name: Setup container
+        run: sudo rm -rf /usr/local/lib64/cmake/glew
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - name: Create build directories
+        run: |
+          mkdir _install
+          mkdir _build
+        shell: bash
+      - name: Install Dependencies
+        run: |
+          share/ci/scripts/linux/install_valgrind.sh 
+        shell: bash
+      - name: Configure
+        run: |
+          cmake ../. \
+                -DCMAKE_INSTALL_PREFIX=../_install \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_CXX_STANDARD=14 \
+                -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
+                -DBUILD_SHARED_LIBS='ON' \
+                -DOPENEXR_BUILD_UTILS='ON' \
+                -DOPENEXR_RUN_FUZZ_TESTS='OFF' \
+                -DPYTHON='ON'\
+                -DPYTHON_EXECUTABLE=$(which python) 
+        working-directory: _build
+      - name: Build
+        run: |
+          cmake --build . \
+                --target install \
+                --config Release \
+                -- -j2
+        working-directory: _build
+      - name: Valgrind memcheck tests
+        run: |
+          ctest -C Release \
+                -E python.*_Python2 \
+                --timeout 50000 \
+                --force-new-ctest-process \
+                --test-action memcheck \
+                --output-on-failure \
+                -VV
+        working-directory: _build
+      - name: Valgrind memcheck test results
+        run: |
+          share/ci/scripts/linux/log_valgrind.sh _build
+        shell: bash
+
+  # ------------------------------------------------------------------------------
+  #  Fuzz test
+  # ------------------------------------------------------------------------------
+  linux_fuzz:
+    name: 'Fuzz Test Linux CentOS 7 VFX CY2020 <GCC 6.3.1>'
+    # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
+    runs-on: ubuntu-latest
+    container:
+      # DockerHub: https://hub.docker.com/u/aswf
+      # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
+      image: aswf/ci-openexr:2020
+    env:
+      CXX: g++
+      CC: gcc
+    steps:
+      # TODO: Remove this workaround following resolution of:
+      #       https://github.com/AcademySoftwareFoundation/aswf-docker/issues/43
+      - name: Setup container
+        run: sudo rm -rf /usr/local/lib64/cmake/glew
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - name: Create build directories
+        run: |
+          mkdir _install
+          mkdir _build
+        shell: bash
+      - name: Configure
+        run: |
+          cmake ../. \
+                -DCMAKE_INSTALL_PREFIX=../_install \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_CXX_STANDARD=14 \
+                -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
+                -DBUILD_SHARED_LIBS='ON' \
+                -DPYTHON='ON'\
+                -DPYTHON_EXECUTABLE=$(which python) 
+        working-directory: _build
+      - name: Build
+        run: |
+          cmake --build . \
+                --target install \
+                --config Release \
+                -- -j2
+        working-directory: _build
+

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -58,7 +58,7 @@ jobs:
             cc-compiler: gcc
             compiler-desc: GCC 6.3.1
             vfx-cy: 2020
-            exclude-tests: -E *_Python2
+            exclude-tests: -E PyImath.*_Python2
           # Debug
           - build: 2
             build-type: Debug
@@ -68,7 +68,7 @@ jobs:
             cc-compiler: gcc
             compiler-desc: GCC 6.3.1
             vfx-cy: 2020
-            exclude-tests: -E *_Python2
+            exclude-tests: -E PyImath.*_Python2
           # C++14
           - build: 3
             build-type: Release
@@ -78,7 +78,7 @@ jobs:
             cc-compiler: gcc
             compiler-desc: GCC 6.3.1
             vfx-cy: 2020
-            exclude-tests: -E *_Python2
+            exclude-tests: -E PyImath.*_Python2
           # Static
           - build: 4
             build-type: Release
@@ -88,7 +88,7 @@ jobs:
             cc-compiler: gcc
             compiler-desc: GCC 6.3.1
             vfx-cy: 2020
-            exclude-tests: -E *_Python2
+            exclude-tests: -E PyImath.*_Python2
           # -------------------------------------------------------------------
           # GCC, VFX CY2019
           # -------------------------------------------------------------------
@@ -114,7 +114,7 @@ jobs:
             cc-compiler: clang
             compiler-desc: Clang 7
             vfx-cy: 2020
-            exclude-tests: -E *_Python2
+            exclude-tests: -E PyImath.*_Python2
           # Debug
           - build: 7
             build-type: Debug
@@ -124,7 +124,7 @@ jobs:
             cc-compiler: clang
             compiler-desc: Clang 7
             vfx-cy: 2020
-            exclude-tests: -E *_Python2
+            exclude-tests: -E PyImath.*_Python2
           # C++14
           - build: 8
             build-type: Release
@@ -134,7 +134,7 @@ jobs:
             cc-compiler: clang
             compiler-desc: Clang 7
             vfx-cy: 2020
-            exclude-tests: -E *_Python2
+            exclude-tests: -E PyImath.*_Python2
           # Static
           - build: 9
             build-type: Release
@@ -144,7 +144,7 @@ jobs:
             cc-compiler: clang
             compiler-desc: Clang 7
             vfx-cy: 2020
-            exclude-tests: -E *_Python2
+            exclude-tests: -E PyImath.*_Python2
           # -------------------------------------------------------------------
           # Clang, VFX CY2019
           # -------------------------------------------------------------------
@@ -220,7 +220,7 @@ jobs:
             build-docs: 'ON'
             cxx-standard: 11
             python-version: 3.7
-            exclude-tests: -E *_Python3
+            exclude-tests: -E PyImath.*_Python3
           # Debug
           - build: 2
             build-type: Debug
@@ -228,7 +228,7 @@ jobs:
             build-docs: 'OFF'
             cxx-standard: 11
             python-version: 3.7
-            exclude-tests: -E *_Python3
+            exclude-tests: -E PyImath.*_Python3
           # C++14
           - build: 3
             build-type: Release
@@ -236,7 +236,7 @@ jobs:
             build-docs: 'OFF'
             cxx-standard: 14
             python-version: 3.7
-            exclude-tests: -E *_Python3
+            exclude-tests: -E PyImath.*_Python3
           # Static
           - build: 4
             build-type: Release
@@ -244,7 +244,7 @@ jobs:
             build-docs: 'OFF'
             cxx-standard: 11
             python-version: 3.7
-            exclude-tests: -E "*_Python3|PyImathTest_Python2"
+            exclude-tests: -E "PyImath.*_Python3|PyImath.PyImathTest_Python2"
           # Python 2.7
           - build: 5
             build-type: Release
@@ -252,7 +252,7 @@ jobs:
             build-docs: 'ON'
             cxx-standard: 11
             python-version: 2.7
-            exclude-tests: -E *_Python3
+            exclude-tests: -E PyImath.*_Python3
     steps:
       - name: Setup Python
         uses: actions/setup-python@v1

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -1,0 +1,420 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+#
+# GitHub Actions workflow file
+# https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
+
+name: CI
+
+on:
+  push:
+    # Jobs are skipped when ONLY Markdown (*.md) files are changed
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  # Linux jobs run in Docker containers, so the latest OS version is OK. macOS 
+  # and Windows jobs need to be locked to specific virtual environment 
+  # versions to mitigate issues from OS updates, and will require maintenance 
+  # as OS versions are retired.
+  #
+  # GH Actions (Free plan) supports 20 concurrent jobs, with 5 concurrent macOS 
+  # jobs. This workflow tries to utilize (but not exceed) that budget to 
+  # promote timely CI.
+
+  # ---------------------------------------------------------------------------
+  # Linux
+  # ---------------------------------------------------------------------------
+  # TODO: Add ARM build. Add sanitize build.
+
+  linux:
+    name: 'Linux CentOS 7 VFX CY${{ matrix.vfx-cy }} 
+      <${{ matrix.compiler-desc }} 
+       config=${{ matrix.build-type }}, 
+       shared=${{ matrix.build-shared }}, 
+       cxx=${{ matrix.cxx-standard }}>'
+    # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
+    runs-on: ubuntu-latest
+    container:
+      # DockerHub: https://hub.docker.com/u/aswf
+      # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
+      image: aswf/ci-openexr:${{ matrix.vfx-cy }}
+    strategy:
+      matrix:
+        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        include:
+          # -------------------------------------------------------------------
+          # GCC, VFX CY2020
+          # -------------------------------------------------------------------
+          # C++11, Python 3.7
+          - build: 1
+            build-type: Release
+            build-shared: 'ON'
+            cxx-standard: 11
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: GCC 6.3.1
+            vfx-cy: 2020
+            exclude-tests: -E python.*_Python2
+          # Debug
+          - build: 2
+            build-type: Debug
+            build-shared: 'ON'
+            cxx-standard: 11
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: GCC 6.3.1
+            vfx-cy: 2020
+            exclude-tests: -E python.*_Python2
+          # C++14
+          - build: 3
+            build-type: Release
+            build-shared: 'ON'
+            cxx-standard: 14
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: GCC 6.3.1
+            vfx-cy: 2020
+            exclude-tests: -E python.*_Python2
+          # Static
+          - build: 4
+            build-type: Release
+            build-shared: 'OFF'
+            cxx-standard: 11
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: GCC 6.3.1
+            vfx-cy: 2020
+            exclude-tests: -E python.*_Python2
+          # -------------------------------------------------------------------
+          # GCC, VFX CY2019
+          # -------------------------------------------------------------------
+          # Python 2.7
+          - build: 5
+            build-type: Release
+            build-shared: 'ON'
+            cxx-standard: 11
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: GCC 6.3.1
+            vfx-cy: 2019
+            exclude-tests: 
+          # -------------------------------------------------------------------
+          # Clang, VFX CY2020
+          # -------------------------------------------------------------------
+          # C++11, Python 3.7
+          - build: 6
+            build-type: Release
+            build-shared: 'ON'
+            cxx-standard: 11
+            cxx-compiler: clang++
+            cc-compiler: clang
+            compiler-desc: Clang 7
+            vfx-cy: 2020
+            exclude-tests: -E python.*_Python2
+          # Debug
+          - build: 7
+            build-type: Debug
+            build-shared: 'ON'
+            cxx-standard: 11
+            cxx-compiler: clang++
+            cc-compiler: clang
+            compiler-desc: Clang 7
+            vfx-cy: 2020
+            exclude-tests: -E python.*_Python2
+          # C++14
+          - build: 8
+            build-type: Release
+            build-shared: 'ON'
+            cxx-standard: 14
+            cxx-compiler: clang++
+            cc-compiler: clang
+            compiler-desc: Clang 7
+            vfx-cy: 2020
+            exclude-tests: -E python.*_Python2
+          # Static
+          - build: 9
+            build-type: Release
+            build-shared: 'OFF'
+            cxx-standard: 11
+            cxx-compiler: clang++
+            cc-compiler: clang
+            compiler-desc: Clang 7
+            vfx-cy: 2020
+            exclude-tests: -E python.*_Python2
+          # -------------------------------------------------------------------
+          # Clang, VFX CY2019
+          # -------------------------------------------------------------------
+          # Python 2.7
+          - build: 10
+            build-type: Release
+            build-shared: 'ON'
+            cxx-standard: 11
+            cxx-compiler: clang++
+            cc-compiler: clang
+            compiler-desc: Clang 7
+            vfx-cy: 2019
+            exclude-tests:
+    env:
+      CXX: ${{ matrix.cxx-compiler }}
+      CC: ${{ matrix.cc-compiler }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Create build directories
+        run: |
+          mkdir _install
+          mkdir _build
+      - name: Configure
+        run: |
+          cmake ../. \
+                -DCMAKE_INSTALL_PREFIX=../_install \
+                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+                -DCMAKE_CXX_STANDARD=${{ matrix.cxx-standard }} \
+                -DCMAKE_CXX_FLAGS=${{ matrix.cxx-flags }} \
+                -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
+                -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} \
+                -DPYTHON='ON'\
+                -DPYTHON_EXECUTABLE=$(which python) 
+        working-directory: _build
+      - name: Build
+        run: |
+          cmake --build . \
+                --target install \
+                --config ${{ matrix.build-type }} \
+                -- -j4
+        working-directory: _build
+      - name: Test
+        run: |
+          ctest -T Test ${{ matrix.exclude-tests }} \
+                -C ${{ matrix.build-type }} \
+                --timeout 7200 \
+                --output-on-failure \
+                -VV
+        working-directory: _build
+
+  # ---------------------------------------------------------------------------
+  # macOS
+  # ---------------------------------------------------------------------------
+  
+  macos:
+    name: 'macOS 10.15 
+      <AppleClang 11.0 
+       config=${{ matrix.build-type }}, 
+       shared=${{ matrix.build-shared }}, 
+       cxx=${{ matrix.cxx-standard }}, 
+       python=${{ matrix.python-version }}, 
+       docs=${{ matrix.build-docs }}>'
+    runs-on: macos-10.15
+    strategy:
+      matrix:
+        build: [1, 2, 3, 4, 5]
+        include:
+          # C++11, Python 3.7
+          - build: 1
+            build-type: Release
+            build-shared: 'ON'
+            build-docs: 'ON'
+            cxx-standard: 11
+            python-version: 3.7
+            exclude-tests: -E python.*_Python3
+          # Debug
+          - build: 2
+            build-type: Debug
+            build-shared: 'ON'
+            build-docs: 'OFF'
+            cxx-standard: 11
+            python-version: 3.7
+            exclude-tests: -E python.*_Python3
+          # C++14
+          - build: 3
+            build-type: Release
+            build-shared: 'ON'
+            build-docs: 'OFF'
+            cxx-standard: 14
+            python-version: 3.7
+            exclude-tests: -E python.*_Python3
+          # Static
+          - build: 4
+            build-type: Release
+            build-shared: 'OFF'
+            build-docs: 'OFF'
+            cxx-standard: 11
+            python-version: 3.7
+            exclude-tests: -E "python.*_Python3|python.PyImathTest_Python2"
+          # Python 2.7
+          - build: 5
+            build-type: Release
+            build-shared: 'ON'
+            build-docs: 'ON'
+            cxx-standard: 11
+            python-version: 2.7
+            exclude-tests: -E python.*_Python3
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Create build directories
+        run: |
+          mkdir _install
+          mkdir _build
+      - name: Install Dependences
+        run: |
+          share/ci/scripts/macos/install_boost.sh 
+        shell: bash
+      - name: Configure
+        run: |
+          cmake ../. \
+                -DCMAKE_INSTALL_PREFIX=../_install \
+                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+                -DCMAKE_CXX_STANDARD=${{ matrix.cxx-standard }} \
+                -DCMAKE_CXX_FLAGS=${{ matrix.cxx-flags }} \
+                -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
+                -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} \
+                -DPYTHON='ON'\
+                -DPYTHON_EXECUTABLE=$(which python) \
+                -DBoost_NO_BOOST_CMAKE=ON
+        working-directory: _build
+      - name: Build
+        run: |
+          cmake --build . \
+                --target install \
+                --config ${{ matrix.build-type }} \
+                -- -j2
+        working-directory: _build
+      - name: Test
+        run: |
+          ctest -T Test ${{matrix.exclude-tests }} \
+                -C ${{matrix.build-type}} \
+                --timeout 7200 \
+                --output-on-failure \
+                -VV
+        working-directory: _build
+
+  # ---------------------------------------------------------------------------
+  # Windows
+  # ---------------------------------------------------------------------------
+  # TODO: Figure out how to get CMake to use Python 3.7.7.
+  #       Boost 1.70.0 will only make boost python for 3.7.
+  #       CMake finds Python 3.8 on the VM when configuring, then does not find 
+  #       a corresponding boost python38 module. As a result PyIlmbase tests are not 
+  #       built or run.
+  # TODO: Determine why tests hang in Debug job.
+  # TODO: Fix boost script to install from sourceforge.
+
+  # windows:
+    # name: 'Windows 2019 
+      # <MSVC 16.4 
+       # config=${{ matrix.build-type }}, 
+       # shared=${{ matrix.build-shared }}, 
+       # cxx=${{ matrix.cxx-standard }}, 
+       # python=${{ matrix.python-version }}, 
+       # docs=${{ matrix.build-docs }}>'
+    # runs-on: windows-2019
+    # strategy:
+      # matrix:
+        # build: [1, 3, 4]
+        # include:
+          # # C++11, Python 3.7
+          # - build: 1
+            # build-type: Release
+            # build-shared: 'ON'
+            # build-docs: 'ON'
+            # cxx-standard: 11
+            # python-version: 3.7.7
+            # boost-version: 1.70.0
+            # zlib-version: 1.2.11
+            # zlib-lib: zlib.lib
+            # exclude-tests: ''
+          # # Debug -
+          # # - build: 2
+            # # build-type: Debug
+            # # build-shared: 'ON'
+            # # build-docs: 'OFF'
+            # # cxx-standard: 11
+            # # python-version: 3.7.7
+            # # boost-version: 1.70.0
+            # # zlib-version: 1.2.11
+            # # zlib-lib: zlib.lib
+            # # exclude-tests: ''
+          # # C++14
+          # - build: 3
+            # build-type: Release
+            # build-shared: 'ON'
+            # build-docs: 'OFF'
+            # cxx-standard: 14
+            # python-version: 3.7.7
+            # boost-version: 1.70.0
+            # zlib-version: 1.2.11
+            # zlib-lib: zlib.lib
+            # exclude-tests: ''
+          # # Static
+          # - build: 4
+            # build-type: Release
+            # build-shared: 'OFF'
+            # build-docs: 'OFF'
+            # cxx-standard: 11
+            # python-version: 3.7.7
+            # boost-version: 1.70.0
+            # zlib-version: 1.2.11
+            # zlib-lib: zlibstatic.lib
+            # exclude-tests: ''
+ 
+    # steps:
+      # - name: Setup Python
+        # uses: actions/setup-python@v1
+        # with:
+          # python-version: ${{ matrix.python-version }}
+      # - name: Checkout
+        # uses: actions/checkout@v2
+      # - name: Create build directories
+        # run: |
+          # mkdir _install
+          # mkdir _build
+        # shell: bash
+      # - name: Install Dependences
+        # run: |
+          # share/ci/scripts/windows/install_python.ps1 ${{ matrix.python-version }} $HOME 
+          # share/ci/scripts/windows/install_boost.ps1 ${{ matrix.boost-version }} $HOME 3.8
+          # share/ci/scripts/windows/install_zlib.ps1 ${{ matrix.zlib-version }} $HOME 
+        # shell: powershell
+      # - name: Configure
+        # run: |
+          # cmake ../. \
+                # -DCMAKE_INSTALL_PREFIX=../_install \
+                # -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+                # -DCMAKE_CXX_STANDARD=${{ matrix.cxx-standard }} \
+                # -DCMAKE_CXX_FLAGS=${{ matrix.cxx-flags }} \
+                # -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
+                # -DBOOST_ROOT:FILEPATH=$BOOST_ROOT \
+                # -DZLIB_ROOT:FILEPATH="$ZLIB_ROOT" \
+                # -DZLIB_LIBRARY:FILEPATH="$ZLIB_ROOT/lib/${{ matrix.zlib-lib }}" \
+                # -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} \
+                # -DPYTHON='ON'\
+               # # -DPython_EXECUTABLE:FILEPATH="$PYTHON_ROOT" \
+               # # -DPython_INCLUDE_DIR:FILEPATH="$PYTHON_ROOT/include" \       
+               # # -DPython_LIBRARY:"$PYTHON_ROOT\libs" \
+        # shell: bash
+        # working-directory: _build
+      # - name: Build
+        # run: |
+          # cmake --build . \
+                # --target install \
+                # --config ${{ matrix.build-type }}
+        # shell: bash
+        # working-directory: _build
+      # - name: Test
+        # run: |
+          # ctest -T Test ${{ matrix.exclude-tests }} \
+                # -C ${{ matrix.build-type }} \
+                # --timeout 7200 \
+                # --output-on-failure \
+                # -VV
+        # shell: bash
+        # working-directory: _build

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -58,7 +58,7 @@ jobs:
             cc-compiler: gcc
             compiler-desc: GCC 6.3.1
             vfx-cy: 2020
-            exclude-tests: -E python.*_Python2
+            exclude-tests: -E *_Python2
           # Debug
           - build: 2
             build-type: Debug
@@ -68,7 +68,7 @@ jobs:
             cc-compiler: gcc
             compiler-desc: GCC 6.3.1
             vfx-cy: 2020
-            exclude-tests: -E python.*_Python2
+            exclude-tests: -E *_Python2
           # C++14
           - build: 3
             build-type: Release
@@ -78,7 +78,7 @@ jobs:
             cc-compiler: gcc
             compiler-desc: GCC 6.3.1
             vfx-cy: 2020
-            exclude-tests: -E python.*_Python2
+            exclude-tests: -E *_Python2
           # Static
           - build: 4
             build-type: Release
@@ -88,7 +88,7 @@ jobs:
             cc-compiler: gcc
             compiler-desc: GCC 6.3.1
             vfx-cy: 2020
-            exclude-tests: -E python.*_Python2
+            exclude-tests: -E *_Python2
           # -------------------------------------------------------------------
           # GCC, VFX CY2019
           # -------------------------------------------------------------------
@@ -114,7 +114,7 @@ jobs:
             cc-compiler: clang
             compiler-desc: Clang 7
             vfx-cy: 2020
-            exclude-tests: -E python.*_Python2
+            exclude-tests: -E *_Python2
           # Debug
           - build: 7
             build-type: Debug
@@ -124,7 +124,7 @@ jobs:
             cc-compiler: clang
             compiler-desc: Clang 7
             vfx-cy: 2020
-            exclude-tests: -E python.*_Python2
+            exclude-tests: -E *_Python2
           # C++14
           - build: 8
             build-type: Release
@@ -134,7 +134,7 @@ jobs:
             cc-compiler: clang
             compiler-desc: Clang 7
             vfx-cy: 2020
-            exclude-tests: -E python.*_Python2
+            exclude-tests: -E *_Python2
           # Static
           - build: 9
             build-type: Release
@@ -144,7 +144,7 @@ jobs:
             cc-compiler: clang
             compiler-desc: Clang 7
             vfx-cy: 2020
-            exclude-tests: -E python.*_Python2
+            exclude-tests: -E *_Python2
           # -------------------------------------------------------------------
           # Clang, VFX CY2019
           # -------------------------------------------------------------------
@@ -220,7 +220,7 @@ jobs:
             build-docs: 'ON'
             cxx-standard: 11
             python-version: 3.7
-            exclude-tests: -E python.*_Python3
+            exclude-tests: -E *_Python3
           # Debug
           - build: 2
             build-type: Debug
@@ -228,7 +228,7 @@ jobs:
             build-docs: 'OFF'
             cxx-standard: 11
             python-version: 3.7
-            exclude-tests: -E python.*_Python3
+            exclude-tests: -E *_Python3
           # C++14
           - build: 3
             build-type: Release
@@ -236,7 +236,7 @@ jobs:
             build-docs: 'OFF'
             cxx-standard: 14
             python-version: 3.7
-            exclude-tests: -E python.*_Python3
+            exclude-tests: -E *_Python3
           # Static
           - build: 4
             build-type: Release
@@ -244,7 +244,7 @@ jobs:
             build-docs: 'OFF'
             cxx-standard: 11
             python-version: 3.7
-            exclude-tests: -E "python.*_Python3|python.PyImathTest_Python2"
+            exclude-tests: -E "*_Python3|PyImathTest_Python2"
           # Python 2.7
           - build: 5
             build-type: Release
@@ -252,7 +252,7 @@ jobs:
             build-docs: 'ON'
             cxx-standard: 11
             python-version: 2.7
-            exclude-tests: -E python.*_Python3
+            exclude-tests: -E *_Python3
     steps:
       - name: Setup Python
         uses: actions/setup-python@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+_build/
+_install/

--- a/Imath/CMakeLists.txt
+++ b/Imath/CMakeLists.txt
@@ -44,6 +44,6 @@ imath_define_library(Imath
     ImathVecAlgo.h
     ImathVec.h
   DEPENDENCIES
-    Half IexMath
+    Half
     )
   

--- a/Imath/ImathBox.h
+++ b/Imath/ImathBox.h
@@ -108,21 +108,26 @@ class Box
     //	Query functions - these compute results each time
     //---------------------------------------------------
 
-    constexpr T 	size () const;
-    constexpr T		center () const;
-    constexpr bool	intersects (const T &point) const;
-    constexpr bool	intersects (const Box<T> &box) const;
+    IMATH_CONSTEXPR14 T size () const;
+    constexpr T	        center () const;
+    IMATH_CONSTEXPR14
+    bool	        intersects (const T &point) const;
+    IMATH_CONSTEXPR14
+    bool	        intersects (const Box<T> &box) const;
 
-    constexpr
+    IMATH_CONSTEXPR14
     unsigned int	majorAxis () const;
 
     //----------------
     //	Classification
     //----------------
 
-    constexpr bool	isEmpty () const;
-    constexpr bool	hasVolume () const;
-    constexpr bool	isInfinite () const;
+    IMATH_CONSTEXPR14
+    bool	        isEmpty () const;
+    IMATH_CONSTEXPR14
+    bool	        hasVolume () const;
+    IMATH_CONSTEXPR14
+    bool	        isInfinite () const;
 };
 
 
@@ -229,7 +234,7 @@ Box<T>::extendBy(const Box<T> &box)
 
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<T>::intersects(const T &point) const
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
@@ -243,7 +248,7 @@ Box<T>::intersects(const T &point) const
 
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<T>::intersects(const Box<T> &box) const
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
@@ -257,7 +262,7 @@ Box<T>::intersects(const Box<T> &box) const
 
 
 template <class T> 
-constexpr inline T
+IMATH_CONSTEXPR14 inline T
 Box<T>::size() const 
 { 
     if (isEmpty())
@@ -276,7 +281,7 @@ Box<T>::center() const
 
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<T>::isEmpty() const
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
@@ -289,7 +294,7 @@ Box<T>::isEmpty() const
 }
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<T>::isInfinite() const
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
@@ -303,7 +308,7 @@ Box<T>::isInfinite() const
 
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<T>::hasVolume() const
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
@@ -317,7 +322,7 @@ Box<T>::hasVolume() const
 
 
 template<class T>
-constexpr inline unsigned int
+IMATH_CONSTEXPR14 inline unsigned int
 Box<T>::majorAxis() const
 {
     unsigned int major = 0;
@@ -380,21 +385,27 @@ class Box<Vec2<T> >
     //  Query functions - these compute results each time
     //---------------------------------------------------
 
-    constexpr Vec2<T>	size() const;
+    IMATH_CONSTEXPR14
+    Vec2<T>	        size() const;
     constexpr Vec2<T>	center() const;
-    constexpr bool	intersects (const Vec2<T> &point) const;
-    constexpr bool	intersects (const Box<Vec2<T> > &box) const;
+    IMATH_CONSTEXPR14
+    bool	        intersects (const Vec2<T> &point) const;
+    IMATH_CONSTEXPR14
+    bool	        intersects (const Box<Vec2<T> > &box) const;
 
-    constexpr
+    IMATH_CONSTEXPR14
     unsigned int	majorAxis() const;
 
     //----------------
     //  Classification
     //----------------
 
-    constexpr bool	isEmpty() const;
-    constexpr bool	hasVolume() const;
-    constexpr bool	isInfinite() const;
+    IMATH_CONSTEXPR14
+    bool	        isEmpty() const;
+    IMATH_CONSTEXPR14
+    bool	        hasVolume() const;
+    IMATH_CONSTEXPR14
+    bool 	        isInfinite() const;
 };
 
 
@@ -492,7 +503,7 @@ Box<Vec2<T> >::extendBy (const Box<Vec2<T> > &box)
 
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T> >::intersects (const Vec2<T> &point) const
 {
     if (point[0] < min[0] || point[0] > max[0] ||
@@ -504,7 +515,7 @@ Box<Vec2<T> >::intersects (const Vec2<T> &point) const
 
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T> >::intersects (const Box<Vec2<T> > &box) const
 {
     if (box.max[0] < min[0] || box.min[0] > max[0] ||
@@ -516,7 +527,7 @@ Box<Vec2<T> >::intersects (const Box<Vec2<T> > &box) const
 
 
 template <class T> 
-constexpr inline Vec2<T>
+IMATH_CONSTEXPR14 inline Vec2<T>
 Box<Vec2<T> >::size() const 
 { 
     if (isEmpty())
@@ -535,7 +546,7 @@ Box<Vec2<T> >::center() const
 
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T> >::isEmpty() const
 {
     if (max[0] < min[0] ||
@@ -546,7 +557,7 @@ Box<Vec2<T> >::isEmpty() const
 }
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T> > ::isInfinite() const
 {
     if (min[0] != limits<T>::min() || max[0] != limits<T>::max() ||
@@ -558,7 +569,7 @@ Box<Vec2<T> > ::isInfinite() const
 
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T> >::hasVolume() const
 {
     if (max[0] <= min[0] ||
@@ -570,7 +581,7 @@ Box<Vec2<T> >::hasVolume() const
 
 
 template <class T>
-constexpr inline unsigned int
+IMATH_CONSTEXPR14 inline unsigned int
 Box<Vec2<T> >::majorAxis() const
 {
     unsigned int major = 0;
@@ -623,21 +634,27 @@ class Box<Vec3<T> >
     //  Query functions - these compute results each time
     //---------------------------------------------------
 
-    constexpr Vec3<T>	size() const;
+    IMATH_CONSTEXPR14
+    Vec3<T>	        size() const;
     constexpr Vec3<T>	center() const;
-    constexpr bool	intersects (const Vec3<T> &point) const;
-    constexpr bool	intersects (const Box<Vec3<T> > &box) const;
+    IMATH_CONSTEXPR14
+    bool	        intersects (const Vec3<T> &point) const;
+    IMATH_CONSTEXPR14
+    bool	        intersects (const Box<Vec3<T> > &box) const;
 
-    constexpr
+    IMATH_CONSTEXPR14
     unsigned int	majorAxis() const;
 
     //----------------
     //  Classification
     //----------------
 
-    constexpr bool	isEmpty() const;
-    constexpr bool	hasVolume() const;
-    constexpr bool	isInfinite() const;
+    IMATH_CONSTEXPR14
+    bool	        isEmpty() const;
+    IMATH_CONSTEXPR14
+    bool	        hasVolume() const;
+    IMATH_CONSTEXPR14
+    bool	        isInfinite() const;
 };
 
 
@@ -748,7 +765,7 @@ Box<Vec3<T> >::extendBy (const Box<Vec3<T> > &box)
 
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T> >::intersects (const Vec3<T> &point) const
 {
     if (point[0] < min[0] || point[0] > max[0] ||
@@ -761,7 +778,7 @@ Box<Vec3<T> >::intersects (const Vec3<T> &point) const
 
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T> >::intersects (const Box<Vec3<T> > &box) const
 {
     if (box.max[0] < min[0] || box.min[0] > max[0] ||
@@ -774,7 +791,7 @@ Box<Vec3<T> >::intersects (const Box<Vec3<T> > &box) const
 
 
 template <class T> 
-constexpr inline Vec3<T>
+IMATH_CONSTEXPR14 inline Vec3<T>
 Box<Vec3<T> >::size() const 
 { 
     if (isEmpty())
@@ -793,7 +810,7 @@ Box<Vec3<T> >::center() const
 
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T> >::isEmpty() const
 {
     if (max[0] < min[0] ||
@@ -805,7 +822,7 @@ Box<Vec3<T> >::isEmpty() const
 }
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T> >::isInfinite() const
 {
     if (min[0] != limits<T>::min() || max[0] != limits<T>::max() ||
@@ -818,7 +835,7 @@ Box<Vec3<T> >::isInfinite() const
 
 
 template <class T>
-constexpr inline bool
+IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T> >::hasVolume() const
 {
     if (max[0] <= min[0] ||
@@ -831,7 +848,7 @@ Box<Vec3<T> >::hasVolume() const
 
 
 template <class T>
-constexpr inline unsigned int
+IMATH_CONSTEXPR14 inline unsigned int
 Box<Vec3<T> >::majorAxis() const
 {
     unsigned int major = 0;

--- a/Imath/ImathBoxAlgo.h
+++ b/Imath/ImathBoxAlgo.h
@@ -161,7 +161,7 @@ closestPointOnBox (const Vec3<T> &p, const Box< Vec3<T> > &box)
 
 
 template <class S, class T>
-IMATH_CONSTEXPR14 Box< Vec3<S> >
+Box< Vec3<S> >
 transform (const Box< Vec3<S> > &box, const Matrix44<T> &m)
 {
     //
@@ -324,7 +324,7 @@ transform (const Box< Vec3<S> > &box,
 
 
 template <class S, class T>
-IMATH_CONSTEXPR14 Box< Vec3<S> >
+Box< Vec3<S> >
 affineTransform (const Box< Vec3<S> > &box, const Matrix44<T> &m)
 {
     //

--- a/Imath/ImathColorAlgo.h
+++ b/Imath/ImathColorAlgo.h
@@ -92,7 +92,7 @@ hsv2rgb(const Vec3<T> &hsv)
 
 
 template<class T> 
-constexpr Color4<T>  
+IMATH_CONSTEXPR14 Color4<T>  
 hsv2rgb(const Color4<T> &hsv)
 {
     if ( limits<T>::isIntegral() )

--- a/Imath/ImathEuler.h
+++ b/Imath/ImathEuler.h
@@ -278,13 +278,10 @@ class Euler : public Vec3<T>
     void		extract(const Matrix33<T>&);
     void		extract(const Matrix44<T>&);
     void		extract(const Quat<T>&);
-
-    constexpr
     Matrix33<T>		toMatrix33() const;
-    constexpr
     Matrix44<T>		toMatrix44() const;
-    constexpr Quat<T>	toQuat() const;
-    constexpr Vec3<T>	toXYZVector() const;
+    Quat<T>	        toQuat() const;
+    Vec3<T>	        toXYZVector() const;
 
     //---------------------------------------------------
     //	Use this function to unpack angles from ijk form
@@ -398,7 +395,7 @@ Euler<T>::setXYZVector(const Vec3<T> &v)
 }
 
 template<class T>
-constexpr inline Vec3<T>
+inline Vec3<T>
 Euler<T>::toXYZVector() const
 {
     int i,j,k;
@@ -640,7 +637,7 @@ void Euler<T>::extract(const Matrix44<T> &M)
 }
 
 template<class T>
-constexpr Matrix33<T> Euler<T>::toMatrix33() const
+Matrix33<T> Euler<T>::toMatrix33() const
 {
     int i,j,k;
     angleOrder(i,j,k);
@@ -683,7 +680,7 @@ constexpr Matrix33<T> Euler<T>::toMatrix33() const
 }
 
 template<class T>
-constexpr Matrix44<T> Euler<T>::toMatrix44() const
+Matrix44<T> Euler<T>::toMatrix44() const
 {
     int i,j,k;
     angleOrder(i,j,k);
@@ -726,7 +723,7 @@ constexpr Matrix44<T> Euler<T>::toMatrix44() const
 }
 
 template<class T>
-constexpr Quat<T> Euler<T>::toQuat() const
+Quat<T> Euler<T>::toQuat() const
 {
     Vec3<T> angles;
     int i,j,k;

--- a/Imath/ImathFrustum.h
+++ b/Imath/ImathFrustum.h
@@ -137,8 +137,8 @@ class Frustum
 
     constexpr T         fovx() const;
     constexpr T         fovy() const;
-    constexpr T         aspect() const;
-    constexpr
+    IMATH_CONSTEXPR14 T aspect() const;
+    IMATH_CONSTEXPR14
     Matrix44<T>         projectionMatrix() const;
     constexpr bool      degenerate() const;
 
@@ -149,27 +149,32 @@ class Frustum
     //  space.  
     //-----------------------------------------------------------------------
 
-    constexpr Frustum<T> window(T left, T right, T top, T bottom) const;
+    IMATH_CONSTEXPR14
+    Frustum<T>          window(T left, T right, T top, T bottom) const;
 
     //----------------------------------------------------------
     // Projection is in screen space / Conversion from Z-Buffer
     //----------------------------------------------------------
 
-    constexpr Line3<T>  projectScreenToRay( const Vec2<T> & ) const;
-    constexpr Vec2<T>   projectPointToScreen( const Vec3<T> & ) const;
+    IMATH_CONSTEXPR14
+    Line3<T>            projectScreenToRay( const Vec2<T> & ) const;
+    IMATH_CONSTEXPR14
+    Vec2<T>             projectPointToScreen( const Vec3<T> & ) const;
 
-    constexpr T         ZToDepth(long zval, long min, long max) const;
-    constexpr T         normalizedZToDepth(T zval) const;
-    constexpr long      DepthToZ(T depth, long zmin, long zmax) const;
+    IMATH_CONSTEXPR14 T ZToDepth(long zval, long min, long max) const;
+    IMATH_CONSTEXPR14 T normalizedZToDepth(T zval) const;
+    IMATH_CONSTEXPR14
+    long                DepthToZ(T depth, long zmin, long zmax) const;
 
-    constexpr T         worldRadius(const Vec3<T> &p, T radius) const;
-    constexpr T         screenRadius(const Vec3<T> &p, T radius) const;
+    IMATH_CONSTEXPR14 T worldRadius(const Vec3<T> &p, T radius) const;
+    IMATH_CONSTEXPR14 T screenRadius(const Vec3<T> &p, T radius) const;
 
 
   protected:
 
     constexpr Vec2<T>   screenToLocal( const Vec2<T> & ) const;
-    constexpr Vec2<T>   localToScreen( const Vec2<T> & ) const;
+    IMATH_CONSTEXPR14
+    Vec2<T>             localToScreen( const Vec2<T> & ) const;
 
   protected:
     T                   _nearPlane;
@@ -340,7 +345,7 @@ constexpr T Frustum<T>::fovy() const
 }
 
 template<class T>
-constexpr T Frustum<T>::aspect() const
+IMATH_CONSTEXPR14 T Frustum<T>::aspect() const
 {
     T rightMinusLeft = _right-_left;
     T topMinusBottom = _top-_bottom;
@@ -356,7 +361,7 @@ constexpr T Frustum<T>::aspect() const
 }
 
 template<class T>
-constexpr Matrix44<T> Frustum<T>::projectionMatrix() const
+IMATH_CONSTEXPR14 Matrix44<T> Frustum<T>::projectionMatrix() const
 {
     T rightPlusLeft  = _right+_left;
     T rightMinusLeft = _right-_left;
@@ -450,7 +455,7 @@ constexpr bool Frustum<T>::degenerate() const
 }
 
 template<class T>
-constexpr Frustum<T> Frustum<T>::window(T l, T r, T t, T b) const
+IMATH_CONSTEXPR14 Frustum<T> Frustum<T>::window(T l, T r, T t, T b) const
 {
     // move it to 0->1 space
 
@@ -469,7 +474,7 @@ constexpr Vec2<T> Frustum<T>::screenToLocal(const Vec2<T> &s) const
 }
 
 template<class T>
-constexpr Vec2<T> Frustum<T>::localToScreen(const Vec2<T> &p) const
+IMATH_CONSTEXPR14 Vec2<T> Frustum<T>::localToScreen(const Vec2<T> &p) const
 {
     T leftPlusRight  = _left - T (2) * p.x + _right;
     T leftMinusRight = _left-_right;
@@ -491,7 +496,7 @@ constexpr Vec2<T> Frustum<T>::localToScreen(const Vec2<T> &p) const
 }
 
 template<class T>
-constexpr Line3<T> Frustum<T>::projectScreenToRay(const Vec2<T> &p) const
+IMATH_CONSTEXPR14 Line3<T> Frustum<T>::projectScreenToRay(const Vec2<T> &p) const
 {
     Vec2<T> point = screenToLocal(p);
     if (orthographic())
@@ -502,7 +507,7 @@ constexpr Line3<T> Frustum<T>::projectScreenToRay(const Vec2<T> &p) const
 }
 
 template<class T>
-constexpr Vec2<T> Frustum<T>::projectPointToScreen(const Vec3<T> &point) const
+IMATH_CONSTEXPR14 Vec2<T> Frustum<T>::projectPointToScreen(const Vec3<T> &point) const
 {
     if (orthographic() || point.z == T (0))
         return localToScreen( Vec2<T>( point.x, point.y ) );
@@ -512,7 +517,7 @@ constexpr Vec2<T> Frustum<T>::projectPointToScreen(const Vec3<T> &point) const
 }
 
 template<class T>
-constexpr T Frustum<T>::ZToDepth(long zval,long zmin,long zmax) const
+IMATH_CONSTEXPR14 T Frustum<T>::ZToDepth(long zval,long zmin,long zmax) const
 {
     int zdiff = zmax - zmin;
 
@@ -529,7 +534,7 @@ constexpr T Frustum<T>::ZToDepth(long zval,long zmin,long zmax) const
 }
 
 template<class T>
-constexpr T Frustum<T>::normalizedZToDepth(T zval) const
+IMATH_CONSTEXPR14 T Frustum<T>::normalizedZToDepth(T zval) const
 {
     T Zp = zval * 2.0 - 1;
 
@@ -556,7 +561,7 @@ constexpr T Frustum<T>::normalizedZToDepth(T zval) const
 }
 
 template<class T>
-constexpr long Frustum<T>::DepthToZ(T depth,long zmin,long zmax) const
+IMATH_CONSTEXPR14 long Frustum<T>::DepthToZ(T depth,long zmin,long zmax) const
 {
     long zdiff     = zmax - zmin;
     T farMinusNear = _farPlane-_nearPlane;
@@ -604,7 +609,7 @@ constexpr long Frustum<T>::DepthToZ(T depth,long zmin,long zmax) const
 }
 
 template<class T>
-constexpr T Frustum<T>::screenRadius(const Vec3<T> &p, T radius) const
+IMATH_CONSTEXPR14 T Frustum<T>::screenRadius(const Vec3<T> &p, T radius) const
 {
     // Derivation:
     // Consider X-Z plane.
@@ -631,7 +636,7 @@ constexpr T Frustum<T>::screenRadius(const Vec3<T> &p, T radius) const
 }
 
 template<class T>
-constexpr T Frustum<T>::worldRadius(const Vec3<T> &p, T radius) const
+IMATH_CONSTEXPR14 T Frustum<T>::worldRadius(const Vec3<T> &p, T radius) const
 {
     if (abs(-_nearPlane) > 1 || abs(p.z) < limits<T>::max() * abs(-_nearPlane))
     {

--- a/Imath/ImathGL.h
+++ b/Imath/ImathGL.h
@@ -40,7 +40,6 @@
 
 #include "ImathVec.h"
 #include "ImathMatrix.h"
-#include "IexMathExc.h"
 #include "ImathFun.h"
 #include "ImathNamespace.h"
 

--- a/Imath/ImathMatrix.h
+++ b/Imath/ImathMatrix.h
@@ -587,7 +587,6 @@ template <class T> class Matrix33
     IMATH_CONSTEXPR14
     const Matrix33 &    gjInvert (bool singExc = false);
 
-    IMATH_CONSTEXPR14
     Matrix33<T>         gjInverse (bool singExc = false) const;
 
 
@@ -992,7 +991,6 @@ template <class T> class Matrix44
     IMATH_CONSTEXPR14
     const Matrix44 &    gjInvert (bool singExc = false);
 
-    IMATH_CONSTEXPR14
     Matrix44<T>         gjInverse (bool singExc = false) const;
 
 
@@ -2366,7 +2364,7 @@ Matrix33<T>::gjInvert (bool singExc)
 }
 
 template <class T>
-IMATH_CONSTEXPR14 Matrix33<T>
+Matrix33<T>
 Matrix33<T>::gjInverse (bool singExc) const
 {
     int i, j, k;
@@ -3635,7 +3633,7 @@ Matrix44<T>::gjInvert (bool singExc)
 }
 
 template <class T>
-IMATH_CONSTEXPR14 Matrix44<T>
+Matrix44<T>
 Matrix44<T>::gjInverse (bool singExc) const
 {
     int i, j, k;

--- a/Imath/ImathMatrix.h
+++ b/Imath/ImathMatrix.h
@@ -281,7 +281,6 @@ template <class T> class Matrix22
     //-----------------------------------------
 
     template <class S>
-    IMATH_CONSTEXPR14
     const Matrix22 &    setRotation (S r);
 
 
@@ -614,7 +613,6 @@ template <class T> class Matrix33
     //-----------------------------------------
 
     template <class S>
-    IMATH_CONSTEXPR14
     const Matrix33 &    setRotation (S r);
 
 
@@ -1018,7 +1016,6 @@ template <class T> class Matrix44
     //--------------------------------------------------------
 
     template <class S>
-    IMATH_CONSTEXPR14
     const Matrix44 &    setEulerAngles (const Vec3<S>& r);
 
 
@@ -1036,7 +1033,6 @@ template <class T> class Matrix44
     //-------------------------------------------
 
     template <class S>
-    IMATH_CONSTEXPR14
     const Matrix44 &    rotate (const Vec3<S> &r);
 
 
@@ -1730,7 +1726,7 @@ Matrix22<T>::determinant () const
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 const Matrix22<T> &
+const Matrix22<T> &
 Matrix22<T>::setRotation (S r)
 {
     S cos_r, sin_r;
@@ -2617,7 +2613,7 @@ Matrix33<T>::determinant () const
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 const Matrix33<T> &
+const Matrix33<T> &
 Matrix33<T>::setRotation (S r)
 {
     S cos_r, sin_r;
@@ -3857,7 +3853,7 @@ Matrix44<T>::determinant () const
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 const Matrix44<T> &
+const Matrix44<T> &
 Matrix44<T>::setEulerAngles (const Vec3<S>& r)
 {
     S cos_rz, sin_rz, cos_ry, sin_ry, cos_rx, sin_rx;
@@ -3927,7 +3923,7 @@ Matrix44<T>::setAxisAngle (const Vec3<S>& axis, S angle)
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 const Matrix44<T> &
+const Matrix44<T> &
 Matrix44<T>::rotate (const Vec3<S> &r)
 {
     S cos_rz, sin_rz, cos_ry, sin_ry, cos_rx, sin_rx;

--- a/Imath/ImathMatrixAlgo.cpp
+++ b/Imath/ImathMatrixAlgo.cpp
@@ -95,7 +95,7 @@ public:
         _total = t;
     }
 
-    constexpr double get() const
+    double get() const
     {
         return _total;
     }

--- a/Imath/ImathQuat.h
+++ b/Imath/ImathQuat.h
@@ -172,9 +172,7 @@ class Quat
     Matrix33<T>		toMatrix33 () const;
     constexpr
     Matrix44<T>		toMatrix44 () const;
-    IMATH_CONSTEXPR14
     Quat<T>	        log () const;
-    IMATH_CONSTEXPR14
     Quat<T>	        exp () const;
 
 
@@ -660,7 +658,7 @@ intermediate (const Quat<T> &q0, const Quat<T> &q1, const Quat<T> &q2)
 
 
 template <class T>
-IMATH_CONSTEXPR14 inline Quat<T>
+inline Quat<T>
 Quat<T>::log () const
 {
     //
@@ -686,7 +684,7 @@ Quat<T>::log () const
 
 
 template <class T>
-IMATH_CONSTEXPR14 inline Quat<T>
+inline Quat<T>
 Quat<T>::exp () const
 {
     //

--- a/Imath/ImathQuat.h
+++ b/Imath/ImathQuat.h
@@ -150,7 +150,8 @@ class Quat
     IMATH_CONSTEXPR14
     Quat<T>	        normalized () const;
     constexpr T	 	length () const;	// in R4
-    constexpr Vec3<T>   rotateVector(const Vec3<T> &original) const;
+    IMATH_CONSTEXPR14
+    Vec3<T>             rotateVector(const Vec3<T> &original) const;
     constexpr T         euclideanInnerProduct(const Quat<T> &q) const;
 
     //-----------------------
@@ -171,9 +172,10 @@ class Quat
     Matrix33<T>		toMatrix33 () const;
     constexpr
     Matrix44<T>		toMatrix44 () const;
-
-    constexpr Quat<T>	log () const;
-    constexpr Quat<T>	exp () const;
+    IMATH_CONSTEXPR14
+    Quat<T>	        log () const;
+    IMATH_CONSTEXPR14
+    Quat<T>	        exp () const;
 
 
   private:
@@ -187,13 +189,13 @@ class Quat
 template<class T> IMATH_CONSTEXPR14
 Quat<T>	                slerp (const Quat<T> &q1, const Quat<T> &q2, T t);
 
-template<class T>
-constexpr Quat<T>	slerpShortestArc
+template<class T> IMATH_CONSTEXPR14
+Quat<T>	                slerpShortestArc
                               (const Quat<T> &q1, const Quat<T> &q2, T t);
 
 
-template<class T>
-constexpr Quat<T>	squad (const Quat<T> &q1, const Quat<T> &q2, 
+template<class T> IMATH_CONSTEXPR14
+Quat<T>	                 squad (const Quat<T> &q1, const Quat<T> &q2, 
 			       const Quat<T> &qa, const Quat<T> &qb, T t);
 
 template<class T>
@@ -478,7 +480,8 @@ Quat<T>::invert ()
 
 
 template<class T>
-constexpr inline Vec3<T>
+IMATH_CONSTEXPR14
+Vec3<T>
 Quat<T>::rotateVector(const Vec3<T>& original) const
 {
     //
@@ -559,7 +562,7 @@ slerp (const Quat<T> &q1, const Quat<T> &q2, T t)
 
 
 template<class T>
-constexpr Quat<T>
+IMATH_CONSTEXPR14 Quat<T>
 slerpShortestArc (const Quat<T> &q1, const Quat<T> &q2, T t)
 {
     //
@@ -576,7 +579,7 @@ slerpShortestArc (const Quat<T> &q1, const Quat<T> &q2, T t)
 
 
 template<class T>
-constexpr Quat<T>
+IMATH_CONSTEXPR14 Quat<T>
 spline (const Quat<T> &q0, const Quat<T> &q1,
         const Quat<T> &q2, const Quat<T> &q3,
 	T t)
@@ -612,7 +615,7 @@ spline (const Quat<T> &q0, const Quat<T> &q1,
 
 
 template<class T>
-constexpr Quat<T>
+IMATH_CONSTEXPR14 Quat<T>
 squad (const Quat<T> &q1, const Quat<T> &qa,
        const Quat<T> &qb, const Quat<T> &q2,
        T t)
@@ -635,7 +638,7 @@ squad (const Quat<T> &q1, const Quat<T> &qa,
 
 
 template<class T>
-constexpr Quat<T>
+IMATH_CONSTEXPR14 Quat<T>
 intermediate (const Quat<T> &q0, const Quat<T> &q1, const Quat<T> &q2)
 {
     //
@@ -657,7 +660,7 @@ intermediate (const Quat<T> &q0, const Quat<T> &q1, const Quat<T> &q2)
 
 
 template <class T>
-constexpr inline Quat<T>
+IMATH_CONSTEXPR14 inline Quat<T>
 Quat<T>::log () const
 {
     //
@@ -683,7 +686,7 @@ Quat<T>::log () const
 
 
 template <class T>
-constexpr inline Quat<T>
+IMATH_CONSTEXPR14 inline Quat<T>
 Quat<T>::exp () const
 {
     //

--- a/Imath/ImathShear.h
+++ b/Imath/ImathShear.h
@@ -95,7 +95,7 @@ template <class T> class Shear6
     IMATH_CONSTEXPR14
     const Shear6 &	operator = (const Shear6 &h);
     template <class S> 
-	constexpr
+        IMATH_CONSTEXPR14
         const Shear6 &	operator = (const Vec3<S> &v);
 
     //------------
@@ -153,8 +153,10 @@ template <class T> class Shear6
     //      abs (this[i] - h[i]) <= e * abs (this[i])
     //-----------------------------------------------------------------------
 
-    constexpr bool	equalWithAbsError (const Shear6<T> &h, T e) const;
-    constexpr bool	equalWithRelError (const Shear6<T> &h, T e) const;
+    IMATH_CONSTEXPR14
+    bool	        equalWithAbsError (const Shear6<T> &h, T e) const;
+    IMATH_CONSTEXPR14
+    bool	        equalWithRelError (const Shear6<T> &h, T e) const;
 
 
     //------------------------
@@ -377,7 +379,7 @@ Shear6<T>::operator = (const Shear6 &h)
 
 template <class T>
 template <class S>
-constexpr inline const Shear6<T> &
+IMATH_CONSTEXPR14 inline const Shear6<T> &
 Shear6<T>::operator = (const Vec3<S> &v)
 {
     xy = T (v.x);
@@ -474,7 +476,7 @@ Shear6<T>::operator != (const Shear6<S> &h) const
 }
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 Shear6<T>::equalWithAbsError (const Shear6<T> &h, T e) const
 {
     for (int i = 0; i < 6; i++)
@@ -485,7 +487,7 @@ Shear6<T>::equalWithAbsError (const Shear6<T> &h, T e) const
 }
 
 template <class T>
-constexpr bool
+IMATH_CONSTEXPR14 bool
 Shear6<T>::equalWithRelError (const Shear6<T> &h, T e) const
 {
     for (int i = 0; i < 6; i++)

--- a/Imath/ImathSphere.h
+++ b/Imath/ImathSphere.h
@@ -89,8 +89,8 @@ class Sphere3
     //-------------------------------------------------------------------
 
     void circumscribe(const Box<Vec3<T> > &box);
-    constexpr bool intersect(const Line3<T> &l, Vec3<T> &intersection) const;
-    constexpr bool intersectT(const Line3<T> &l, T &t) const;
+    IMATH_CONSTEXPR14 bool intersect(const Line3<T> &l, Vec3<T> &intersection) const;
+    IMATH_CONSTEXPR14 bool intersectT(const Line3<T> &l, T &t) const;
 };
 
 
@@ -115,7 +115,7 @@ void Sphere3<T>::circumscribe(const Box<Vec3<T> > &box)
 
 
 template <class T>
-constexpr bool Sphere3<T>::intersectT(const Line3<T> &line, T &t) const
+IMATH_CONSTEXPR14 bool Sphere3<T>::intersectT(const Line3<T> &line, T &t) const
 {
     bool doesIntersect = true;
 
@@ -157,7 +157,7 @@ constexpr bool Sphere3<T>::intersectT(const Line3<T> &line, T &t) const
 
 
 template <class T>
-constexpr bool Sphere3<T>::intersect(const Line3<T> &line, Vec3<T> &intersection) const
+IMATH_CONSTEXPR14 bool Sphere3<T>::intersect(const Line3<T> &line, Vec3<T> &intersection) const
 {
     T t;
 

--- a/Imath/ImathVec.cpp
+++ b/Imath/ImathVec.cpp
@@ -55,7 +55,7 @@ namespace
 {
 
 template<class T>
-bool
+IMATH_CONSTEXPR14 bool
 normalizeOrThrow(Vec2<T> &v)
 {
     int axis = -1;
@@ -78,7 +78,7 @@ normalizeOrThrow(Vec2<T> &v)
 
 
 template<class T>
-bool
+IMATH_CONSTEXPR14 bool
 normalizeOrThrow(Vec3<T> &v)
 {
     int axis = -1;
@@ -101,7 +101,7 @@ normalizeOrThrow(Vec3<T> &v)
 
 
 template<class T>
-bool
+IMATH_CONSTEXPR14 bool
 normalizeOrThrow(Vec4<T> &v)
 {
     int axis = -1;
@@ -280,7 +280,7 @@ Vec2<int>::normalizedNonNull () const
 // Vec3<short>
 
 template <> 
-IMATH_EXPORT
+IMATH_EXPORT 
 short
 Vec3<short>::length () const
 {

--- a/Imath/ImathVec.h
+++ b/Imath/ImathVec.h
@@ -228,6 +228,7 @@ template <class T> class Vec2
     constexpr Vec2	operator / (T a) const;
 
 
+  
     //----------------------------------------------------------------
     // Length and normalization:  If v.length() is 0.0, v.normalize()
     // and v.normalized() produce a null vector; v.normalizeExc() and
@@ -237,21 +238,15 @@ template <class T> class Vec2
     // is 0.0, the result is undefined.
     //----------------------------------------------------------------
 
-    IMATH_CONSTEXPR14 T	length () const;
+    T	                length () const;
     constexpr T		length2 () const;
 
-    IMATH_CONSTEXPR14
     const Vec2 &	normalize ();           // modifies *this
-    IMATH_CONSTEXPR14
     const Vec2 &	normalizeExc ();
-    IMATH_CONSTEXPR14
     const Vec2 &	normalizeNonNull ();
 
-    IMATH_CONSTEXPR14
     Vec2<T>	        normalized () const;	// does not modify *this
-    IMATH_CONSTEXPR14
     Vec2<T>	        normalizedExc () const;
-    IMATH_CONSTEXPR14
     Vec2<T>	        normalizedNonNull () const;
 
     //--------------------------------------------------------
@@ -475,21 +470,15 @@ template <class T> class Vec3
     // is 0.0, the result is undefined.
     //----------------------------------------------------------------
 
-    IMATH_CONSTEXPR14 T	length () const;
+    T	                length () const;
     constexpr T		length2 () const;
 
-    IMATH_CONSTEXPR14
     const Vec3 &	normalize ();           // modifies *this
-    IMATH_CONSTEXPR14
     const Vec3 &	normalizeExc ();
-    IMATH_CONSTEXPR14
     const Vec3 &	normalizeNonNull ();
 
-    IMATH_CONSTEXPR14
     Vec3<T>	        normalized () const;	// does not modify *this
-    IMATH_CONSTEXPR14
     Vec3<T>	        normalizedExc () const;
-    IMATH_CONSTEXPR14
     Vec3<T>	        normalizedNonNull () const;
 
 
@@ -682,22 +671,15 @@ template <class T> class Vec4
     // is 0.0, the result is undefined.
     //----------------------------------------------------------------
 
-    IMATH_CONSTEXPR14
     T               length () const;
     constexpr T     length2 () const;
 
-    IMATH_CONSTEXPR14
     const Vec4 &    normalize ();           // modifies *this
-    IMATH_CONSTEXPR14
     const Vec4 &    normalizeExc ();
-    IMATH_CONSTEXPR14
     const Vec4 &    normalizeNonNull ();
 
-    IMATH_CONSTEXPR14
     Vec4<T>         normalized () const;	// does not modify *this
-    IMATH_CONSTEXPR14
     Vec4<T>         normalizedExc () const;
-    IMATH_CONSTEXPR14
     Vec4<T>         normalizedNonNull () const;
 
 
@@ -876,7 +858,8 @@ Vec3<int>::normalizedNonNull () const;
 template <> short
 Vec4<short>::length () const;
 
-template <> const Vec4<short> &
+template <> const
+Vec4<short> &
 Vec4<short>::normalize ();
 
 template <> const Vec4<short> &
@@ -1242,7 +1225,7 @@ Vec2<T>::lengthTiny () const
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline T
+inline T
 Vec2<T>::length () const
 {
     T length2 = dot (*this);
@@ -1261,7 +1244,7 @@ Vec2<T>::length2 () const
 }
 
 template <class T>
-IMATH_CONSTEXPR14 const Vec2<T> &
+const Vec2<T> &
 Vec2<T>::normalize ()
 {
     T l = length();
@@ -1282,7 +1265,7 @@ Vec2<T>::normalize ()
 }
 
 template <class T>
-IMATH_CONSTEXPR14 const Vec2<T> &
+const Vec2<T> &
 Vec2<T>::normalizeExc ()
 {
     T l = length();
@@ -1296,7 +1279,7 @@ Vec2<T>::normalizeExc ()
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline
+inline
 const Vec2<T> &
 Vec2<T>::normalizeNonNull ()
 {
@@ -1306,8 +1289,7 @@ Vec2<T>::normalizeNonNull ()
     return *this;
 }
 
-template <class T>
-IMATH_CONSTEXPR14 Vec2<T>
+template <class T> Vec2<T>
 Vec2<T>::normalized () const
 {
     T l = length();
@@ -1318,8 +1300,7 @@ Vec2<T>::normalized () const
     return Vec2 (x / l, y / l);
 }
 
-template <class T>
-IMATH_CONSTEXPR14 Vec2<T>
+template <class T> Vec2<T>
 Vec2<T>::normalizedExc () const
 {
     T l = length();
@@ -1331,8 +1312,7 @@ Vec2<T>::normalizedExc () const
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline
-Vec2<T>
+inline Vec2<T>
 Vec2<T>::normalizedNonNull () const
 {
     T l = length();
@@ -1733,7 +1713,7 @@ Vec3<T>::lengthTiny () const
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline T
+inline T
 Vec3<T>::length () const
 {
     T length2 = dot (*this);
@@ -1752,7 +1732,7 @@ Vec3<T>::length2 () const
 }
 
 template <class T>
-IMATH_CONSTEXPR14 const Vec3<T> &
+const Vec3<T> &
 Vec3<T>::normalize ()
 {
     T l = length();
@@ -1774,7 +1754,7 @@ Vec3<T>::normalize ()
 }
 
 template <class T>
-IMATH_CONSTEXPR14 const Vec3<T> &
+const Vec3<T> &
 Vec3<T>::normalizeExc ()
 {
     T l = length();
@@ -1790,7 +1770,7 @@ Vec3<T>::normalizeExc ()
 
 template <class T>
 inline
-IMATH_CONSTEXPR14 const Vec3<T> &
+const Vec3<T> &
 Vec3<T>::normalizeNonNull ()
 {
     T l = length();
@@ -1801,7 +1781,7 @@ Vec3<T>::normalizeNonNull ()
 }
 
 template <class T>
-IMATH_CONSTEXPR14 Vec3<T>
+Vec3<T>
 Vec3<T>::normalized () const
 {
     T l = length();
@@ -1813,7 +1793,7 @@ Vec3<T>::normalized () const
 }
 
 template <class T>
-IMATH_CONSTEXPR14 Vec3<T>
+Vec3<T>
 Vec3<T>::normalizedExc () const
 {
     T l = length();
@@ -1825,8 +1805,7 @@ Vec3<T>::normalizedExc () const
 }
 
 template <class T>
-inline
-IMATH_CONSTEXPR14 Vec3<T>
+inline Vec3<T>
 Vec3<T>::normalizedNonNull () const
 {
     T l = length();
@@ -2137,7 +2116,7 @@ Vec4<T>::lengthTiny () const
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline T
+inline T
 Vec4<T>::length () const
 {
     T length2 = dot (*this);
@@ -2156,7 +2135,7 @@ Vec4<T>::length2 () const
 }
 
 template <class T>
-IMATH_CONSTEXPR14 const Vec4<T> &
+const Vec4<T> &
 Vec4<T>::normalize ()
 {
     T l = length();
@@ -2179,7 +2158,7 @@ Vec4<T>::normalize ()
 }
 
 template <class T>
-IMATH_CONSTEXPR14 const Vec4<T> &
+const Vec4<T> &
 Vec4<T>::normalizeExc ()
 {
     T l = length();
@@ -2195,7 +2174,7 @@ Vec4<T>::normalizeExc ()
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline
+inline
 const Vec4<T> &
 Vec4<T>::normalizeNonNull ()
 {
@@ -2208,7 +2187,7 @@ Vec4<T>::normalizeNonNull ()
 }
 
 template <class T>
-IMATH_CONSTEXPR14 Vec4<T>
+Vec4<T>
 Vec4<T>::normalized () const
 {
     T l = length();
@@ -2220,7 +2199,7 @@ Vec4<T>::normalized () const
 }
 
 template <class T>
-IMATH_CONSTEXPR14 Vec4<T>
+Vec4<T>
 Vec4<T>::normalizedExc () const
 {
     T l = length();
@@ -2232,8 +2211,7 @@ Vec4<T>::normalizedExc () const
 }
 
 template <class T>
-inline
-IMATH_CONSTEXPR14 Vec4<T>
+inline Vec4<T>
 Vec4<T>::normalizedNonNull () const
 {
     T l = length();

--- a/share/ci/scripts/linux/install_boost.sh
+++ b/share/ci/scripts/linux/install_boost.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -ex
+
+BOOST_VERSION="$1"
+BOOST_MAJOR_MINOR=$(echo "${BOOST_VERSION}" | cut -d. -f-2)
+BOOST_MAJOR=$(echo "${BOOST_VERSION}" | cut -d. -f-1)
+BOOST_MINOR=$(echo "${BOOST_MAJOR_MINOR}" | cut -d. -f2-)
+BOOST_PATCH=$(echo "${BOOST_VERSION}" | cut -d. -f3-)
+BOOST_VERSION_U="${BOOST_MAJOR}_${BOOST_MINOR}_${BOOST_PATCH}"
+
+mkdir _boost
+cd _boost
+
+wget -q https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION_U}.tar.gz
+tar -xzf boost_${BOOST_VERSION_U}.tar.gz
+
+cd boost_${BOOST_VERSION_U}
+sh bootstrap.sh
+./b2 install -j4 variant=release toolset=gcc \
+    --with-system \
+    --with-regex \
+    --with-filesystem \
+    --with-thread \
+    --with-python \
+    --prefix=/usr/local
+
+cd ../..
+rm -rf _boost

--- a/share/ci/scripts/linux/install_cmake.sh
+++ b/share/ci/scripts/linux/install_cmake.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo "Updating to newer cmake to enable python-3"
+
+CMAKE_VERSION="$1"
+
+curl --location "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh" -o /tmp/cmake.sh
+cd /tmp && sh cmake.sh --skip-license --prefix=/usr/local --exclude-subdir
+rm /tmp/cmake.sh
+
+echo $(ls /usr/local/bin)
+echo $(which cmake)

--- a/share/ci/scripts/linux/install_gdb.sh
+++ b/share/ci/scripts/linux/install_gdb.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -ex
+
+GDB_VERSION="8.3"
+
+echo "Installing gdb-${GDB_VERSION}" 
+
+wget -q https://ftp.gnu.org/gnu/gdb/gdb-${GDB_VERSION}.tar.xz
+tar -xvf gdb-${GDB_VERSION}.tar.xz
+
+cd gdb-${GDB_VERSION}
+
+# Build gdb
+./configure --prefix=/usr \
+            --with-system-readline \
+            --with-python=/usr/bin/python3 &&
+make
+sudo make -C gdb install
+
+cd ..

--- a/share/ci/scripts/linux/install_six.sh
+++ b/share/ci/scripts/linux/install_six.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -ex
+
+SIX_VERSION="1.12.0"
+
+echo "Installing six-${SIX_VERSION}" 
+
+wget -q  https://files.pythonhosted.org/packages/source/s/six/six-${SIX_VERSION}.tar.gz
+tar -xvf six-${SIX_VERSION}.tar.gz
+
+cd six-${SIX_VERSION}
+
+# Install six
+python3 setup.py build
+sudo python3 setup.py install --optimize=1
+
+cd ..
+

--- a/share/ci/scripts/linux/install_sonar.sh
+++ b/share/ci/scripts/linux/install_sonar.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -ex
+
+SONAR_VERSION="$1"
+
+mkdir _sonar
+cd _sonar
+
+wget https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
+unzip build-wrapper-linux-x86.zip
+mv build-wrapper-linux-x86 /var/opt/.
+ln -s /var/opt/build-wrapper-linux-x86/build-wrapper-linux-x86-64 /usr/bin/build-wrapper-linux-x86-64
+echo $(build-wrapper-linux-x86-64 --help)
+
+wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_VERSION}-linux.zip
+unzip sonar-scanner-cli-${SONAR_VERSION}-linux.zip
+mv sonar-scanner-${SONAR_VERSION}-linux /var/opt/.
+ln -s /var/opt/sonar-scanner-${SONAR_VERSION}-linux/bin/sonar-scanner /usr/bin/sonar-scanner
+echo $(sonar-scanner --help)
+
+cd ..
+rm -rf _sonar

--- a/share/ci/scripts/linux/install_valgrind.sh
+++ b/share/ci/scripts/linux/install_valgrind.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -ex
+
+VALGRIND_VERSION="3.15.0"
+
+echo "Updating to Valgrind ${VALGRIND_VERSION}" 
+
+wget -q https://sourceware.org/ftp/valgrind/valgrind-${VALGRIND_VERSION}.tar.bz2 
+tar -xjf valgrind-${VALGRIND_VERSION}.tar.bz2
+
+cd valgrind-${VALGRIND_VERSION}
+
+# Build valgrind 
+sed -i 's|/doc/valgrind||' docs/Makefile.in &&
+./configure --prefix=/usr \
+            --datadir=/usr/share/doc/valgrind-${VALGRIND_VERSION} &&
+make
+
+# Test the build - disabled
+# NOTE: if enabled, must install prerequisites gedb-8.3 and six-1.12.0
+# make regtest
+
+# Install valgrind 
+sudo make install
+
+echo $(which valgrind)
+
+cd ..

--- a/share/ci/scripts/linux/log_valgrind.sh
+++ b/share/ci/scripts/linux/log_valgrind.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -ex
+
+LOGDIR="$1"
+
+if [[ -d ${LOGDIR}/Testing/Temporary ]]; then 
+	for log in ${LOGDIR}/Testing/Temporary/MemoryChecker.*.log; do 
+		echo "========================== " ${log##*/} " ==========================" 
+		cat $log 
+		echo 
+	done 
+else 
+	echo "Memcheck log files not found." 
+fi

--- a/share/ci/scripts/linux/run_gcov.sh
+++ b/share/ci/scripts/linux/run_gcov.sh
@@ -1,0 +1,17 @@
+!/usr/bin/env bash
+
+set -ex
+
+mkdir _coverage
+cd _coverage
+
+# The sed command below converts from:
+#   ../_build/src/OpenEXR/CMakeFiles/OpenColorIO.dir/ops/Exponent.gcno
+# to:
+#   ../src/OpenEXR/ops/Exponent.cpp
+
+for g in $(find ../_build -name "*.gcno" -type f); do
+    gcov -l -p -o $(dirname "$g") $(echo "$g" | sed -e 's/\/_build\//\//' -e 's/\.gcno/\.cpp/' -e 's/\/CMakeFiles.*\.dir\//\//')
+done
+
+cd ..

--- a/share/ci/scripts/macos/install_boost.sh
+++ b/share/ci/scripts/macos/install_boost.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -ex
+
+brew update
+brew install boost
+brew install boost-python
+brew install boost-python3

--- a/share/ci/scripts/macos/install_python.sh
+++ b/share/ci/scripts/macos/install_python.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -ex
+
+PYTHON_VERSION="$1"
+PYTHON_MAJOR="$(echo ${PYTHON_VERSION} | cut -f 1 -d .)"
+
+MACOS_MAJOR="$(sw_vers -productVersion | cut -f 1 -d .)"
+MACOS_MINOR="$(sw_vers -productVersion | cut -f 2 -d .)"
+
+echo "Installing Python ${PYTHON_VERSION} Major ${PYTHON_MAJOR}"
+
+# This workaround is needed for building Python on macOS >= 10.14:
+#   https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes
+
+if [[ "$MACOS_MAJOR" -gt 9 && "$MACOS_MINOR" -gt 13 ]]; then
+    sudo installer \
+        -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_${MACOS_MAJOR}.${MACOS_MINOR}.pkg \
+        -target /
+fi
+
+unset CFLAGS
+
+brew update
+brew install pyenv openssl 
+
+CFLAGS="-I/usr/local/Cellar/openssl/1.0.2s/include"
+LDFLAGS="-L/usr/local/Cellar/openssl/1.0.2s/lib"
+
+echo 'eval "$(pyenv init -)"' >> .bash_profile
+source .bash_profile
+env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install -v ${PYTHON_VERSION}
+pyenv global ${PYTHON_VERSION}
+
+sudo pip install --upgrade pip
+if [[ $PYTHON_MAJOR -eq 2 ]]; then
+    sudo pip install numpy
+else
+    sudo pip3 install numpy
+fi

--- a/share/ci/scripts/windows/install_boost.ps1
+++ b/share/ci/scripts/windows/install_boost.ps1
@@ -1,0 +1,70 @@
+#
+# TODO: fix this script to work with sourceforge archive!
+#
+$homeDir = (pwd)
+
+$boostVersion = $Args[0]
+$boostWorkingDir = $Args[1]
+$pythonVersion = $Args[2]
+
+$boostRoot = "${boostWorkingDir}\_boost"
+
+$boostMajorMinor = [io.path]::GetFileNameWithoutExtension("$boostVersion")
+$boostVersionConcise = $boostVersion -replace '[.]',''
+$boostArray = $boostVersion -split "\."
+$boostMajor = $boostArray[0]
+$boostMinor = $boostArray[1]
+$boostPatch = $boostArray[2];
+$boostVersionU = "boost_${boostMajor}_${boostMinor}_${boostPatch}"
+$boostArchive = "https://sourceforge.net/projects/boost/files/boost-binaries/1.70.0/boost_1_70_0-msvc-14.1-64.exe"
+$boostBuildPath = "${boostRoot}\boost-${boostVersion}\${boostVersionU}"
+
+$pythonMajor = ($pythonVersion -split '\.')[0]
+$pythonMinor = ($pythonVersion -split '\.')[1]
+$pythonMajorMinor = "${pythonMajor}.${pythonMinor}"
+
+Write-Host "boostRoot ${boostRoot}"
+Write-Host "boostBuildPath ${boostBuildPath}"
+Write-Host "pythonMajorMinor ${pythonMajorMinor}"
+
+if (-NOT (Test-Path $boostRoot))
+{
+	New-Item -ItemType Directory $boostRoot
+}
+
+cd $boostRoot
+
+# Retrieve/expand archive 
+Write-Host "Retrieving ${boostArchive}"
+Invoke-WebRequest $boostArchive -OutFile "boost-${boostVersion}.zip"
+Write-Host "Expanding archive boost-${boostVersion}.zip"
+Expand-Archive "boost-${boostVersion}.zip" 
+
+cd "${boostBuildPath}\tools\build"
+
+# Configure and install boost 
+echo "Configuring boost..."
+& .\bootstrap.bat --with-python-version=$pythonMajorMinor
+& .\b2 install -j4 variant=release toolset=msvc `
+      --prefix=$boostBuildPath `
+      --address-model=64
+
+$env:Path = "${boostBuildPath}\bin;${boostBuildPath};$env:Path"
+
+cd $boostBuildPath
+
+# Build boost-python2 libs 
+echo "Building boost python..."
+& b2 --with-python `
+	 --address-model=64 `
+	 --prefix=$boostBuildPath `
+	 toolset=msvc
+
+cd $homeDir
+
+$env:BOOST_ROOT = $boostBuildPath
+echo "BOOST_ROOT = ${env:BOOST_ROOT}"
+
+echo "::set-env name=BOOST_ROOT::$boostBuildPath"
+echo "::add-path::$boostBuildPath"
+

--- a/share/ci/scripts/windows/install_cmake.ps1
+++ b/share/ci/scripts/windows/install_cmake.ps1
@@ -1,0 +1,7 @@
+$cmakeVersion = $Args[0]
+$cmakeMajorMinor = [io.path]::GetFileNameWithoutExtension("$cmakeVersion")
+
+Invoke-WebRequest "https://cmake.org/files/v${cmakeMajorMinor}/cmake-${cmakeVersion}-win64-x64.zip" -OutFile "C:\cmake-${cmakeVersion}-win64-x64.zip"
+Expand-Archive "C:\cmake-${cmakeVersion}-win64-x64.zip" -DestinationPath C:\
+Rename-Item -Path "C:\cmake-${cmakeVersion}-win64-x64" -NewName C:\_cmake
+Write-Host "##vso[task.prependpath]C:\_cmake\bin"

--- a/share/ci/scripts/windows/install_python.ps1
+++ b/share/ci/scripts/windows/install_python.ps1
@@ -1,0 +1,34 @@
+$homeDir = (pwd)
+
+$pythonVersion = $Args[0]
+$pythonWorkingDir = $Args[1]
+
+$pythonMajor = ($pythonVersion -split '\.')[0]
+$pythonMinor = ($pythonVersion -split '\.')[1]
+$pythonRoot = "${pythonWorkingDir}\_python${pythonMajor}${pythonMinor}"
+
+Write-Host "Installing python version ${pythonVersion} ${pythonRoot}"
+
+if (-NOT (Test-Path $pythonRoot))
+{
+	New-Item -ItemType Directory $pythonRoot
+}
+
+cd $pythonRoot
+
+if ($pythonMajor -eq "3")
+{
+    Invoke-WebRequest "https://www.python.org/ftp/python/${pythonVersion}/python-${pythonVersion}.exe" -OutFile "python-${pythonVersion}-amd64.exe"
+    Invoke-Expression "./python-${pythonVersion}-amd64.exe /quiet /l* _python.log TargetDir=${pythonRoot} PrependPath=1"
+}
+else
+{
+    Invoke-WebRequest "https://www.python.org/ftp/python/${pythonVersion}/python-${pythonVersion}.amd64.msi" -OutFile "python-${pythonVersion}-amd64.msi"
+    msiexec /i "python-${pythonVersion}-amd64.msi" /quiet /l* _python.log TARGETDIR="${pythonRoot}" PrependPath=1
+}
+
+cd $homeDir
+
+echo "::set-env name=PYTHON_ROOT::$pythonRoot"
+echo "::add-path::$pythonRoot"
+echo "::add-path::$pythonRoot/Scripts"

--- a/share/ci/scripts/windows/install_zlib.ps1
+++ b/share/ci/scripts/windows/install_zlib.ps1
@@ -1,0 +1,36 @@
+$homeDir = (pwd)
+
+$zlibVersion = $Args[0]
+$zlibWorkingDir = $Args[1]
+
+$zlibMajorMinor = [io.path]::GetFileNameWithoutExtension("$zlibVersion")
+$zlibVersionConcise = $zlibVersion -replace '[.]',''
+$zlibArchive = "https://www.zlib.net/zlib${zlibVersionConcise}.zip"
+
+$zlibRoot = "${zlibWorkingDir}\_zlib"
+$zlibBuildPath = "${zlibWorkingDir}\zlib-${zlibVersion}"
+$zlibDllPath = "${zlibRoot}\bin"
+$msbuild = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe"
+
+Write-Host "Retrieving ${zlibArchive}"
+Invoke-WebRequest "${zlibArchive}" -OutFile "${zlibBuildPath}.zip"
+Write-Host "Expanding archive ${zlibBuildPath}.zip"
+Expand-Archive "${zlibBuildPath}.zip" -DestinationPath "${zlibWorkingDir}"
+
+if (-NOT (Test-Path $zlibRoot))
+{
+	New-Item -ItemType Directory $zlibRoot
+}
+
+cd $zlibBuildPath
+mkdir _build
+cd _build
+cmake .. -G"Visual Studio 16 2019" -DCMAKE_INSTALL_PREFIX="${zlibRoot}"
+
+Write-Host "Building ${zlibBuildPath}\_build\INSTALL.vcxproj" -foregroundcolor green 
+& "${msbuild}" "${zlibBuildPath}\_build\INSTALL.vcxproj" /P:Configuration=Release
+
+cd $homeDir
+
+echo "::set-env name=ZLIB_ROOT::$zlibRoot"
+echo "::add-path::$zlibDllPath"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+#
+# SonarCloud analysis configuration file
+# https://sonarcloud.io/documentation/analysis/analysis-parameters
+
+sonar.host.url=https://sonarcloud.io
+
+# Required metadata
+sonar.organization=academysoftwarefoundation
+sonar.projectKey=AcademySoftwareFoundation_Imath
+sonar.projectName=Imath
+sonar.projectVersion=2.5
+
+# Project links
+sonar.links.homepage=http://openexr.com
+sonar.links.ci=https://github.com/AcademySoftwareFoundation/imath/actions
+sonar.links.scm=https://github.com/AcademySoftwareFoundation/imath
+sonar.links.issue=https://github.com/AcademySoftwareFoundation/imath/issues
+
+# Source properties
+sonar.exclusions=src/bindings/java/**,*.java
+
+# C/C++ analyzer properties
+sonar.cfamily.build-wrapper-output=_build/bw_output
+sonar.cfamily.gcov.reportsPath=_coverage
+


### PR DESCRIPTION
Starting with CI identical to that of OpenEXR, this testing infrastructure was adapted to work for the Imath repository.

Changes made to constexpr previously (after separation from openEXR) caused issues with both the clang++ and g++-6.3.1 compilers used in the VFX CI. This required few changes in order to get CI to pass. Now all tests should pass.