### PR TITLE
Deprecate Math<T> in favor of std::

### DIFF
--- a/config/ImathConfig.h.in
+++ b/config/ImathConfig.h.in
@@ -63,12 +63,14 @@
 
 
 //
-// Simple way to mark things as deprecated
+// Simple way to mark things as deprecated.
+// When we are sure that C++14 is our true minimum, then we can just
+// directly use [[deprecated(msg)]].
 //
-#if defined(__cplusplus) && (__cplusplus >= 201402L)
-# define IMATH_DEPRECATED(msg) [[deprecated(msg)]]
-#elif defined(_MSC_VER)
+#if defined(_MSC_VER)
 # define IMATH_DEPRECATED(msg) __declspec(deprecated(msg))
+#elif __cplusplus >= 201402L
+# define IMATH_DEPRECATED(msg) [[deprecated(msg)]]
 #elif defined(__GNUC__) || defined(__clang__)
 # define IMATH_DEPRECATED(msg) __attribute__((deprecated(msg)))
 #else

--- a/config/ImathConfig.h.in
+++ b/config/ImathConfig.h.in
@@ -61,4 +61,18 @@
   #define IMATH_HOSTDEVICE
 #endif
 
+
+//
+// Simple way to mark things as deprecated
+//
+#if defined(__cplusplus) && (__cplusplus >= 201402L)
+# define IMATH_DEPRECATED(msg) [[deprecated(msg)]]
+#elif defined(_MSC_VER)
+# define IMATH_DEPRECATED(msg) __declspec(deprecated(msg))
+#elif defined(__GNUC__) || defined(__clang__)
+# define IMATH_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#else
+# define IMATH_DEPRECATED(msg) /* unsupported on this platform */
+#endif
+
 #endif // INCLUDED_IMATH_CONFIG_H

--- a/src/Imath/ImathColorAlgo.cpp
+++ b/src/Imath/ImathColorAlgo.cpp
@@ -56,7 +56,7 @@ hsv2rgb_d (const Vec3<double>& hsv)
     else
         hue *= 6;
 
-    int i    = int (Math<double>::floor (hue));
+    int i    = int (std::floor (hue));
     double f = hue - i;
     double p = val * (1 - sat);
     double q = val * (1 - (sat * f));
@@ -113,7 +113,7 @@ hsv2rgb_d (const Color4<double>& hsv)
     else
         hue *= 6;
 
-    int i    = int (Math<double>::floor (hue));
+    int i    = int (std::floor (hue));
     double f = hue - i;
     double p = val * (1 - sat);
     double q = val * (1 - (sat * f));

--- a/src/Imath/ImathEuler.h
+++ b/src/Imath/ImathEuler.h
@@ -496,7 +496,7 @@ Euler<T>::extract (const Matrix33<T>& M)
         // Extract the first angle, x.
         //
 
-        x = Math<T>::atan2 (M[j][i], M[k][i]);
+        x = std::atan2 (M[j][i], M[k][i]);
 
         //
         // Remove the x rotation from M, so that the remaining
@@ -530,9 +530,9 @@ Euler<T>::extract (const Matrix33<T>& M)
         // Extract the other two angles, y and z, from N.
         //
 
-        T sy = Math<T>::sqrt (N[j][i] * N[j][i] + N[k][i] * N[k][i]);
-        y    = Math<T>::atan2 (sy, N[i][i]);
-        z    = Math<T>::atan2 (N[j][k], N[j][j]);
+        T sy = std::sqrt (N[j][i] * N[j][i] + N[k][i] * N[k][i]);
+        y    = std::atan2 (sy, N[i][i]);
+        z    = std::atan2 (N[j][k], N[j][j]);
     }
     else
     {
@@ -540,7 +540,7 @@ Euler<T>::extract (const Matrix33<T>& M)
         // Extract the first angle, x.
         //
 
-        x = Math<T>::atan2 (M[j][k], M[k][k]);
+        x = std::atan2 (M[j][k], M[k][k]);
 
         //
         // Remove the x rotation from M, so that the remaining
@@ -574,9 +574,9 @@ Euler<T>::extract (const Matrix33<T>& M)
         // Extract the other two angles, y and z, from N.
         //
 
-        T cy = Math<T>::sqrt (N[i][i] * N[i][i] + N[i][j] * N[i][j]);
-        y    = Math<T>::atan2 (-N[i][k], cy);
-        z    = Math<T>::atan2 (-N[j][i], N[j][j]);
+        T cy = std::sqrt (N[i][i] * N[i][i] + N[i][j] * N[i][j]);
+        y    = std::atan2 (-N[i][k], cy);
+        z    = std::atan2 (-N[j][i], N[j][j]);
     }
 
     if (!_parityEven)
@@ -603,7 +603,7 @@ Euler<T>::extract (const Matrix44<T>& M)
         // Extract the first angle, x.
         //
 
-        x = Math<T>::atan2 (M[j][i], M[k][i]);
+        x = std::atan2 (M[j][i], M[k][i]);
 
         //
         // Remove the x rotation from M, so that the remaining
@@ -622,9 +622,9 @@ Euler<T>::extract (const Matrix44<T>& M)
         // Extract the other two angles, y and z, from N.
         //
 
-        T sy = Math<T>::sqrt (N[j][i] * N[j][i] + N[k][i] * N[k][i]);
-        y    = Math<T>::atan2 (sy, N[i][i]);
-        z    = Math<T>::atan2 (N[j][k], N[j][j]);
+        T sy = std::sqrt (N[j][i] * N[j][i] + N[k][i] * N[k][i]);
+        y    = std::atan2 (sy, N[i][i]);
+        z    = std::atan2 (N[j][k], N[j][j]);
     }
     else
     {
@@ -632,7 +632,7 @@ Euler<T>::extract (const Matrix44<T>& M)
         // Extract the first angle, x.
         //
 
-        x = Math<T>::atan2 (M[j][k], M[k][k]);
+        x = std::atan2 (M[j][k], M[k][k]);
 
         //
         // Remove the x rotation from M, so that the remaining
@@ -651,9 +651,9 @@ Euler<T>::extract (const Matrix44<T>& M)
         // Extract the other two angles, y and z, from N.
         //
 
-        T cy = Math<T>::sqrt (N[i][i] * N[i][i] + N[i][j] * N[i][j]);
-        y    = Math<T>::atan2 (-N[i][k], cy);
-        z    = Math<T>::atan2 (-N[j][i], N[j][j]);
+        T cy = std::sqrt (N[i][i] * N[i][i] + N[i][j] * N[i][j]);
+        y    = std::atan2 (-N[i][k], cy);
+        z    = std::atan2 (-N[j][i], N[j][j]);
     }
 
     if (!_parityEven)
@@ -684,12 +684,12 @@ Euler<T>::toMatrix33() const
     if (!_parityEven)
         angles *= -1.0;
 
-    T ci = Math<T>::cos (angles.x);
-    T cj = Math<T>::cos (angles.y);
-    T ch = Math<T>::cos (angles.z);
-    T si = Math<T>::sin (angles.x);
-    T sj = Math<T>::sin (angles.y);
-    T sh = Math<T>::sin (angles.z);
+    T ci = std::cos (angles.x);
+    T cj = std::cos (angles.y);
+    T ch = std::cos (angles.z);
+    T si = std::sin (angles.x);
+    T sj = std::sin (angles.y);
+    T sh = std::sin (angles.z);
 
     T cc = ci * ch;
     T cs = ci * sh;
@@ -743,12 +743,12 @@ Euler<T>::toMatrix44() const
     if (!_parityEven)
         angles *= -1.0;
 
-    T ci = Math<T>::cos (angles.x);
-    T cj = Math<T>::cos (angles.y);
-    T ch = Math<T>::cos (angles.z);
-    T si = Math<T>::sin (angles.x);
-    T sj = Math<T>::sin (angles.y);
-    T sh = Math<T>::sin (angles.z);
+    T ci = std::cos (angles.x);
+    T cj = std::cos (angles.y);
+    T ch = std::cos (angles.z);
+    T si = std::sin (angles.x);
+    T sj = std::sin (angles.y);
+    T sh = std::sin (angles.z);
 
     T cc = ci * ch;
     T cs = ci * sh;
@@ -804,12 +804,12 @@ Euler<T>::toQuat() const
     T ti = angles.x * 0.5;
     T tj = angles.y * 0.5;
     T th = angles.z * 0.5;
-    T ci = Math<T>::cos (ti);
-    T cj = Math<T>::cos (tj);
-    T ch = Math<T>::cos (th);
-    T si = Math<T>::sin (ti);
-    T sj = Math<T>::sin (tj);
-    T sh = Math<T>::sin (th);
+    T ci = std::cos (ti);
+    T cj = std::cos (tj);
+    T ch = std::cos (th);
+    T si = std::sin (ti);
+    T sj = std::sin (tj);
+    T sh = std::sin (th);
     T cc = ci * ch;
     T cs = ci * sh;
     T sc = si * ch;

--- a/src/Imath/ImathFrustum.h
+++ b/src/Imath/ImathFrustum.h
@@ -303,14 +303,14 @@ Frustum<T>::setExc (T nearPlane, T farPlane, T fovx, T fovy, T aspect)
 
     if (fovx != T (0))
     {
-        _right  = nearPlane * Math<T>::tan (fovx / two);
+        _right  = nearPlane * std::tan (fovx / two);
         _left   = -_right;
         _top    = ((_right - _left) / aspect) / two;
         _bottom = -_top;
     }
     else
     {
-        _top    = nearPlane * Math<T>::tan (fovy / two);
+        _top    = nearPlane * std::tan (fovy / two);
         _bottom = -_top;
         _right  = (_top - _bottom) * aspect / two;
         _left   = -_right;
@@ -328,14 +328,14 @@ Frustum<T>::set (T nearPlane, T farPlane, T fovx, T fovy, T aspect) noexcept
 
     if (fovx != T (0))
     {
-        _right  = nearPlane * Math<T>::tan (fovx / two);
+        _right  = nearPlane * std::tan (fovx / two);
         _left   = -_right;
         _top    = ((_right - _left) / aspect) / two;
         _bottom = -_top;
     }
     else
     {
-        _top    = nearPlane * Math<T>::tan (fovy / two);
+        _top    = nearPlane * std::tan (fovy / two);
         _bottom = -_top;
         _right  = (_top - _bottom) * aspect / two;
         _left   = -_right;
@@ -349,14 +349,14 @@ template <class T>
 constexpr inline T
 Frustum<T>::fovx() const
 {
-    return Math<T>::atan2 (_right, _nearPlane) - Math<T>::atan2 (_left, _nearPlane);
+    return std::atan2 (_right, _nearPlane) - std::atan2 (_left, _nearPlane);
 }
 
 template <class T>
 constexpr inline T
 Frustum<T>::fovy() const
 {
-    return Math<T>::atan2 (_top, _nearPlane) - Math<T>::atan2 (_bottom, _nearPlane);
+    return std::atan2 (_top, _nearPlane) - std::atan2 (_bottom, _nearPlane);
 }
 
 template <class T>

--- a/src/Imath/ImathLineAlgo.h
+++ b/src/Imath/ImathLineAlgo.h
@@ -257,8 +257,8 @@ rotatePoint (const Vec3<T> p, Line3<T> l, T angle)
     x.normalize();
     Vec3<T> y = (x % l.dir).normalize();
 
-    T cosangle = Math<T>::cos (angle);
-    T sinangle = Math<T>::sin (angle);
+    T cosangle = std::cos (angle);
+    T sinangle = std::sin (angle);
 
     Vec3<T> r = q + x * radius * cosangle + y * radius * sinangle;
 

--- a/src/Imath/ImathMath.h
+++ b/src/Imath/ImathMath.h
@@ -59,33 +59,74 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 template <class T> struct Math
 {
-    IMATH_HOSTDEVICE static T acos (T x) { return std::acos (x); }
-    IMATH_HOSTDEVICE static T asin (T x) { return std::asin (x); }
-    IMATH_HOSTDEVICE static T atan (T x) { return std::atan (x); }
-    IMATH_HOSTDEVICE static T atan2 (T x, T y) { return std::atan2 (x, y); }
-    IMATH_HOSTDEVICE static T cos (T x) { return std::cos (x); }
-    IMATH_HOSTDEVICE static T sin (T x) { return std::sin (x); }
-    IMATH_HOSTDEVICE static T tan (T x) { return std::tan (x); }
-    IMATH_HOSTDEVICE static T cosh (T x) { return std::cosh (x); }
-    IMATH_HOSTDEVICE static T sinh (T x) { return std::sinh (x); }
-    IMATH_HOSTDEVICE static T tanh (T x) { return std::tanh (x); }
-    IMATH_HOSTDEVICE static T exp (T x) { return std::exp (x); }
-    IMATH_HOSTDEVICE static T log (T x) { return std::log (x); }
-    IMATH_HOSTDEVICE static T log10 (T x) { return std::log10 (x); }
-    IMATH_HOSTDEVICE static T modf (T x, T* iptr)
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T acos (T x) { return std::acos (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T asin (T x) { return std::asin (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T atan (T x) { return std::atan (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T atan2 (T x, T y) { return std::atan2 (x, y); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T cos (T x) { return std::cos (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T sin (T x) { return std::sin (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T tan (T x) { return std::tan (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T cosh (T x) { return std::cosh (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T sinh (T x) { return std::sinh (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T tanh (T x) { return std::tanh (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T exp (T x) { return std::exp (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T log (T x) { return std::log (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T log10 (T x) { return std::log10 (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T modf (T x, T* iptr)
     {
         T ival;
         T rval (std::modf (T (x), &ival));
         *iptr = ival;
         return rval;
     }
-    IMATH_HOSTDEVICE static T pow (T x, T y) { return std::pow (x, y); }
-    IMATH_HOSTDEVICE static T sqrt (T x) { return std::sqrt (x); }
-    IMATH_HOSTDEVICE static T ceil (T x) { return std::ceil (x); }
-    IMATH_HOSTDEVICE static T fabs (T x) { return std::fabs (x); }
-    IMATH_HOSTDEVICE static T floor (T x) { return std::floor (x); }
-    IMATH_HOSTDEVICE static T fmod (T x, T y) { return std::fmod (x, y); }
-    IMATH_HOSTDEVICE static T hypot (T x, T y) { return std::hypot (x, y); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T pow (T x, T y) { return std::pow (x, y); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T sqrt (T x) { return std::sqrt (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T ceil (T x) { return std::ceil (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T fabs (T x) { return std::fabs (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T floor (T x) { return std::floor (x); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T fmod (T x, T y) { return std::fmod (x, y); }
+
+    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    static T hypot (T x, T y) { return std::hypot (x, y); }
 };
 
 

--- a/src/Imath/ImathMath.h
+++ b/src/Imath/ImathMath.h
@@ -35,115 +35,59 @@
 #ifndef INCLUDED_IMATHMATH_H
 #define INCLUDED_IMATHMATH_H
 
-//----------------------------------------------------------------------------
-//
-//	ImathMath.h
-//
-//	This file contains template functions which call the double-
-//	precision math functions defined in math.h (sin(), sqrt(),
-//	exp() etc.), with specializations that call the faster
-//	single-precision versions (sinf(), sqrtf(), expf() etc.)
-//	when appropriate.
-//
-//	Example:
-//
-//	    double x = Math<double>::sqrt (3);	// calls ::sqrt(double);
-//	    float  y = Math<float>::sqrt (3);	// calls ::sqrtf(float);
-//
-//	When would I want to use this?
-//
-//	You may be writing a template which needs to call some function
-//	defined in math.h, for example to extract a square root, but you
-//	don't know whether to call the single- or the double-precision
-//	version of this function (sqrt() or sqrtf()):
-//
-//	    template <class T>
-//	    T
-//	    glorp (T x)
-//	    {
-//		return sqrt (x + 1);		// should call ::sqrtf(float)
-//	    }					// if x is a float, but we
-//						// don't know if it is
-//
-//	Using the templates in this file, you can make sure that
-//	the appropriate version of the math function is called:
-//
-//	    template <class T>
-//	    T
-//	    glorp (T x, T y)
-//	    {
-//		return Math<T>::sqrt (x + 1);	// calls ::sqrtf(float) if x
-//	    }					// is a float, ::sqrt(double)
-//	    					// otherwise
-//
-//----------------------------------------------------------------------------
-
 #include "ImathLimits.h"
 #include "ImathNamespace.h"
 #include "ImathPlatform.h"
-#include <math.h>
+#include <cmath>
 
 IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
+//----------------------------------------------------------------------------
+//
+// The deprecated Math<T> methods were intended to allow templated access to
+// math functions so that they would automatically choose either the double
+// (e.g. sin()) or float (e.g., sinf()) version.
+//
+// Beginning wth C++11, this is unnecessary, as std:: versions of all these
+// functions are available and are templated by type.
+//
+// We keep these old definitions for backward compatibility but encourage
+// users to prefer the std:: versions. Some day we may remove these
+// deprecated versions.
+//
+//----------------------------------------------------------------------------
+
 template <class T> struct Math
 {
-    IMATH_HOSTDEVICE static T acos (T x) { return ::acos (double (x)); }
-    IMATH_HOSTDEVICE static T asin (T x) { return ::asin (double (x)); }
-    IMATH_HOSTDEVICE static T atan (T x) { return ::atan (double (x)); }
-    IMATH_HOSTDEVICE static T atan2 (T x, T y) { return ::atan2 (double (x), double (y)); }
-    IMATH_HOSTDEVICE static T cos (T x) { return ::cos (double (x)); }
-    IMATH_HOSTDEVICE static T sin (T x) { return ::sin (double (x)); }
-    IMATH_HOSTDEVICE static T tan (T x) { return ::tan (double (x)); }
-    IMATH_HOSTDEVICE static T cosh (T x) { return ::cosh (double (x)); }
-    IMATH_HOSTDEVICE static T sinh (T x) { return ::sinh (double (x)); }
-    IMATH_HOSTDEVICE static T tanh (T x) { return ::tanh (double (x)); }
-    IMATH_HOSTDEVICE static T exp (T x) { return ::exp (double (x)); }
-    IMATH_HOSTDEVICE static T log (T x) { return ::log (double (x)); }
-    IMATH_HOSTDEVICE static T log10 (T x) { return ::log10 (double (x)); }
+    IMATH_HOSTDEVICE static T acos (T x) { return std::acos (x); }
+    IMATH_HOSTDEVICE static T asin (T x) { return std::asin (x); }
+    IMATH_HOSTDEVICE static T atan (T x) { return std::atan (x); }
+    IMATH_HOSTDEVICE static T atan2 (T x, T y) { return std::atan2 (x, y); }
+    IMATH_HOSTDEVICE static T cos (T x) { return std::cos (x); }
+    IMATH_HOSTDEVICE static T sin (T x) { return std::sin (x); }
+    IMATH_HOSTDEVICE static T tan (T x) { return std::tan (x); }
+    IMATH_HOSTDEVICE static T cosh (T x) { return std::cosh (x); }
+    IMATH_HOSTDEVICE static T sinh (T x) { return std::sinh (x); }
+    IMATH_HOSTDEVICE static T tanh (T x) { return std::tanh (x); }
+    IMATH_HOSTDEVICE static T exp (T x) { return std::exp (x); }
+    IMATH_HOSTDEVICE static T log (T x) { return std::log (x); }
+    IMATH_HOSTDEVICE static T log10 (T x) { return std::log10 (x); }
     IMATH_HOSTDEVICE static T modf (T x, T* iptr)
     {
-        double ival;
-        T rval (::modf (double (x), &ival));
+        T ival;
+        T rval (std::modf (T (x), &ival));
         *iptr = ival;
         return rval;
     }
-    IMATH_HOSTDEVICE static T pow (T x, T y) { return ::pow (double (x), double (y)); }
-    IMATH_HOSTDEVICE static T sqrt (T x) { return ::sqrt (double (x)); }
-    IMATH_HOSTDEVICE static T ceil (T x) { return ::ceil (double (x)); }
-    IMATH_HOSTDEVICE static T fabs (T x) { return ::fabs (double (x)); }
-    IMATH_HOSTDEVICE static T floor (T x) { return ::floor (double (x)); }
-    IMATH_HOSTDEVICE static T fmod (T x, T y) { return ::fmod (double (x), double (y)); }
-    IMATH_HOSTDEVICE static T hypot (T x, T y) { return ::hypot (double (x), double (y)); }
+    IMATH_HOSTDEVICE static T pow (T x, T y) { return std::pow (x, y); }
+    IMATH_HOSTDEVICE static T sqrt (T x) { return std::sqrt (x); }
+    IMATH_HOSTDEVICE static T ceil (T x) { return std::ceil (x); }
+    IMATH_HOSTDEVICE static T fabs (T x) { return std::fabs (x); }
+    IMATH_HOSTDEVICE static T floor (T x) { return std::floor (x); }
+    IMATH_HOSTDEVICE static T fmod (T x, T y) { return std::fmod (x, y); }
+    IMATH_HOSTDEVICE static T hypot (T x, T y) { return std::hypot (x, y); }
 };
 
-template <> struct Math<float>
-{
-    IMATH_HOSTDEVICE static float acos (float x) { return ::acosf (x); }
-    IMATH_HOSTDEVICE static float asin (float x) { return ::asinf (x); }
-    IMATH_HOSTDEVICE static float atan (float x) { return ::atanf (x); }
-    IMATH_HOSTDEVICE static float atan2 (float x, float y) { return ::atan2f (x, y); }
-    IMATH_HOSTDEVICE static float cos (float x) { return ::cosf (x); }
-    IMATH_HOSTDEVICE static float sin (float x) { return ::sinf (x); }
-    IMATH_HOSTDEVICE static float tan (float x) { return ::tanf (x); }
-    IMATH_HOSTDEVICE static float cosh (float x) { return ::coshf (x); }
-    IMATH_HOSTDEVICE static float sinh (float x) { return ::sinhf (x); }
-    IMATH_HOSTDEVICE static float tanh (float x) { return ::tanhf (x); }
-    IMATH_HOSTDEVICE static float exp (float x) { return ::expf (x); }
-    IMATH_HOSTDEVICE static float log (float x) { return ::logf (x); }
-    IMATH_HOSTDEVICE static float log10 (float x) { return ::log10f (x); }
-    IMATH_HOSTDEVICE static float modf (float x, float* y) { return ::modff (x, y); }
-    IMATH_HOSTDEVICE static float pow (float x, float y) { return ::powf (x, y); }
-    IMATH_HOSTDEVICE static float sqrt (float x) { return ::sqrtf (x); }
-    IMATH_HOSTDEVICE static float ceil (float x) { return ::ceilf (x); }
-    IMATH_HOSTDEVICE static float fabs (float x) { return ::fabsf (x); }
-    IMATH_HOSTDEVICE static float floor (float x) { return ::floorf (x); }
-    IMATH_HOSTDEVICE static float fmod (float x, float y) { return ::fmodf (x, y); }
-#if !defined(_MSC_VER)
-    IMATH_HOSTDEVICE static float hypot (float x, float y) { return ::hypotf (x, y); }
-#else
-    IMATH_HOSTDEVICE static float hypot (float x, float y) { return ::sqrtf (x * x + y * y); }
-#endif
-};
 
 //--------------------------------------------------------------------------
 // Don Hatch's version of sin(x)/x, which is accurate for very small x.
@@ -157,7 +101,7 @@ sinx_over_x (T x)
     if (x * x < limits<T>::epsilon())
         return T (1);
     else
-        return Math<T>::sin (x) / x;
+        return std::sin (x) / x;
 }
 
 //--------------------------------------------------------------------------

--- a/src/Imath/ImathMatrix.h
+++ b/src/Imath/ImathMatrix.h
@@ -4095,8 +4095,8 @@ IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::setAxisAngle (const Vec3<S>& axis, S angle)
 {
     Vec3<S> unit (axis.normalized());
-    S sine   = Math<T>::sin (angle);
-    S cosine = Math<T>::cos (angle);
+    S sine   = std::sin (angle);
+    S cosine = std::cos (angle);
 
     x[0][0] = unit[0] * unit[0] * (1 - cosine) + cosine;
     x[0][1] = unit[0] * unit[1] * (1 - cosine) + unit[2] * sine;

--- a/src/Imath/ImathMatrixAlgo.h
+++ b/src/Imath/ImathMatrixAlgo.h
@@ -523,7 +523,7 @@ extractEulerXYZ (const Matrix44<T>& mat, Vec3<T>& rot)
     // Extract the first angle, rot.x.
     //
 
-    rot.x = Math<T>::atan2 (M[1][2], M[2][2]);
+    rot.x = std::atan2 (M[1][2], M[2][2]);
 
     //
     // Remove the rot.x rotation from M, so that the remaining
@@ -539,9 +539,9 @@ extractEulerXYZ (const Matrix44<T>& mat, Vec3<T>& rot)
     // Extract the other two angles, rot.y and rot.z, from N.
     //
 
-    T cy  = Math<T>::sqrt (N[0][0] * N[0][0] + N[0][1] * N[0][1]);
-    rot.y = Math<T>::atan2 (-N[0][2], cy);
-    rot.z = Math<T>::atan2 (-N[1][0], N[1][1]);
+    T cy  = std::sqrt (N[0][0] * N[0][0] + N[0][1] * N[0][1]);
+    rot.y = std::atan2 (-N[0][2], cy);
+    rot.z = std::atan2 (-N[1][0], N[1][1]);
 }
 
 template <class T>
@@ -566,7 +566,7 @@ extractEulerZYX (const Matrix44<T>& mat, Vec3<T>& rot)
     // Extract the first angle, rot.x.
     //
 
-    rot.x = -Math<T>::atan2 (M[1][0], M[0][0]);
+    rot.x = -std::atan2 (M[1][0], M[0][0]);
 
     //
     // Remove the x rotation from M, so that the remaining
@@ -582,9 +582,9 @@ extractEulerZYX (const Matrix44<T>& mat, Vec3<T>& rot)
     // Extract the other two angles, rot.y and rot.z, from N.
     //
 
-    T cy  = Math<T>::sqrt (N[2][2] * N[2][2] + N[2][1] * N[2][1]);
-    rot.y = -Math<T>::atan2 (-N[2][0], cy);
-    rot.z = -Math<T>::atan2 (-N[1][2], N[1][1]);
+    T cy  = std::sqrt (N[2][2] * N[2][2] + N[2][1] * N[2][1]);
+    rot.y = -std::atan2 (-N[2][0], cy);
+    rot.z = -std::atan2 (-N[1][2], N[1][1]);
 }
 
 template <class T>
@@ -604,7 +604,7 @@ extractQuat (const Matrix44<T>& mat)
     // check the diagonal
     if (tr > 0.0)
     {
-        s      = Math<T>::sqrt (tr + T (1.0));
+        s      = std::sqrt (tr + T (1.0));
         quat.r = s / T (2.0);
         s      = T (0.5) / s;
 
@@ -623,7 +623,7 @@ extractQuat (const Matrix44<T>& mat)
 
         j = nxt[i];
         k = nxt[j];
-        s = Math<T>::sqrt ((mat[i][i] - (mat[j][j] + mat[k][k])) + T (1.0));
+        s = std::sqrt ((mat[i][i] - (mat[j][j] + mat[k][k])) + T (1.0));
 
         q[i] = s * T (0.5);
         if (s != T (0.0))
@@ -1152,7 +1152,7 @@ extractEuler (const Matrix22<T>& mat, T& rot)
     // Extract the angle, rot.
     //
 
-    rot = -Math<T>::atan2 (j[0], i[0]);
+    rot = -std::atan2 (j[0], i[0]);
 }
 
 template <class T>
@@ -1173,7 +1173,7 @@ extractEuler (const Matrix33<T>& mat, T& rot)
     // Extract the angle, rot.
     //
 
-    rot = -Math<T>::atan2 (j[0], i[0]);
+    rot = -std::atan2 (j[0], i[0]);
 }
 
 template <class T>

--- a/src/Imath/ImathQuat.h
+++ b/src/Imath/ImathQuat.h
@@ -347,7 +347,7 @@ template <class T>
 constexpr inline T
 Quat<T>::length() const
 {
-    return Math<T>::sqrt (r * r + (v ^ v));
+    return std::sqrt (r * r + (v ^ v));
 }
 
 template <class T>
@@ -439,12 +439,12 @@ angle4D (const Quat<T>& q1, const Quat<T>& q2)
     //
 
     Quat<T> d = q1 - q2;
-    T lengthD = Math<T>::sqrt (d ^ d);
+    T lengthD = std::sqrt (d ^ d);
 
     Quat<T> s = q1 + q2;
-    T lengthS = Math<T>::sqrt (s ^ s);
+    T lengthS = std::sqrt (s ^ s);
 
-    return 2 * Math<T>::atan2 (lengthD, lengthS);
+    return 2 * std::atan2 (lengthD, lengthS);
 }
 
 template <class T>
@@ -578,12 +578,12 @@ Quat<T>::log() const
     // Rendering Techniques by Watt and Watt, Page 366:
     //
 
-    T theta = Math<T>::acos (std::min (r, (T) 1.0));
+    T theta = std::acos (std::min (r, (T) 1.0));
 
     if (theta == 0)
         return Quat<T> (0, v);
 
-    T sintheta = Math<T>::sin (theta);
+    T sintheta = std::sin (theta);
 
     T k;
     if (abs (sintheta) < 1 && abs (theta) >= limits<T>::max() * abs (sintheta))
@@ -605,7 +605,7 @@ Quat<T>::exp() const
     //
 
     T theta    = v.length();
-    T sintheta = Math<T>::sin (theta);
+    T sintheta = std::sin (theta);
 
     T k;
     if (abs (theta) < 1 && abs (sintheta) >= limits<T>::max() * abs (theta))
@@ -613,7 +613,7 @@ Quat<T>::exp() const
     else
         k = sintheta / theta;
 
-    T costheta = Math<T>::cos (theta);
+    T costheta = std::cos (theta);
 
     return Quat<T> (costheta, v.x * k, v.y * k, v.z * k);
 }
@@ -622,7 +622,7 @@ template <class T>
 constexpr inline T
 Quat<T>::angle() const
 {
-    return 2 * Math<T>::atan2 (v.length(), r);
+    return 2 * std::atan2 (v.length(), r);
 }
 
 template <class T>
@@ -636,8 +636,8 @@ template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>&
 Quat<T>::setAxisAngle (const Vec3<T>& axis, T radians)
 {
-    r = Math<T>::cos (radians / 2);
-    v = axis.normalized() * Math<T>::sin (radians / 2);
+    r = std::cos (radians / 2);
+    v = axis.normalized() * std::sin (radians / 2);
     return *this;
 }
 

--- a/src/Imath/ImathRoots.h
+++ b/src/Imath/ImathRoots.h
@@ -129,7 +129,7 @@ solveQuadratic (T a, T b, T c, T x[2])
 
         if (D > 0)
         {
-            T s = Math<T>::sqrt (D);
+            T s = std::sqrt (D);
             T q = -(b + (b > 0 ? 1 : -1) * s) / T (2);
 
             x[0] = q / a;

--- a/src/Imath/ImathSphere.h
+++ b/src/Imath/ImathSphere.h
@@ -134,7 +134,7 @@ Sphere3<T>::intersectT (const Line3<T>& line, T& t) const
     {
         // t0: (-B - sqrt(B^2 - 4AC)) / 2A  (A = 1)
 
-        T sqroot = Math<T>::sqrt (discr);
+        T sqroot = std::sqrt (discr);
         t        = (-B - sqroot) * T (0.5);
 
         if (t < 0.0)

--- a/src/Imath/ImathVec.cpp
+++ b/src/Imath/ImathVec.cpp
@@ -125,7 +125,7 @@ template <>
 IMATH_EXPORT short
 Vec2<short>::length() const
 {
-    float lenF = Math<float>::sqrt ((float) dot (*this));
+    float lenF = std::sqrt ((float) dot (*this));
     short lenS = (short) (lenF + 0.5f);
     return lenS;
 }
@@ -193,7 +193,7 @@ template <>
 IMATH_EXPORT int
 Vec2<int>::length() const
 {
-    float lenF = Math<float>::sqrt ((float) dot (*this));
+    float lenF = std::sqrt ((float) dot (*this));
     int lenI   = (int) (lenF + 0.5f);
     return lenI;
 }
@@ -261,7 +261,7 @@ template <>
 IMATH_EXPORT short
 Vec3<short>::length() const
 {
-    float lenF = Math<float>::sqrt ((float) dot (*this));
+    float lenF = std::sqrt ((float) dot (*this));
     short lenS = (short) (lenF + 0.5f);
     return lenS;
 }
@@ -329,7 +329,7 @@ template <>
 IMATH_EXPORT int
 Vec3<int>::length() const
 {
-    float lenF = Math<float>::sqrt ((float) dot (*this));
+    float lenF = std::sqrt ((float) dot (*this));
     int lenI   = (int) (lenF + 0.5f);
     return lenI;
 }
@@ -397,7 +397,7 @@ template <>
 IMATH_EXPORT short
 Vec4<short>::length() const
 {
-    float lenF = Math<float>::sqrt ((float) dot (*this));
+    float lenF = std::sqrt ((float) dot (*this));
     short lenS = (short) (lenF + 0.5f);
     return lenS;
 }
@@ -465,7 +465,7 @@ template <>
 IMATH_EXPORT int
 Vec4<int>::length() const
 {
-    float lenF = Math<float>::sqrt ((float) dot (*this));
+    float lenF = std::sqrt ((float) dot (*this));
     int lenI   = (int) (lenF + 0.5f);
     return lenI;
 }

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -1049,7 +1049,7 @@ Vec2<T>::lengthTiny() const
     absX /= max;
     absY /= max;
 
-    return max * sqrt ((T) absX * absX + absY * absY);
+    return max * std::sqrt (absX * absX + absY * absY);
 }
 
 template <class T>
@@ -1061,7 +1061,7 @@ Vec2<T>::length() const
     if (length2 < T (2) * limits<T>::smallest())
         return lengthTiny();
 
-    return sqrt ((T) length2);
+    return std::sqrt (length2);
 }
 
 template <class T>
@@ -1519,7 +1519,7 @@ Vec3<T>::lengthTiny() const
     absY /= max;
     absZ /= max;
 
-    return max * sqrt ((T) absX * absX + absY * absY + absZ * absZ);
+    return max * std::sqrt (absX * absX + absY * absY + absZ * absZ);
 }
 
 template <class T>
@@ -1531,7 +1531,7 @@ Vec3<T>::length() const
     if (length2 < T (2) * limits<T>::smallest())
         return lengthTiny();
 
-    return sqrt ((T) length2);
+    return std::sqrt (length2);
 }
 
 template <class T>
@@ -1904,7 +1904,7 @@ Vec4<T>::lengthTiny() const
     absZ /= max;
     absW /= max;
 
-    return max * sqrt ((T) absX * absX + absY * absY + absZ * absZ + absW * absW);
+    return max * std::sqrt (absX * absX + absY * absY + absZ * absZ + absW * absW);
 }
 
 template <class T>
@@ -1916,7 +1916,7 @@ Vec4<T>::length() const
     if (length2 < T (2) * limits<T>::smallest())
         return lengthTiny();
 
-    return sqrt ((T) length2);
+    return std::sqrt (length2);
 }
 
 template <class T>

--- a/src/ImathTest/testColor.cpp
+++ b/src/ImathTest/testColor.cpp
@@ -106,77 +106,77 @@ testColor()
 
     X *= 0.001f;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.r * 0.001f) - X.r) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.g * 0.001f) - X.g) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.b * 0.001f) - X.b) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.a * 0.001f) - X.a) <= epsilon);
+    assert (std::fabs ((Y.r * 0.001f) - X.r) <= epsilon &&
+            std::fabs ((Y.g * 0.001f) - X.g) <= epsilon &&
+            std::fabs ((Y.b * 0.001f) - X.b) <= epsilon &&
+            std::fabs ((Y.a * 0.001f) - X.a) <= epsilon);
 
     X = Y = IMATH_INTERNAL_NAMESPACE::C4f (0.123f, -0.420f, 0.501f, 0.998f);
 
     X /= -1.001f;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.r / -1.001f) - X.r) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.g / -1.001f) - X.g) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.b / -1.001f) - X.b) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.a / -1.001f) - X.a) <= epsilon);
+    assert (std::fabs ((Y.r / -1.001f) - X.r) <= epsilon &&
+            std::fabs ((Y.g / -1.001f) - X.g) <= epsilon &&
+            std::fabs ((Y.b / -1.001f) - X.b) <= epsilon &&
+            std::fabs ((Y.a / -1.001f) - X.a) <= epsilon);
 
     Y = IMATH_INTERNAL_NAMESPACE::C4f (0.998f, -0.001f, 0.501f, 1.001f);
     X = IMATH_INTERNAL_NAMESPACE::C4f (0.011f, -0.420f, -0.501f, 0.998f);
 
     tmp = X + Y;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.r + Y.r) - tmp.r) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.g + Y.g) - tmp.g) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.b + Y.b) - tmp.b) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.a + Y.a) - tmp.a) <= epsilon);
+    assert (std::fabs ((X.r + Y.r) - tmp.r) <= epsilon &&
+            std::fabs ((X.g + Y.g) - tmp.g) <= epsilon &&
+            std::fabs ((X.b + Y.b) - tmp.b) <= epsilon &&
+            std::fabs ((X.a + Y.a) - tmp.a) <= epsilon);
 
     tmp = X - Y;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.r - Y.r) - tmp.r) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.g - Y.g) - tmp.g) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.b - Y.b) - tmp.b) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.a - Y.a) - tmp.a) <= epsilon);
+    assert (std::fabs ((X.r - Y.r) - tmp.r) <= epsilon &&
+            std::fabs ((X.g - Y.g) - tmp.g) <= epsilon &&
+            std::fabs ((X.b - Y.b) - tmp.b) <= epsilon &&
+            std::fabs ((X.a - Y.a) - tmp.a) <= epsilon);
 
     tmp = X * Y;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.r * Y.r) - tmp.r) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.g * Y.g) - tmp.g) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.b * Y.b) - tmp.b) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.a * Y.a) - tmp.a) <= epsilon);
+    assert (std::fabs ((X.r * Y.r) - tmp.r) <= epsilon &&
+            std::fabs ((X.g * Y.g) - tmp.g) <= epsilon &&
+            std::fabs ((X.b * Y.b) - tmp.b) <= epsilon &&
+            std::fabs ((X.a * Y.a) - tmp.a) <= epsilon);
 
     tmp = X / Y;
 
     //
     // epsilon doesn't work here.
     //
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.r / Y.r) - tmp.r) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.g / Y.g) - tmp.g) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.b / Y.b) - tmp.b) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.a / Y.a) - tmp.a) <= 1e-5f);
+    assert (std::fabs ((X.r / Y.r) - tmp.r) <= 1e-5f &&
+            std::fabs ((X.g / Y.g) - tmp.g) <= 1e-5f &&
+            std::fabs ((X.b / Y.b) - tmp.b) <= 1e-5f &&
+            std::fabs ((X.a / Y.a) - tmp.a) <= 1e-5f);
 
     tmp = X;
     tmp += Y;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.r + Y.r) - tmp.r) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.g + Y.g) - tmp.g) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.b + Y.b) - tmp.b) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.a + Y.a) - tmp.a) <= epsilon);
+    assert (std::fabs ((X.r + Y.r) - tmp.r) <= epsilon &&
+            std::fabs ((X.g + Y.g) - tmp.g) <= epsilon &&
+            std::fabs ((X.b + Y.b) - tmp.b) <= epsilon &&
+            std::fabs ((X.a + Y.a) - tmp.a) <= epsilon);
 
     tmp = X;
     tmp -= Y;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.r - Y.r) - tmp.r) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.g - Y.g) - tmp.g) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.b - Y.b) - tmp.b) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.a - Y.a) - tmp.a) <= epsilon);
+    assert (std::fabs ((X.r - Y.r) - tmp.r) <= epsilon &&
+            std::fabs ((X.g - Y.g) - tmp.g) <= epsilon &&
+            std::fabs ((X.b - Y.b) - tmp.b) <= epsilon &&
+            std::fabs ((X.a - Y.a) - tmp.a) <= epsilon);
 
     tmp = X;
     tmp *= Y;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.r * Y.r) - tmp.r) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.g * Y.g) - tmp.g) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.b * Y.b) - tmp.b) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.a * Y.a) - tmp.a) <= epsilon);
+    assert (std::fabs ((X.r * Y.r) - tmp.r) <= epsilon &&
+            std::fabs ((X.g * Y.g) - tmp.g) <= epsilon &&
+            std::fabs ((X.b * Y.b) - tmp.b) <= epsilon &&
+            std::fabs ((X.a * Y.a) - tmp.a) <= epsilon);
 
     tmp = X;
     tmp /= Y;
@@ -184,10 +184,10 @@ testColor()
     //
     // epsilon doesn't work here.
     //
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.r / Y.r) - tmp.r) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.g / Y.g) - tmp.g) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.b / Y.b) - tmp.b) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.a / Y.a) - tmp.a) <= 1e-5f);
+    assert (std::fabs ((X.r / Y.r) - tmp.r) <= 1e-5f &&
+            std::fabs ((X.g / Y.g) - tmp.g) <= 1e-5f &&
+            std::fabs ((X.b / Y.b) - tmp.b) <= 1e-5f &&
+            std::fabs ((X.a / Y.a) - tmp.a) <= 1e-5f);
 
     cout << "ok\n" << endl;
 }

--- a/src/ImathTest/testQuat.cpp
+++ b/src/ImathTest/testQuat.cpp
@@ -135,7 +135,7 @@ testQuatT ()
     //
 
     {
-	T t = 10 * Math<T>::sqrt (s);
+	T t = 10 * std::sqrt (s);
 
 	Quat<T> q;
 	q.setAxisAngle (Vec3<T> (0, 0, 1), t);
@@ -153,7 +153,7 @@ testQuatT ()
     }
 
     {
-	T t = 0.001 * Math<T>::sqrt (s);
+	T t = 0.001 * std::sqrt (s);
 
 	Quat<T> q;
 	q.setAxisAngle (Vec3<T> (0, 0, 1), t);

--- a/src/ImathTest/testShear.cpp
+++ b/src/ImathTest/testShear.cpp
@@ -96,95 +96,95 @@ testShear()
 
     X *= 0.001f;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.xy * 0.001f) - X.xy) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.xz * 0.001f) - X.xz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.yz * 0.001f) - X.yz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.yx * 0.001f) - X.yx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.zx * 0.001f) - X.zx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.zy * 0.001f) - X.zy) <= epsilon);
+    assert (std::fabs ((Y.xy * 0.001f) - X.xy) <= epsilon &&
+            std::fabs ((Y.xz * 0.001f) - X.xz) <= epsilon &&
+            std::fabs ((Y.yz * 0.001f) - X.yz) <= epsilon &&
+            std::fabs ((Y.yx * 0.001f) - X.yx) <= epsilon &&
+            std::fabs ((Y.zx * 0.001f) - X.zx) <= epsilon &&
+            std::fabs ((Y.zy * 0.001f) - X.zy) <= epsilon);
 
     X = Y = IMATH_INTERNAL_NAMESPACE::Shear6f (0.123f, -0.420f, 0.501f, 0.998f, -0.231f, -0.034f);
 
     X /= -1.001f;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.xy / -1.001f) - X.xy) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.xz / -1.001f) - X.xz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.yz / -1.001f) - X.yz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.yx / -1.001f) - X.yx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.zx / -1.001f) - X.zx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((Y.zy / -1.001f) - X.zy) <= epsilon);
+    assert (std::fabs ((Y.xy / -1.001f) - X.xy) <= epsilon &&
+            std::fabs ((Y.xz / -1.001f) - X.xz) <= epsilon &&
+            std::fabs ((Y.yz / -1.001f) - X.yz) <= epsilon &&
+            std::fabs ((Y.yx / -1.001f) - X.yx) <= epsilon &&
+            std::fabs ((Y.zx / -1.001f) - X.zx) <= epsilon &&
+            std::fabs ((Y.zy / -1.001f) - X.zy) <= epsilon);
 
     Y = IMATH_INTERNAL_NAMESPACE::Shear6f (0.998f, -0.001f, 0.501f, 1.001f, -0.231f, -0.034f);
     X = IMATH_INTERNAL_NAMESPACE::Shear6f (0.011f, -0.420f, -0.501f, 0.998f, -0.231f, -0.034f);
 
     tmp = X + Y;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xy + Y.xy) - tmp.xy) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xz + Y.xz) - tmp.xz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yz + Y.yz) - tmp.yz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yx + Y.yx) - tmp.yx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.zx + Y.zx) - tmp.zx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.zy + Y.zy) - tmp.zy) <= epsilon);
+    assert (std::fabs ((X.xy + Y.xy) - tmp.xy) <= epsilon &&
+            std::fabs ((X.xz + Y.xz) - tmp.xz) <= epsilon &&
+            std::fabs ((X.yz + Y.yz) - tmp.yz) <= epsilon &&
+            std::fabs ((X.yx + Y.yx) - tmp.yx) <= epsilon &&
+            std::fabs ((X.zx + Y.zx) - tmp.zx) <= epsilon &&
+            std::fabs ((X.zy + Y.zy) - tmp.zy) <= epsilon);
 
     tmp = X - Y;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xy - Y.xy) - tmp.xy) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xz - Y.xz) - tmp.xz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yz - Y.yz) - tmp.yz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yx - Y.yx) - tmp.yx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.zx - Y.zx) - tmp.zx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.zy - Y.zy) - tmp.zy) <= epsilon);
+    assert (std::fabs ((X.xy - Y.xy) - tmp.xy) <= epsilon &&
+            std::fabs ((X.xz - Y.xz) - tmp.xz) <= epsilon &&
+            std::fabs ((X.yz - Y.yz) - tmp.yz) <= epsilon &&
+            std::fabs ((X.yx - Y.yx) - tmp.yx) <= epsilon &&
+            std::fabs ((X.zx - Y.zx) - tmp.zx) <= epsilon &&
+            std::fabs ((X.zy - Y.zy) - tmp.zy) <= epsilon);
 
     tmp = X * Y;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xy * Y.xy) - tmp.xy) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xz * Y.xz) - tmp.xz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yz * Y.yz) - tmp.yz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yx * Y.yx) - tmp.yx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.zx * Y.zx) - tmp.zx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.zy * Y.zy) - tmp.zy) <= epsilon);
+    assert (std::fabs ((X.xy * Y.xy) - tmp.xy) <= epsilon &&
+            std::fabs ((X.xz * Y.xz) - tmp.xz) <= epsilon &&
+            std::fabs ((X.yz * Y.yz) - tmp.yz) <= epsilon &&
+            std::fabs ((X.yx * Y.yx) - tmp.yx) <= epsilon &&
+            std::fabs ((X.zx * Y.zx) - tmp.zx) <= epsilon &&
+            std::fabs ((X.zy * Y.zy) - tmp.zy) <= epsilon);
 
     tmp = X / Y;
 
     //
     // epsilon doesn't work here.
     //
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xy / Y.xy) - tmp.xy) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xz / Y.xz) - tmp.xz) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yz / Y.yz) - tmp.yz) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yx / Y.yx) - tmp.yx) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.zx / Y.zx) - tmp.zx) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.zy / Y.zy) - tmp.zy) <= 1e-5f);
+    assert (std::fabs ((X.xy / Y.xy) - tmp.xy) <= 1e-5f &&
+            std::fabs ((X.xz / Y.xz) - tmp.xz) <= 1e-5f &&
+            std::fabs ((X.yz / Y.yz) - tmp.yz) <= 1e-5f &&
+            std::fabs ((X.yx / Y.yx) - tmp.yx) <= 1e-5f &&
+            std::fabs ((X.zx / Y.zx) - tmp.zx) <= 1e-5f &&
+            std::fabs ((X.zy / Y.zy) - tmp.zy) <= 1e-5f);
 
     tmp = X;
     tmp += Y;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xy + Y.xy) - tmp.xy) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xz + Y.xz) - tmp.xz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yz + Y.yz) - tmp.yz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yx + Y.yx) - tmp.yx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.zx + Y.zx) - tmp.zx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.zy + Y.zy) - tmp.zy) <= epsilon);
+    assert (std::fabs ((X.xy + Y.xy) - tmp.xy) <= epsilon &&
+            std::fabs ((X.xz + Y.xz) - tmp.xz) <= epsilon &&
+            std::fabs ((X.yz + Y.yz) - tmp.yz) <= epsilon &&
+            std::fabs ((X.yx + Y.yx) - tmp.yx) <= epsilon &&
+            std::fabs ((X.zx + Y.zx) - tmp.zx) <= epsilon &&
+            std::fabs ((X.zy + Y.zy) - tmp.zy) <= epsilon);
 
     tmp = X;
     tmp -= Y;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xy - Y.xy) - tmp.xy) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xz - Y.xz) - tmp.xz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yz - Y.yz) - tmp.yz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yx - Y.yx) - tmp.yx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xz - Y.xz) - tmp.xz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yz - Y.yz) - tmp.yz) <= epsilon);
+    assert (std::fabs ((X.xy - Y.xy) - tmp.xy) <= epsilon &&
+            std::fabs ((X.xz - Y.xz) - tmp.xz) <= epsilon &&
+            std::fabs ((X.yz - Y.yz) - tmp.yz) <= epsilon &&
+            std::fabs ((X.yx - Y.yx) - tmp.yx) <= epsilon &&
+            std::fabs ((X.xz - Y.xz) - tmp.xz) <= epsilon &&
+            std::fabs ((X.yz - Y.yz) - tmp.yz) <= epsilon);
 
     tmp = X;
     tmp *= Y;
 
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xy * Y.xy) - tmp.xy) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xz * Y.xz) - tmp.xz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yz * Y.yz) - tmp.yz) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yx * Y.yx) - tmp.yx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.zx * Y.zx) - tmp.zx) <= epsilon &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.zy * Y.zy) - tmp.zy) <= epsilon);
+    assert (std::fabs ((X.xy * Y.xy) - tmp.xy) <= epsilon &&
+            std::fabs ((X.xz * Y.xz) - tmp.xz) <= epsilon &&
+            std::fabs ((X.yz * Y.yz) - tmp.yz) <= epsilon &&
+            std::fabs ((X.yx * Y.yx) - tmp.yx) <= epsilon &&
+            std::fabs ((X.zx * Y.zx) - tmp.zx) <= epsilon &&
+            std::fabs ((X.zy * Y.zy) - tmp.zy) <= epsilon);
 
     tmp = X;
     tmp /= Y;
@@ -192,12 +192,12 @@ testShear()
     //
     // epsilon doesn't work here.
     //
-    assert (IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xy / Y.xy) - tmp.xy) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.xz / Y.xz) - tmp.xz) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yz / Y.yz) - tmp.yz) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.yx / Y.yx) - tmp.yx) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.zx / Y.zx) - tmp.zx) <= 1e-5f &&
-            IMATH_INTERNAL_NAMESPACE::Math<float>::fabs ((X.zy / Y.zy) - tmp.zy) <= 1e-5f);
+    assert (std::fabs ((X.xy / Y.xy) - tmp.xy) <= 1e-5f &&
+            std::fabs ((X.xz / Y.xz) - tmp.xz) <= 1e-5f &&
+            std::fabs ((X.yz / Y.yz) - tmp.yz) <= 1e-5f &&
+            std::fabs ((X.yx / Y.yx) - tmp.yx) <= 1e-5f &&
+            std::fabs ((X.zx / Y.zx) - tmp.zx) <= 1e-5f &&
+            std::fabs ((X.zy / Y.zy) - tmp.zy) <= 1e-5f);
 
     cout << "ok\n" << endl;
 }

--- a/src/ImathTest/testVec.cpp
+++ b/src/ImathTest/testVec.cpp
@@ -54,7 +54,7 @@ template <class T>
 void
 testLength2T()
 {
-    const T s = Math<T>::sqrt (limits<T>::smallest());
+    const T s = std::sqrt (limits<T>::smallest());
     const T e = 4 * limits<T>::epsilon();
 
     Vec2<T> v;
@@ -80,7 +80,7 @@ testLength2T()
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t, t * e));
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
     v = Vec2<T> (-t, -t);
-    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t * Math<T>::sqrt (2), t * e));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t * std::sqrt (2), t * e));
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
 
     t = s / (1 << 4);
@@ -92,7 +92,7 @@ testLength2T()
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t, t * e));
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
     v = Vec2<T> (-t, -t);
-    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t * Math<T>::sqrt (2), t * e));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t * std::sqrt (2), t * e));
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
 
     t = s / (1 << 20);
@@ -104,7 +104,7 @@ testLength2T()
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t, t * e));
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
     v = Vec2<T> (-t, -t);
-    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t * Math<T>::sqrt (2), t * e));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t * std::sqrt (2), t * e));
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
 }
 
@@ -112,7 +112,7 @@ template <class T>
 void
 testLength3T()
 {
-    const T s = Math<T>::sqrt (limits<T>::smallest());
+    const T s = std::sqrt (limits<T>::smallest());
     const T e = 4 * limits<T>::epsilon();
 
     Vec3<T> v;
@@ -130,11 +130,11 @@ testLength3T()
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
 
     v = Vec3<T> (1, -1, 1);
-    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), 1 * Math<T>::sqrt (3), e));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), 1 * std::sqrt (3), e));
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
 
     v = Vec3<T> (1000, -1000, 1000);
-    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), 1000 * Math<T>::sqrt (3), 1000 * e));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), 1000 * std::sqrt (3), 1000 * e));
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
 
     T t = s * (1 << 4);
@@ -149,7 +149,7 @@ testLength3T()
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t, t * e));
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
     v = Vec3<T> (-t, -t, -t);
-    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t * Math<T>::sqrt (3), t * e));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t * std::sqrt (3), t * e));
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
 
     t = s / (1 << 4);
@@ -164,7 +164,7 @@ testLength3T()
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t, t * e));
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
     v = Vec3<T> (-t, -t, -t);
-    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t * Math<T>::sqrt (3), t * e));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t * std::sqrt (3), t * e));
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
 
     t = s / (1 << 20);
@@ -179,7 +179,7 @@ testLength3T()
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t, t * e));
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
     v = Vec3<T> (-t, -t, -t);
-    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t * Math<T>::sqrt (3), t * e));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (v.length(), t * std::sqrt (3), t * e));
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
 }
 
@@ -187,7 +187,7 @@ template <class T>
 void
 testLength4T()
 {
-    const T s = Math<T>::sqrt (limits<T>::smallest());
+    const T s = std::sqrt (limits<T>::smallest());
     const T e = 4 * limits<T>::epsilon();
 
     Vec4<T> v;


### PR DESCRIPTION
These were helpful to allow templated application of either double or
float in the olden days, but in C++11 and beyond, std:: versions of
these math functions do the same thing and should be preferred.

For back compatibility for applications, I'm keeping Math<T> but
defining them to just be the std:: versions. But the goal should be
to remove them eventually.

Signed-off-by: Larry Gritz <lg@larrygritz.com>