### PR TITLE
Stoped sonar cloud from running on PR

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -7,8 +7,7 @@
 name: Analysis
 
 on:
-  pull_request:
-    # TODO: Stop testing on pull requests when testing is known to work!
+  push:
     # Jobs are skipped when ONLY Markdown (*.md) files are changed
     paths-ignore:
       - '**.md'

--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -7,10 +7,6 @@
 name: Analysis
 
 on:
-  push:
-    # Jobs are skipped when ONLY Markdown (*.md) files are changed
-    paths-ignore:
-      - '**.md'
   schedule:
     # Weekly Sunday build
     - cron: "0 0 * * 0"


### PR DESCRIPTION
As per discussion in yesterday's meeting, part of the CI concerning sonarcloud has been disabled for PRs (only now running on push) so as to prevent it from failing redundantly because of issues with permissions. 