### PR TITLE
Fixes the subproject test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,17 +78,15 @@ endif()
 #set(CTEST_DROP_SITE "open.cdash.org")
 #set(CTEST_DROP_LOCATION "/submit.php?project=MyProject")
 #set(CTEST_DROP_SITE_CDASH TRUE)
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-  include(CTest)
+include(CTest)
 
-  if(BUILD_TESTING)
-    enable_testing()
-    add_subdirectory(src/ImathTest)
-  endif()
+if(BUILD_TESTING AND NOT IMATH_IS_SUBPROJECT)
+  enable_testing()
+  add_subdirectory(src/ImathTest)
 endif()
 
 # Including this module will add a `clang-format` target to the build if
 # the clang-format executable can be found. Only do this if we are top level
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+if(NOT IMATH_IS_SUBPROJECT)
   include(cmake/clang-format.cmake)
 endif()

--- a/config/ImathSetup.cmake
+++ b/config/ImathSetup.cmake
@@ -6,6 +6,11 @@ include(GNUInstallDirs)
 ########################
 ## Target configuration
 
+if(NOT "${CMAKE_PROJECT_NAME}" STREQUAL "${PROJECT_NAME}")
+  set(IMATH_IS_SUBPROJECT ON)
+  message(NOTICE "Imath is configuring as a cmake sub project")
+endif()
+
 # This is primarily for the halfFunction code that enables a stack
 # object (if you enable this) that contains a LUT of the function
 option(IMATH_ENABLE_LARGE_STACK "Enables code to take advantage of large stack support"     OFF)


### PR DESCRIPTION
If someone uses FetchContent then add_subdirectory, this correctly
disables the tests and clang format targets

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>