### PR TITLE
Adding missing header

### DIFF
--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -46,6 +46,7 @@
 #include "ImathNamespace.h"
 
 #include <iostream>
+#include <stdexcept>
 
 #if (defined _WIN32 || defined _WIN64) && defined _MSC_VER
 // suppress exception specification warnings


### PR DESCRIPTION
When I try to build the library with `g++-4.8` on `CentOS-7` I get following error: 

```
git/Imath/src/Imath/ImathVec.h: In member function ‘const Imath_3_0::Vec2<T>& Imath_3_0::Vec2<T>::normalizeExc()’:
git/Imath/src/Imath/ImathVec.h:1102:15: error: ‘domain_error’ is not a member of ‘std’
```
Adding necessary header file(`<stdexcept>`) to `ImathVec.h` solves the problem.

