### PR TITLE
Use likely/unlikely to improve certain vector ops

### DIFF
--- a/config/ImathConfig.h.in
+++ b/config/ImathConfig.h.in
@@ -61,4 +61,27 @@
   #define IMATH_HOSTDEVICE
 #endif
 
+
+
+//
+// Some compilers define a special intrinsic to use in conditionals that can
+// speed up extremely performance-critical spots if the conditional is
+// usually (or rarely) is true.  You use it by replacing
+//     if (x) ...
+// with
+//     if (IMATH_LIKELY(x)) ...     // if you think x will usually be true
+// or
+//     if (IMATH_UNLIKELY(x)) ...   // if you think x will rarely be true
+//
+// Caveat: Programmers are notoriously bad at guessing this, so it should be
+// used only with thorough benchmarking.
+//
+#if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
+#    define IMATH_LIKELY(x) (__builtin_expect(bool(x), true))
+#    define IMATH_UNLIKELY(x) (__builtin_expect(bool(x), false))
+#else
+#    define IMATH_LIKELY(x) (x)
+#    define IMATH_UNLIKELY(x) (x)
+#endif
+
 #endif // INCLUDED_IMATH_CONFIG_H

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -1029,15 +1029,15 @@ template <class T>
 IMATH_CONSTEXPR14 inline T
 Vec2<T>::lengthTiny() const
 {
-    T absX = (x >= T (0)) ? x : -x;
-    T absY = (y >= T (0)) ? y : -y;
+    T absX = std::abs(x);
+    T absY = std::abs(y);
 
     T max = absX;
 
     if (max < absY)
         max = absY;
 
-    if (max == T (0))
+    if (IMATH_UNLIKELY(max == T (0)))
         return T (0);
 
     //
@@ -1058,7 +1058,7 @@ Vec2<T>::length() const
 {
     T length2 = dot (*this);
 
-    if (length2 < T (2) * limits<T>::smallest())
+    if (IMATH_UNLIKELY(length2 < T (2) * limits<T>::smallest()))
         return lengthTiny();
 
     return sqrt ((T) length2);
@@ -1077,7 +1077,7 @@ Vec2<T>::normalize()
 {
     T l = length();
 
-    if (l != T (0))
+    if (IMATH_LIKELY(l != T (0)))
     {
         //
         // Do not replace the divisions by l with multiplications by 1/l.
@@ -1098,7 +1098,7 @@ Vec2<T>::normalizeExc()
 {
     T l = length();
 
-    if (l == T (0))
+    if (IMATH_UNLIKELY(l == T (0)))
         throw std::domain_error ("Cannot normalize null vector.");
 
     x /= l;
@@ -1122,7 +1122,7 @@ Vec2<T>::normalized() const
 {
     T l = length();
 
-    if (l == T (0))
+    if (IMATH_UNLIKELY(l == T (0)))
         return Vec2 (T (0));
 
     return Vec2 (x / l, y / l);
@@ -1134,7 +1134,7 @@ Vec2<T>::normalizedExc() const
 {
     T l = length();
 
-    if (l == T (0))
+    if (IMATH_UNLIKELY(l == T (0)))
         throw std::domain_error ("Cannot normalize null vector.");
 
     return Vec2 (x / l, y / l);
@@ -1506,7 +1506,7 @@ Vec3<T>::lengthTiny() const
     if (max < absZ)
         max = absZ;
 
-    if (max == T (0))
+    if (IMATH_UNLIKELY(max == T (0)))
         return T (0);
 
     //
@@ -1528,7 +1528,7 @@ Vec3<T>::length() const
 {
     T length2 = dot (*this);
 
-    if (length2 < T (2) * limits<T>::smallest())
+    if (IMATH_UNLIKELY(length2 < T (2) * limits<T>::smallest()))
         return lengthTiny();
 
     return sqrt ((T) length2);
@@ -1547,7 +1547,7 @@ Vec3<T>::normalize()
 {
     T l = length();
 
-    if (l != T (0))
+    if (IMATH_LIKELY(l != T (0)))
     {
         //
         // Do not replace the divisions by l with multiplications by 1/l.
@@ -1569,7 +1569,7 @@ Vec3<T>::normalizeExc()
 {
     T l = length();
 
-    if (l == T (0))
+    if (IMATH_UNLIKELY(l == T (0)))
         throw std::domain_error ("Cannot normalize null vector.");
 
     x /= l;
@@ -1595,7 +1595,7 @@ Vec3<T>::normalized() const
 {
     T l = length();
 
-    if (l == T (0))
+    if (IMATH_UNLIKELY((l == T (0))))
         return Vec3 (T (0));
 
     return Vec3 (x / l, y / l, z / l);
@@ -1607,7 +1607,7 @@ Vec3<T>::normalizedExc() const
 {
     T l = length();
 
-    if (l == T (0))
+    if (IMATH_UNLIKELY(l == T (0)))
         throw std::domain_error ("Cannot normalize null vector.");
 
     return Vec3 (x / l, y / l, z / l);
@@ -1890,7 +1890,7 @@ Vec4<T>::lengthTiny() const
     if (max < absW)
         max = absW;
 
-    if (max == T (0))
+    if (IMATH_UNLIKELY(max == T (0)))
         return T (0);
 
     //
@@ -1913,7 +1913,7 @@ Vec4<T>::length() const
 {
     T length2 = dot (*this);
 
-    if (length2 < T (2) * limits<T>::smallest())
+    if (IMATH_UNLIKELY(length2 < T (2) * limits<T>::smallest()))
         return lengthTiny();
 
     return sqrt ((T) length2);
@@ -1932,7 +1932,7 @@ Vec4<T>::normalize()
 {
     T l = length();
 
-    if (l != T (0))
+    if (IMATH_LIKELY(l != T (0)))
     {
         //
         // Do not replace the divisions by l with multiplications by 1/l.
@@ -1955,7 +1955,7 @@ Vec4<T>::normalizeExc()
 {
     T l = length();
 
-    if (l == T (0))
+    if (IMATH_UNLIKELY(l == T (0)))
         throw std::domain_error ("Cannot normalize null vector.");
 
     x /= l;
@@ -1983,7 +1983,7 @@ Vec4<T>::normalized() const
 {
     T l = length();
 
-    if (l == T (0))
+    if (IMATH_UNLIKELY(l == T (0)))
         return Vec4 (T (0));
 
     return Vec4 (x / l, y / l, z / l, w / l);
@@ -1995,7 +1995,7 @@ Vec4<T>::normalizedExc() const
 {
     T l = length();
 
-    if (l == T (0))
+    if (IMATH_UNLIKELY(l == T (0)))
         throw std::domain_error ("Cannot normalize null vector.");
 
     return Vec4 (x / l, y / l, z / l, w / l);


### PR DESCRIPTION
Some compilers have special ways to indicate that a branch of an `if`
is especially likely or unlikely to be taken, and can do some
micro-optimizations based on that. Establish IMATH_LIKELY and
IMATH_UNLIKELY macros to implement this. (In C++20 and beyond, there
will be standard attributes for this, but it'll be a while before we
can rely on those.)

For a few conditions in the length and normalize methods of vectors,
in OSL we had replaced these functions with our own modified versions
after analysis from Intel engineers that these hints really did help
generate more performant code in these specific places. In this PR,
I'm pushing those improvements back to the Imath project itself.

These new macros should be used with caution -- programmers
notoriously guess wrong and can hurt performance by using them
inappropriately.  "My intuition is that it will take this branch most
of the time" is not good enough.  Truly exceptional conditions (like
branches that handle very rarely encountered errors) can safely be
marked, but most ordinary control flow should not use these except in
response to clear indications from performance tests.

Signed-off-by: Larry Gritz <lg@larrygritz.com>