### PR TITLE
Add .git-blame-ignore-revs to ignore reformatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Disable clang-format in half.cpp
+344334aef268206ed1d46399ea85ab276f3f13e6
+
+# Tune .clang-format to match existing style
+c6014892de1acccca0deada8ab3353cd290e9fbc
+


### PR DESCRIPTION
Use this file with git-blame to ignore commits that have reformatted
old code according to the new clang-format style:

  git blame --ignore-revs-file .git-blame-ignore-revs Imath/ImathVec.h

This helps preserve the old revision history, or at least makes it
more easily accessible.  Note that this requires git version 2.23 or
greater.

Also consider adding this to your git config:

  git config blame.ignoreRevsFile .git-blame-ignore-revs

Signed-off-by: Cary Phillips <cary@ilm.com>