### PR TITLE
noexcept all the things

### DIFF
--- a/src/Imath/ImathBox.h
+++ b/src/Imath/ImathBox.h
@@ -76,23 +76,23 @@ template <class V> class Box
 
     /// Construct an empty bounding box. This initializes the mimimum to
     /// `V::baseTypeMax()` and the maximum to `V::baseTypeMin()`.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box();
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box() noexcept;
 
     /// Construct a bounding box that contains a single point.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const V& point);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const V& point) noexcept;
 
     /// Construct a bounding box with the given minimum and maximum values.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const V& minV, const V& maxV);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const V& minV, const V& maxV) noexcept;
 
     //--------------------
     //  Operators:  ==, !=
     //--------------------
 
     /// Compare two Box objects for equality.
-    IMATH_HOSTDEVICE constexpr bool operator== (const Box<V>& src) const;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Box<V>& src) const noexcept;
 
     /// Compare two Box objects for inequality.
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Box<V>& src) const;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Box<V>& src) const noexcept;
 
     //------------------
     //	Box manipulation
@@ -101,16 +101,16 @@ template <class V> class Box
     /// Set the Box to be empty. A Box is empty if the mimimum is greater
     /// than the maximum. makeEmpty() sets the mimimum to `V::baseTypeMax()`
     /// and the maximum to `V::baseTypeMin()`.
-    IMATH_HOSTDEVICE void makeEmpty();
+    IMATH_HOSTDEVICE void makeEmpty() noexcept;
 
     /// Extend the Box to include the given point.
-    IMATH_HOSTDEVICE void extendBy (const V& point);
+    IMATH_HOSTDEVICE void extendBy (const V& point) noexcept;
 
     /// Extend the Box to include the given box.
-    IMATH_HOSTDEVICE void extendBy (const Box<V>& box);
+    IMATH_HOSTDEVICE void extendBy (const Box<V>& box) noexcept;
 
     /// Make the box include the entire range of V.
-    IMATH_HOSTDEVICE void makeInfinite();
+    IMATH_HOSTDEVICE void makeInfinite() noexcept;
 
     //---------------------------------------------------
     //	Query functions - these compute results each time
@@ -118,21 +118,21 @@ template <class V> class Box
 
     /// Return the size of the box. The size is of type `V`, defined as
     /// (max-min). An empty box has a size of V(0), i.e. 0 in each dimension.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 V size() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 V size() const noexcept;
 
     /// Return the center of the box. The center is defined as
     /// (max+min)/2. The center of an empty box is undefined.
-    IMATH_HOSTDEVICE constexpr V center() const;
+    IMATH_HOSTDEVICE constexpr V center() const noexcept;
 
     /// Return true if the given point is inside the box, false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const V& point) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const V& point) const noexcept;
 
     /// Return true if the given box is inside the box, false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Box<V>& box) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Box<V>& box) const noexcept;
 
     /// Return the major axis of the box. The major axis is the dimension with
     /// the greatest difference between maximum and minimum.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 unsigned int majorAxis() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 unsigned int majorAxis() const noexcept;
 
     //----------------
     //	Classification
@@ -140,15 +140,15 @@ template <class V> class Box
 
     /// Return true if the box is empty, false otherwise. An empty box's
     /// minimum is greater than its maximum.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const noexcept;
 
     /// Return true if the box is larger than a single point, false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const noexcept;
 
     /// Return true if the box contains all points, false otherwise.
     /// An infinite box has a mimimum of`V::baseTypeMin()`
     /// and a maximum of `V::baseTypeMax()`.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const noexcept;
 };
 
 //--------------------
@@ -183,18 +183,18 @@ typedef Box<V3d> Box3d;
 //  Implementation
 //----------------
 
-template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box()
+template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box() noexcept
 {
     makeEmpty();
 }
 
-template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box (const V& point)
+template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box (const V& point) noexcept
 {
     min = point;
     max = point;
 }
 
-template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box (const V& minV, const V& maxV)
+template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box (const V& minV, const V& maxV) noexcept
 {
     min = minV;
     max = maxV;
@@ -202,21 +202,21 @@ template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box (const V& minV, const V&
 
 template <class V>
 constexpr inline bool
-Box<V>::operator== (const Box<V>& src) const
+Box<V>::operator== (const Box<V>& src) const noexcept
 {
     return (min == src.min && max == src.max);
 }
 
 template <class V>
 constexpr inline bool
-Box<V>::operator!= (const Box<V>& src) const
+Box<V>::operator!= (const Box<V>& src) const noexcept
 {
     return (min != src.min || max != src.max);
 }
 
 template <class V>
 inline void
-Box<V>::makeEmpty()
+Box<V>::makeEmpty() noexcept
 {
     min = V (V::baseTypeMax());
     max = V (V::baseTypeMin());
@@ -224,7 +224,7 @@ Box<V>::makeEmpty()
 
 template <class V>
 inline void
-Box<V>::makeInfinite()
+Box<V>::makeInfinite() noexcept
 {
     min = V (V::baseTypeMin());
     max = V (V::baseTypeMax());
@@ -232,7 +232,7 @@ Box<V>::makeInfinite()
 
 template <class V>
 inline void
-Box<V>::extendBy (const V& point)
+Box<V>::extendBy (const V& point) noexcept
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
     {
@@ -246,7 +246,7 @@ Box<V>::extendBy (const V& point)
 
 template <class V>
 inline void
-Box<V>::extendBy (const Box<V>& box)
+Box<V>::extendBy (const Box<V>& box) noexcept
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
     {
@@ -260,7 +260,7 @@ Box<V>::extendBy (const Box<V>& box)
 
 template <class V>
 IMATH_CONSTEXPR14 inline bool
-Box<V>::intersects (const V& point) const
+Box<V>::intersects (const V& point) const noexcept
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
     {
@@ -273,7 +273,7 @@ Box<V>::intersects (const V& point) const
 
 template <class V>
 IMATH_CONSTEXPR14 inline bool
-Box<V>::intersects (const Box<V>& box) const
+Box<V>::intersects (const Box<V>& box) const noexcept
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
     {
@@ -286,7 +286,7 @@ Box<V>::intersects (const Box<V>& box) const
 
 template <class V>
 IMATH_CONSTEXPR14 inline V
-Box<V>::size() const
+Box<V>::size() const noexcept
 {
     if (isEmpty())
         return V (0);
@@ -296,14 +296,14 @@ Box<V>::size() const
 
 template <class V>
 constexpr inline V
-Box<V>::center() const
+Box<V>::center() const noexcept
 {
     return (max + min) / 2;
 }
 
 template <class V>
 IMATH_CONSTEXPR14 inline bool
-Box<V>::isEmpty() const
+Box<V>::isEmpty() const noexcept
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
     {
@@ -316,7 +316,7 @@ Box<V>::isEmpty() const
 
 template <class V>
 IMATH_CONSTEXPR14 inline bool
-Box<V>::isInfinite() const
+Box<V>::isInfinite() const noexcept
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
     {
@@ -329,7 +329,7 @@ Box<V>::isInfinite() const
 
 template <class V>
 IMATH_CONSTEXPR14 inline bool
-Box<V>::hasVolume() const
+Box<V>::hasVolume() const noexcept
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
     {
@@ -342,7 +342,7 @@ Box<V>::hasVolume() const
 
 template <class V>
 IMATH_CONSTEXPR14 inline unsigned int
-Box<V>::majorAxis() const
+Box<V>::majorAxis() const noexcept
 {
     unsigned int major = 0;
     V s                = size();
@@ -384,62 +384,62 @@ template <class T> class Box<Vec2<T>>
     //  Constructors - an "empty" box is created by default
     //-----------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box();
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec2<T>& point);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec2<T>& minT, const Vec2<T>& maxT);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec2<T>& point) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec2<T>& minT, const Vec2<T>& maxT) noexcept;
 
     //--------------------
     //  Operators:  ==, !=
     //--------------------
 
-    IMATH_HOSTDEVICE constexpr bool operator== (const Box<Vec2<T>>& src) const;
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Box<Vec2<T>>& src) const;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Box<Vec2<T>>& src) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Box<Vec2<T>>& src) const noexcept;
 
     //------------------
     //  Box manipulation
     //------------------
 
-    IMATH_HOSTDEVICE void makeEmpty();
-    IMATH_HOSTDEVICE void extendBy (const Vec2<T>& point);
-    IMATH_HOSTDEVICE void extendBy (const Box<Vec2<T>>& box);
-    IMATH_HOSTDEVICE void makeInfinite();
+    IMATH_HOSTDEVICE void makeEmpty() noexcept;
+    IMATH_HOSTDEVICE void extendBy (const Vec2<T>& point) noexcept;
+    IMATH_HOSTDEVICE void extendBy (const Box<Vec2<T>>& box) noexcept;
+    IMATH_HOSTDEVICE void makeInfinite() noexcept;
 
     //---------------------------------------------------
     //  Query functions - these compute results each time
     //---------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2<T> size() const;
-    IMATH_HOSTDEVICE constexpr Vec2<T> center() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Vec2<T>& point) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Box<Vec2<T>>& box) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2<T> size() const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2<T> center() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Vec2<T>& point) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Box<Vec2<T>>& box) const noexcept;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 unsigned int majorAxis() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 unsigned int majorAxis() const noexcept;
 
     //----------------
     //  Classification
     //----------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const noexcept;
 };
 
 //----------------
 //  Implementation
 
-template <class T> IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box()
+template <class T> IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box() noexcept
 {
     makeEmpty();
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box (const Vec2<T>& point)
+template <class T> IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box (const Vec2<T>& point) noexcept
 {
     min = point;
     max = point;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box (const Vec2<T>& minT, const Vec2<T>& maxT)
+IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box (const Vec2<T>& minT, const Vec2<T>& maxT) noexcept
 {
     min = minT;
     max = maxT;
@@ -447,21 +447,21 @@ IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box (const Vec2<T>& minT, const Vec2<T>& 
 
 template <class T>
 constexpr inline bool
-Box<Vec2<T>>::operator== (const Box<Vec2<T>>& src) const
+Box<Vec2<T>>::operator== (const Box<Vec2<T>>& src) const noexcept
 {
     return (min == src.min && max == src.max);
 }
 
 template <class T>
 constexpr inline bool
-Box<Vec2<T>>::operator!= (const Box<Vec2<T>>& src) const
+Box<Vec2<T>>::operator!= (const Box<Vec2<T>>& src) const noexcept
 {
     return (min != src.min || max != src.max);
 }
 
 template <class T>
 inline void
-Box<Vec2<T>>::makeEmpty()
+Box<Vec2<T>>::makeEmpty() noexcept
 {
     min = Vec2<T> (Vec2<T>::baseTypeMax());
     max = Vec2<T> (Vec2<T>::baseTypeMin());
@@ -469,7 +469,7 @@ Box<Vec2<T>>::makeEmpty()
 
 template <class T>
 inline void
-Box<Vec2<T>>::makeInfinite()
+Box<Vec2<T>>::makeInfinite() noexcept
 {
     min = Vec2<T> (Vec2<T>::baseTypeMin());
     max = Vec2<T> (Vec2<T>::baseTypeMax());
@@ -477,7 +477,7 @@ Box<Vec2<T>>::makeInfinite()
 
 template <class T>
 inline void
-Box<Vec2<T>>::extendBy (const Vec2<T>& point)
+Box<Vec2<T>>::extendBy (const Vec2<T>& point) noexcept
 {
     if (point[0] < min[0])
         min[0] = point[0];
@@ -494,7 +494,7 @@ Box<Vec2<T>>::extendBy (const Vec2<T>& point)
 
 template <class T>
 inline void
-Box<Vec2<T>>::extendBy (const Box<Vec2<T>>& box)
+Box<Vec2<T>>::extendBy (const Box<Vec2<T>>& box) noexcept
 {
     if (box.min[0] < min[0])
         min[0] = box.min[0];
@@ -511,7 +511,7 @@ Box<Vec2<T>>::extendBy (const Box<Vec2<T>>& box)
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec2<T>>::intersects (const Vec2<T>& point) const
+Box<Vec2<T>>::intersects (const Vec2<T>& point) const noexcept
 {
     if (point[0] < min[0] || point[0] > max[0] || point[1] < min[1] || point[1] > max[1])
         return false;
@@ -521,7 +521,7 @@ Box<Vec2<T>>::intersects (const Vec2<T>& point) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec2<T>>::intersects (const Box<Vec2<T>>& box) const
+Box<Vec2<T>>::intersects (const Box<Vec2<T>>& box) const noexcept
 {
     if (box.max[0] < min[0] || box.min[0] > max[0] || box.max[1] < min[1] || box.min[1] > max[1])
         return false;
@@ -531,7 +531,7 @@ Box<Vec2<T>>::intersects (const Box<Vec2<T>>& box) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline Vec2<T>
-Box<Vec2<T>>::size() const
+Box<Vec2<T>>::size() const noexcept
 {
     if (isEmpty())
         return Vec2<T> (0);
@@ -541,14 +541,14 @@ Box<Vec2<T>>::size() const
 
 template <class T>
 constexpr inline Vec2<T>
-Box<Vec2<T>>::center() const
+Box<Vec2<T>>::center() const noexcept
 {
     return (max + min) / 2;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec2<T>>::isEmpty() const
+Box<Vec2<T>>::isEmpty() const noexcept
 {
     if (max[0] < min[0] || max[1] < min[1])
         return true;
@@ -558,7 +558,7 @@ Box<Vec2<T>>::isEmpty() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec2<T>>::isInfinite() const
+Box<Vec2<T>>::isInfinite() const noexcept
 {
     if (min[0] != limits<T>::min() || max[0] != limits<T>::max() || min[1] != limits<T>::min() ||
         max[1] != limits<T>::max())
@@ -569,7 +569,7 @@ Box<Vec2<T>>::isInfinite() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec2<T>>::hasVolume() const
+Box<Vec2<T>>::hasVolume() const noexcept
 {
     if (max[0] <= min[0] || max[1] <= min[1])
         return false;
@@ -579,7 +579,7 @@ Box<Vec2<T>>::hasVolume() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline unsigned int
-Box<Vec2<T>>::majorAxis() const
+Box<Vec2<T>>::majorAxis() const noexcept
 {
     unsigned int major = 0;
     Vec2<T> s          = size();
@@ -611,62 +611,62 @@ template <class T> class Box<Vec3<T>>
     //  Constructors - an "empty" box is created by default
     //-----------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box();
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec3<T>& point);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec3<T>& minT, const Vec3<T>& maxT);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec3<T>& point) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec3<T>& minT, const Vec3<T>& maxT) noexcept;
 
     //--------------------
     //  Operators:  ==, !=
     //--------------------
 
-    IMATH_HOSTDEVICE constexpr bool operator== (const Box<Vec3<T>>& src) const;
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Box<Vec3<T>>& src) const;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Box<Vec3<T>>& src) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Box<Vec3<T>>& src) const noexcept;
 
     //------------------
     //  Box manipulation
     //------------------
 
-    IMATH_HOSTDEVICE void makeEmpty();
-    IMATH_HOSTDEVICE void extendBy (const Vec3<T>& point);
-    IMATH_HOSTDEVICE void extendBy (const Box<Vec3<T>>& box);
-    IMATH_HOSTDEVICE void makeInfinite();
+    IMATH_HOSTDEVICE void makeEmpty() noexcept;
+    IMATH_HOSTDEVICE void extendBy (const Vec3<T>& point) noexcept;
+    IMATH_HOSTDEVICE void extendBy (const Box<Vec3<T>>& box) noexcept;
+    IMATH_HOSTDEVICE void makeInfinite() noexcept;
 
     //---------------------------------------------------
     //  Query functions - these compute results each time
     //---------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T> size() const;
-    IMATH_HOSTDEVICE constexpr Vec3<T> center() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Vec3<T>& point) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Box<Vec3<T>>& box) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T> size() const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3<T> center() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Vec3<T>& point) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Box<Vec3<T>>& box) const noexcept;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 unsigned int majorAxis() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 unsigned int majorAxis() const noexcept;
 
     //----------------
     //  Classification
     //----------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const noexcept;
 };
 
 //----------------
 //  Implementation
 
-template <class T> IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box()
+template <class T> IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box() noexcept
 {
     makeEmpty();
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box (const Vec3<T>& point)
+template <class T> IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box (const Vec3<T>& point) noexcept
 {
     min = point;
     max = point;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box (const Vec3<T>& minT, const Vec3<T>& maxT)
+IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box (const Vec3<T>& minT, const Vec3<T>& maxT) noexcept
 {
     min = minT;
     max = maxT;
@@ -674,21 +674,21 @@ IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box (const Vec3<T>& minT, const Vec3<T>& 
 
 template <class T>
 constexpr inline bool
-Box<Vec3<T>>::operator== (const Box<Vec3<T>>& src) const
+Box<Vec3<T>>::operator== (const Box<Vec3<T>>& src) const noexcept
 {
     return (min == src.min && max == src.max);
 }
 
 template <class T>
 constexpr inline bool
-Box<Vec3<T>>::operator!= (const Box<Vec3<T>>& src) const
+Box<Vec3<T>>::operator!= (const Box<Vec3<T>>& src) const noexcept
 {
     return (min != src.min || max != src.max);
 }
 
 template <class T>
 inline void
-Box<Vec3<T>>::makeEmpty()
+Box<Vec3<T>>::makeEmpty() noexcept
 {
     min = Vec3<T> (Vec3<T>::baseTypeMax());
     max = Vec3<T> (Vec3<T>::baseTypeMin());
@@ -696,7 +696,7 @@ Box<Vec3<T>>::makeEmpty()
 
 template <class T>
 inline void
-Box<Vec3<T>>::makeInfinite()
+Box<Vec3<T>>::makeInfinite() noexcept
 {
     min = Vec3<T> (Vec3<T>::baseTypeMin());
     max = Vec3<T> (Vec3<T>::baseTypeMax());
@@ -704,7 +704,7 @@ Box<Vec3<T>>::makeInfinite()
 
 template <class T>
 inline void
-Box<Vec3<T>>::extendBy (const Vec3<T>& point)
+Box<Vec3<T>>::extendBy (const Vec3<T>& point) noexcept
 {
     if (point[0] < min[0])
         min[0] = point[0];
@@ -727,7 +727,7 @@ Box<Vec3<T>>::extendBy (const Vec3<T>& point)
 
 template <class T>
 inline void
-Box<Vec3<T>>::extendBy (const Box<Vec3<T>>& box)
+Box<Vec3<T>>::extendBy (const Box<Vec3<T>>& box) noexcept
 {
     if (box.min[0] < min[0])
         min[0] = box.min[0];
@@ -750,7 +750,7 @@ Box<Vec3<T>>::extendBy (const Box<Vec3<T>>& box)
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec3<T>>::intersects (const Vec3<T>& point) const
+Box<Vec3<T>>::intersects (const Vec3<T>& point) const noexcept
 {
     if (point[0] < min[0] || point[0] > max[0] || point[1] < min[1] || point[1] > max[1] ||
         point[2] < min[2] || point[2] > max[2])
@@ -761,7 +761,7 @@ Box<Vec3<T>>::intersects (const Vec3<T>& point) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec3<T>>::intersects (const Box<Vec3<T>>& box) const
+Box<Vec3<T>>::intersects (const Box<Vec3<T>>& box) const noexcept
 {
     if (box.max[0] < min[0] || box.min[0] > max[0] || box.max[1] < min[1] || box.min[1] > max[1] ||
         box.max[2] < min[2] || box.min[2] > max[2])
@@ -772,7 +772,7 @@ Box<Vec3<T>>::intersects (const Box<Vec3<T>>& box) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline Vec3<T>
-Box<Vec3<T>>::size() const
+Box<Vec3<T>>::size() const noexcept
 {
     if (isEmpty())
         return Vec3<T> (0);
@@ -782,14 +782,14 @@ Box<Vec3<T>>::size() const
 
 template <class T>
 constexpr inline Vec3<T>
-Box<Vec3<T>>::center() const
+Box<Vec3<T>>::center() const noexcept
 {
     return (max + min) / 2;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec3<T>>::isEmpty() const
+Box<Vec3<T>>::isEmpty() const noexcept
 {
     if (max[0] < min[0] || max[1] < min[1] || max[2] < min[2])
         return true;
@@ -799,7 +799,7 @@ Box<Vec3<T>>::isEmpty() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec3<T>>::isInfinite() const
+Box<Vec3<T>>::isInfinite() const noexcept
 {
     if (min[0] != limits<T>::min() || max[0] != limits<T>::max() || min[1] != limits<T>::min() ||
         max[1] != limits<T>::max() || min[2] != limits<T>::min() || max[2] != limits<T>::max())
@@ -810,7 +810,7 @@ Box<Vec3<T>>::isInfinite() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec3<T>>::hasVolume() const
+Box<Vec3<T>>::hasVolume() const noexcept
 {
     if (max[0] <= min[0] || max[1] <= min[1] || max[2] <= min[2])
         return false;
@@ -820,7 +820,7 @@ Box<Vec3<T>>::hasVolume() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline unsigned int
-Box<Vec3<T>>::majorAxis() const
+Box<Vec3<T>>::majorAxis() const noexcept
 {
     unsigned int major = 0;
     Vec3<T> s          = size();

--- a/src/Imath/ImathBoxAlgo.h
+++ b/src/Imath/ImathBoxAlgo.h
@@ -82,7 +82,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T
-clip (const T& p, const Box<T>& box)
+clip (const T& p, const Box<T>& box) noexcept
 {
     //
     // Clip the coordinates of a point, p, against a box.
@@ -106,14 +106,14 @@ clip (const T& p, const Box<T>& box)
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline T
-closestPointInBox (const T& p, const Box<T>& box)
+closestPointInBox (const T& p, const Box<T>& box) noexcept
 {
     return clip (p, box);
 }
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T>
-closestPointOnBox (const Vec3<T>& p, const Box<Vec3<T>>& box)
+closestPointOnBox (const Vec3<T>& p, const Box<Vec3<T>>& box) noexcept
 {
     //
     // Find the point, q, on the surface of
@@ -155,7 +155,7 @@ closestPointOnBox (const Vec3<T>& p, const Box<Vec3<T>>& box)
 
 template <class S, class T>
 IMATH_HOSTDEVICE Box<Vec3<S>>
-transform (const Box<Vec3<S>>& box, const Matrix44<T>& m)
+transform (const Box<Vec3<S>>& box, const Matrix44<T>& m) noexcept
 {
     //
     // Transform a 3D box by a matrix, and compute a new box that
@@ -237,7 +237,7 @@ transform (const Box<Vec3<S>>& box, const Matrix44<T>& m)
 
 template <class S, class T>
 IMATH_HOSTDEVICE void
-transform (const Box<Vec3<S>>& box, const Matrix44<T>& m, Box<Vec3<S>>& result)
+transform (const Box<Vec3<S>>& box, const Matrix44<T>& m, Box<Vec3<S>>& result) noexcept
 {
     //
     // Transform a 3D box by a matrix, and compute a new box that
@@ -315,7 +315,7 @@ transform (const Box<Vec3<S>>& box, const Matrix44<T>& m, Box<Vec3<S>>& result)
 
 template <class S, class T>
 IMATH_HOSTDEVICE Box<Vec3<S>>
-affineTransform (const Box<Vec3<S>>& box, const Matrix44<T>& m)
+affineTransform (const Box<Vec3<S>>& box, const Matrix44<T>& m) noexcept
 {
     //
     // Transform a 3D box by a matrix whose rightmost column
@@ -366,7 +366,7 @@ affineTransform (const Box<Vec3<S>>& box, const Matrix44<T>& m)
 
 template <class S, class T>
 IMATH_HOSTDEVICE void
-affineTransform (const Box<Vec3<S>>& box, const Matrix44<T>& m, Box<Vec3<S>>& result)
+affineTransform (const Box<Vec3<S>>& box, const Matrix44<T>& m, Box<Vec3<S>>& result) noexcept
 {
     //
     // Transform a 3D box by a matrix whose rightmost column
@@ -422,7 +422,7 @@ affineTransform (const Box<Vec3<S>>& box, const Matrix44<T>& m, Box<Vec3<S>>& re
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool
-findEntryAndExitPoints (const Line3<T>& r, const Box<Vec3<T>>& b, Vec3<T>& entry, Vec3<T>& exit)
+findEntryAndExitPoints (const Line3<T>& r, const Box<Vec3<T>>& b, Vec3<T>& entry, Vec3<T>& exit) noexcept
 {
     //
     // Compute the points where a ray, r, enters and exits a box, b:
@@ -696,7 +696,7 @@ findEntryAndExitPoints (const Line3<T>& r, const Box<Vec3<T>>& b, Vec3<T>& entry
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool
-intersects (const Box<Vec3<T>>& b, const Line3<T>& r, Vec3<T>& ip)
+intersects (const Box<Vec3<T>>& b, const Line3<T>& r, Vec3<T>& ip) noexcept
 {
     //
     // Intersect a ray, r, with a box, b, and compute the intersection
@@ -974,7 +974,7 @@ intersects (const Box<Vec3<T>>& b, const Line3<T>& r, Vec3<T>& ip)
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool
-intersects (const Box<Vec3<T>>& box, const Line3<T>& ray)
+intersects (const Box<Vec3<T>>& box, const Line3<T>& ray) noexcept
 {
     Vec3<T> ignored;
     return intersects (box, ray, ignored);

--- a/src/Imath/ImathColor.h
+++ b/src/Imath/ImathColor.h
@@ -54,58 +54,58 @@ template <class T> class Color3 : public Vec3<T>
     // Constructors
     //-------------
 
-    IMATH_HOSTDEVICE Color3();                         // no initialization
-    IMATH_HOSTDEVICE constexpr explicit Color3 (T a);  // (a a a)
-    IMATH_HOSTDEVICE constexpr Color3 (T a, T b, T c); // (a b c)
+    IMATH_HOSTDEVICE Color3() noexcept;                         // no initialization
+    IMATH_HOSTDEVICE constexpr explicit Color3 (T a) noexcept;  // (a a a)
+    IMATH_HOSTDEVICE constexpr Color3 (T a, T b, T c) noexcept; // (a b c)
     ~Color3() = default;
 
     //---------------------------------
     // Copy constructors and assignment
     //---------------------------------
 
-    IMATH_HOSTDEVICE constexpr Color3 (const Color3& c);
-    template <class S> IMATH_HOSTDEVICE constexpr Color3 (const Vec3<S>& v);
+    IMATH_HOSTDEVICE constexpr Color3 (const Color3& c) noexcept;
+    template <class S> IMATH_HOSTDEVICE constexpr Color3 (const Vec3<S>& v) noexcept;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator= (const Color3& c);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator= (const Color3& c) noexcept;
 
     //------------------------
     // Component-wise addition
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator+= (const Color3& c);
-    IMATH_HOSTDEVICE constexpr Color3 operator+ (const Color3& c) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator+= (const Color3& c) noexcept;
+    IMATH_HOSTDEVICE constexpr Color3 operator+ (const Color3& c) const noexcept;
 
     //---------------------------
     // Component-wise subtraction
     //---------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator-= (const Color3& c);
-    IMATH_HOSTDEVICE constexpr Color3 operator- (const Color3& c) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator-= (const Color3& c) noexcept;
+    IMATH_HOSTDEVICE constexpr Color3 operator- (const Color3& c) const noexcept;
 
     //------------------------------------
     // Component-wise multiplication by -1
     //------------------------------------
 
-    IMATH_HOSTDEVICE constexpr Color3 operator-() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& negate();
+    IMATH_HOSTDEVICE constexpr Color3 operator-() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& negate() noexcept;
 
     //------------------------------
     // Component-wise multiplication
     //------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator*= (const Color3& c);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator*= (T a);
-    IMATH_HOSTDEVICE constexpr Color3 operator* (const Color3& c) const;
-    IMATH_HOSTDEVICE constexpr Color3 operator* (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator*= (const Color3& c) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator*= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Color3 operator* (const Color3& c) const noexcept;
+    IMATH_HOSTDEVICE constexpr Color3 operator* (T a) const noexcept;
 
     //------------------------
     // Component-wise division
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator/= (const Color3& c);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator/= (T a);
-    IMATH_HOSTDEVICE constexpr Color3 operator/ (const Color3& c) const;
-    IMATH_HOSTDEVICE constexpr Color3 operator/ (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator/= (const Color3& c) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator/= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Color3 operator/ (const Color3& c) const noexcept;
+    IMATH_HOSTDEVICE constexpr Color3 operator/ (T a) const noexcept;
 };
 
 template <class T> class Color4
@@ -117,103 +117,103 @@ template <class T> class Color4
 
     T r, g, b, a;
 
-    IMATH_HOSTDEVICE T& operator[] (int i);
-    IMATH_HOSTDEVICE const T& operator[] (int i) const;
+    IMATH_HOSTDEVICE T& operator[] (int i) noexcept;
+    IMATH_HOSTDEVICE const T& operator[] (int i) const noexcept;
 
     //-------------
     // Constructors
     //-------------
 
-    IMATH_HOSTDEVICE Color4();                                      // no initialization
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Color4 (T a);       // (a a a a)
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4 (T a, T b, T c, T d); // (a b c d)
+    IMATH_HOSTDEVICE Color4() noexcept;                                      // no initialization
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Color4 (T a) noexcept;       // (a a a a)
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4 (T a, T b, T c, T d) noexcept; // (a b c d)
     ~Color4() = default;
 
     //---------------------------------
     // Copy constructors and assignment
     //---------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4 (const Color4& v);
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4 (const Color4<S>& v);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4 (const Color4& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4 (const Color4<S>& v) noexcept;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator= (const Color4& v);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator= (const Color4& v) noexcept;
 
     //----------------------
     // Compatibility with Sb
     //----------------------
 
-    template <class S> IMATH_HOSTDEVICE void setValue (S a, S b, S c, S d);
+    template <class S> IMATH_HOSTDEVICE void setValue (S a, S b, S c, S d) noexcept;
 
-    template <class S> IMATH_HOSTDEVICE void setValue (const Color4<S>& v);
+    template <class S> IMATH_HOSTDEVICE void setValue (const Color4<S>& v) noexcept;
 
-    template <class S> IMATH_HOSTDEVICE void getValue (S& a, S& b, S& c, S& d) const;
+    template <class S> IMATH_HOSTDEVICE void getValue (S& a, S& b, S& c, S& d) const noexcept;
 
-    template <class S> IMATH_HOSTDEVICE void getValue (Color4<S>& v) const;
+    template <class S> IMATH_HOSTDEVICE void getValue (Color4<S>& v) const noexcept;
 
-    IMATH_HOSTDEVICE T* getValue();
-    IMATH_HOSTDEVICE const T* getValue() const;
+    IMATH_HOSTDEVICE T* getValue() noexcept;
+    IMATH_HOSTDEVICE const T* getValue() const noexcept;
 
     //---------
     // Equality
     //---------
 
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Color4<S>& v) const;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Color4<S>& v) const noexcept;
 
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Color4<S>& v) const;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Color4<S>& v) const noexcept;
 
     //------------------------
     // Component-wise addition
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator+= (const Color4& v);
-    IMATH_HOSTDEVICE constexpr Color4 operator+ (const Color4& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator+= (const Color4& v) noexcept;
+    IMATH_HOSTDEVICE constexpr Color4 operator+ (const Color4& v) const noexcept;
 
     //---------------------------
     // Component-wise subtraction
     //---------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator-= (const Color4& v);
-    IMATH_HOSTDEVICE constexpr Color4 operator- (const Color4& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator-= (const Color4& v) noexcept;
+    IMATH_HOSTDEVICE constexpr Color4 operator- (const Color4& v) const noexcept;
 
     //------------------------------------
     // Component-wise multiplication by -1
     //------------------------------------
 
-    IMATH_HOSTDEVICE constexpr Color4 operator-() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& negate();
+    IMATH_HOSTDEVICE constexpr Color4 operator-() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& negate() noexcept;
 
     //------------------------------
     // Component-wise multiplication
     //------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator*= (const Color4& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator*= (T a);
-    IMATH_HOSTDEVICE constexpr Color4 operator* (const Color4& v) const;
-    IMATH_HOSTDEVICE constexpr Color4 operator* (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator*= (const Color4& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator*= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Color4 operator* (const Color4& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Color4 operator* (T a) const noexcept;
 
     //------------------------
     // Component-wise division
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator/= (const Color4& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator/= (T a);
-    IMATH_HOSTDEVICE constexpr Color4 operator/ (const Color4& v) const;
-    IMATH_HOSTDEVICE constexpr Color4 operator/ (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator/= (const Color4& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator/= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Color4 operator/ (const Color4& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Color4 operator/ (T a) const noexcept;
 
     //----------------------------------------------------------
     // Number of dimensions, i.e. number of elements in a Color4
     //----------------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() { return 4; }
+    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() noexcept { return 4; }
 
     //-------------------------------------------------
     // Limitations of type T (see also class limits<T>)
     //-------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static T baseTypeMin() { return limits<T>::min(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() { return limits<T>::max(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() { return limits<T>::smallest(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() { return limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMin() noexcept { return limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return limits<T>::smallest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return limits<T>::epsilon(); }
 
     //--------------------------------------------------------------
     // Base type -- in templates, which accept a parameter, V, which
@@ -234,7 +234,7 @@ template <class T> std::ostream& operator<< (std::ostream& s, const Color4<T>& v
 // Reverse multiplication: S * Color4<T>
 //----------------------------------------------------
 
-template <class S, class T> constexpr Color4<T> operator* (S a, const Color4<T>& v);
+template <class S, class T> constexpr Color4<T> operator* (S a, const Color4<T>& v) noexcept;
 
 //-------------------------
 // Typedefs for convenience
@@ -258,36 +258,36 @@ typedef unsigned int PackedColor;
 // Implementation of Color3
 //-------------------------
 
-template <class T> inline Color3<T>::Color3() : Vec3<T>()
+template <class T> inline Color3<T>::Color3() noexcept : Vec3<T>()
 {
     // empty
 }
 
-template <class T> constexpr inline Color3<T>::Color3 (T a) : Vec3<T> (a)
+template <class T> constexpr inline Color3<T>::Color3 (T a) noexcept : Vec3<T> (a)
 {
     // empty
 }
 
-template <class T> constexpr inline Color3<T>::Color3 (T a, T b, T c) : Vec3<T> (a, b, c)
+template <class T> constexpr inline Color3<T>::Color3 (T a, T b, T c) noexcept : Vec3<T> (a, b, c)
 {
     // empty
 }
 
-template <class T> constexpr inline Color3<T>::Color3 (const Color3& c) : Vec3<T> (c)
+template <class T> constexpr inline Color3<T>::Color3 (const Color3& c) noexcept : Vec3<T> (c)
 {
     // empty
 }
 
 template <class T>
 template <class S>
-constexpr inline Color3<T>::Color3 (const Vec3<S>& v) : Vec3<T> (v)
+constexpr inline Color3<T>::Color3 (const Vec3<S>& v) noexcept : Vec3<T> (v)
 {
     //empty
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::operator= (const Color3& c)
+Color3<T>::operator= (const Color3& c) noexcept
 {
     *((Vec3<T>*) this) = c;
     return *this;
@@ -295,7 +295,7 @@ Color3<T>::operator= (const Color3& c)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::operator+= (const Color3& c)
+Color3<T>::operator+= (const Color3& c) noexcept
 {
     *((Vec3<T>*) this) += c;
     return *this;
@@ -303,14 +303,14 @@ Color3<T>::operator+= (const Color3& c)
 
 template <class T>
 constexpr inline Color3<T>
-Color3<T>::operator+ (const Color3& c) const
+Color3<T>::operator+ (const Color3& c) const noexcept
 {
     return Color3 (*(Vec3<T>*) this + (const Vec3<T>&) c);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::operator-= (const Color3& c)
+Color3<T>::operator-= (const Color3& c) noexcept
 {
     *((Vec3<T>*) this) -= c;
     return *this;
@@ -318,21 +318,21 @@ Color3<T>::operator-= (const Color3& c)
 
 template <class T>
 constexpr inline Color3<T>
-Color3<T>::operator- (const Color3& c) const
+Color3<T>::operator- (const Color3& c) const noexcept
 {
     return Color3 (*(Vec3<T>*) this - (const Vec3<T>&) c);
 }
 
 template <class T>
 constexpr inline Color3<T>
-Color3<T>::operator-() const
+Color3<T>::operator-() const noexcept
 {
     return Color3 (-(*(Vec3<T>*) this));
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::negate()
+Color3<T>::negate() noexcept
 {
     ((Vec3<T>*) this)->negate();
     return *this;
@@ -340,7 +340,7 @@ Color3<T>::negate()
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::operator*= (const Color3& c)
+Color3<T>::operator*= (const Color3& c) noexcept
 {
     *((Vec3<T>*) this) *= c;
     return *this;
@@ -348,7 +348,7 @@ Color3<T>::operator*= (const Color3& c)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::operator*= (T a)
+Color3<T>::operator*= (T a) noexcept
 {
     *((Vec3<T>*) this) *= a;
     return *this;
@@ -356,21 +356,21 @@ Color3<T>::operator*= (T a)
 
 template <class T>
 constexpr inline Color3<T>
-Color3<T>::operator* (const Color3& c) const
+Color3<T>::operator* (const Color3& c) const noexcept
 {
     return Color3 (*(Vec3<T>*) this * (const Vec3<T>&) c);
 }
 
 template <class T>
 constexpr inline Color3<T>
-Color3<T>::operator* (T a) const
+Color3<T>::operator* (T a) const noexcept
 {
     return Color3 (*(Vec3<T>*) this * a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::operator/= (const Color3& c)
+Color3<T>::operator/= (const Color3& c) noexcept
 {
     *((Vec3<T>*) this) /= c;
     return *this;
@@ -378,7 +378,7 @@ Color3<T>::operator/= (const Color3& c)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::operator/= (T a)
+Color3<T>::operator/= (T a) noexcept
 {
     *((Vec3<T>*) this) /= a;
     return *this;
@@ -386,14 +386,14 @@ Color3<T>::operator/= (T a)
 
 template <class T>
 constexpr inline Color3<T>
-Color3<T>::operator/ (const Color3& c) const
+Color3<T>::operator/ (const Color3& c) const noexcept
 {
     return Color3 (*(Vec3<T>*) this / (const Vec3<T>&) c);
 }
 
 template <class T>
 constexpr inline Color3<T>
-Color3<T>::operator/ (T a) const
+Color3<T>::operator/ (T a) const noexcept
 {
     return Color3 (*(Vec3<T>*) this / a);
 }
@@ -404,29 +404,29 @@ Color3<T>::operator/ (T a) const
 
 template <class T>
 inline T&
-Color4<T>::operator[] (int i)
+Color4<T>::operator[] (int i) noexcept
 {
     return (&r)[i];
 }
 
 template <class T>
 inline const T&
-Color4<T>::operator[] (int i) const
+Color4<T>::operator[] (int i) const noexcept
 {
     return (&r)[i];
 }
 
-template <class T> inline Color4<T>::Color4()
+template <class T> inline Color4<T>::Color4() noexcept
 {
     // empty
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x)
+template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x) noexcept
 {
     r = g = b = a = x;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x, T y, T z, T w)
+template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x, T y, T z, T w) noexcept
 {
     r = x;
     g = y;
@@ -434,7 +434,7 @@ template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x, T y, T z, T 
     a = w;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4& v)
+template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4& v) noexcept
 {
     r = v.r;
     g = v.g;
@@ -444,7 +444,7 @@ template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4& v)
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4<S>& v)
+IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4<S>& v) noexcept
 {
     r = T (v.r);
     g = T (v.g);
@@ -454,7 +454,7 @@ IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4<S>& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::operator= (const Color4& v)
+Color4<T>::operator= (const Color4& v) noexcept
 {
     r = v.r;
     g = v.g;
@@ -466,7 +466,7 @@ Color4<T>::operator= (const Color4& v)
 template <class T>
 template <class S>
 inline void
-Color4<T>::setValue (S x, S y, S z, S w)
+Color4<T>::setValue (S x, S y, S z, S w) noexcept
 {
     r = T (x);
     g = T (y);
@@ -477,7 +477,7 @@ Color4<T>::setValue (S x, S y, S z, S w)
 template <class T>
 template <class S>
 inline void
-Color4<T>::setValue (const Color4<S>& v)
+Color4<T>::setValue (const Color4<S>& v) noexcept
 {
     r = T (v.r);
     g = T (v.g);
@@ -488,7 +488,7 @@ Color4<T>::setValue (const Color4<S>& v)
 template <class T>
 template <class S>
 inline void
-Color4<T>::getValue (S& x, S& y, S& z, S& w) const
+Color4<T>::getValue (S& x, S& y, S& z, S& w) const noexcept
 {
     x = S (r);
     y = S (g);
@@ -499,7 +499,7 @@ Color4<T>::getValue (S& x, S& y, S& z, S& w) const
 template <class T>
 template <class S>
 inline void
-Color4<T>::getValue (Color4<S>& v) const
+Color4<T>::getValue (Color4<S>& v) const noexcept
 {
     v.r = S (r);
     v.g = S (g);
@@ -509,14 +509,14 @@ Color4<T>::getValue (Color4<S>& v) const
 
 template <class T>
 inline T*
-Color4<T>::getValue()
+Color4<T>::getValue() noexcept
 {
     return (T*) &r;
 }
 
 template <class T>
 inline const T*
-Color4<T>::getValue() const
+Color4<T>::getValue() const noexcept
 {
     return (const T*) &r;
 }
@@ -524,7 +524,7 @@ Color4<T>::getValue() const
 template <class T>
 template <class S>
 constexpr inline bool
-Color4<T>::operator== (const Color4<S>& v) const
+Color4<T>::operator== (const Color4<S>& v) const noexcept
 {
     return r == v.r && g == v.g && b == v.b && a == v.a;
 }
@@ -532,14 +532,14 @@ Color4<T>::operator== (const Color4<S>& v) const
 template <class T>
 template <class S>
 constexpr inline bool
-Color4<T>::operator!= (const Color4<S>& v) const
+Color4<T>::operator!= (const Color4<S>& v) const noexcept
 {
     return r != v.r || g != v.g || b != v.b || a != v.a;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::operator+= (const Color4& v)
+Color4<T>::operator+= (const Color4& v) noexcept
 {
     r += v.r;
     g += v.g;
@@ -550,14 +550,14 @@ Color4<T>::operator+= (const Color4& v)
 
 template <class T>
 constexpr inline Color4<T>
-Color4<T>::operator+ (const Color4& v) const
+Color4<T>::operator+ (const Color4& v) const noexcept
 {
     return Color4 (r + v.r, g + v.g, b + v.b, a + v.a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::operator-= (const Color4& v)
+Color4<T>::operator-= (const Color4& v) noexcept
 {
     r -= v.r;
     g -= v.g;
@@ -568,21 +568,21 @@ Color4<T>::operator-= (const Color4& v)
 
 template <class T>
 constexpr inline Color4<T>
-Color4<T>::operator- (const Color4& v) const
+Color4<T>::operator- (const Color4& v) const noexcept
 {
     return Color4 (r - v.r, g - v.g, b - v.b, a - v.a);
 }
 
 template <class T>
 constexpr inline Color4<T>
-Color4<T>::operator-() const
+Color4<T>::operator-() const noexcept
 {
     return Color4 (-r, -g, -b, -a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::negate()
+Color4<T>::negate() noexcept
 {
     r = -r;
     g = -g;
@@ -593,7 +593,7 @@ Color4<T>::negate()
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::operator*= (const Color4& v)
+Color4<T>::operator*= (const Color4& v) noexcept
 {
     r *= v.r;
     g *= v.g;
@@ -604,7 +604,7 @@ Color4<T>::operator*= (const Color4& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::operator*= (T x)
+Color4<T>::operator*= (T x) noexcept
 {
     r *= x;
     g *= x;
@@ -615,21 +615,21 @@ Color4<T>::operator*= (T x)
 
 template <class T>
 constexpr inline Color4<T>
-Color4<T>::operator* (const Color4& v) const
+Color4<T>::operator* (const Color4& v) const noexcept
 {
     return Color4 (r * v.r, g * v.g, b * v.b, a * v.a);
 }
 
 template <class T>
 constexpr inline Color4<T>
-Color4<T>::operator* (T x) const
+Color4<T>::operator* (T x) const noexcept
 {
     return Color4 (r * x, g * x, b * x, a * x);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::operator/= (const Color4& v)
+Color4<T>::operator/= (const Color4& v) noexcept
 {
     r /= v.r;
     g /= v.g;
@@ -640,7 +640,7 @@ Color4<T>::operator/= (const Color4& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::operator/= (T x)
+Color4<T>::operator/= (T x) noexcept
 {
     r /= x;
     g /= x;
@@ -651,14 +651,14 @@ Color4<T>::operator/= (T x)
 
 template <class T>
 constexpr inline Color4<T>
-Color4<T>::operator/ (const Color4& v) const
+Color4<T>::operator/ (const Color4& v) const noexcept
 {
     return Color4 (r / v.r, g / v.g, b / v.b, a / v.a);
 }
 
 template <class T>
 constexpr inline Color4<T>
-Color4<T>::operator/ (T x) const
+Color4<T>::operator/ (T x) const noexcept
 {
     return Color4 (r / x, g / x, b / x, a / x);
 }
@@ -676,7 +676,7 @@ operator<< (std::ostream& s, const Color4<T>& v)
 
 template <class S, class T>
 constexpr inline Color4<T>
-operator* (S x, const Color4<T>& v)
+operator* (S x, const Color4<T>& v) noexcept
 {
     return Color4<T> (x * v.r, x * v.g, x * v.b, x * v.a);
 }

--- a/src/Imath/ImathColorAlgo.cpp
+++ b/src/Imath/ImathColorAlgo.cpp
@@ -43,7 +43,7 @@
 IMATH_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 Vec3<double>
-hsv2rgb_d (const Vec3<double>& hsv)
+hsv2rgb_d (const Vec3<double>& hsv) noexcept
 {
     double hue = hsv.x;
     double sat = hsv.y;
@@ -100,7 +100,7 @@ hsv2rgb_d (const Vec3<double>& hsv)
 }
 
 Color4<double>
-hsv2rgb_d (const Color4<double>& hsv)
+hsv2rgb_d (const Color4<double>& hsv) noexcept
 {
     double hue = hsv.r;
     double sat = hsv.g;
@@ -157,7 +157,7 @@ hsv2rgb_d (const Color4<double>& hsv)
 }
 
 Vec3<double>
-rgb2hsv_d (const Vec3<double>& c)
+rgb2hsv_d (const Vec3<double>& c) noexcept
 {
     const double& x = c.x;
     const double& y = c.y;
@@ -193,7 +193,7 @@ rgb2hsv_d (const Vec3<double>& c)
 }
 
 Color4<double>
-rgb2hsv_d (const Color4<double>& c)
+rgb2hsv_d (const Color4<double>& c) noexcept
 {
     const double& r = c.r;
     const double& g = c.g;

--- a/src/Imath/ImathColorAlgo.h
+++ b/src/Imath/ImathColorAlgo.h
@@ -48,13 +48,13 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 //	These routines eliminate type warnings under g++.
 //
 
-IMATH_EXPORT Vec3<double> hsv2rgb_d (const Vec3<double>& hsv);
+IMATH_EXPORT Vec3<double> hsv2rgb_d (const Vec3<double>& hsv) noexcept;
 
-IMATH_EXPORT Color4<double> hsv2rgb_d (const Color4<double>& hsv);
+IMATH_EXPORT Color4<double> hsv2rgb_d (const Color4<double>& hsv) noexcept;
 
-IMATH_EXPORT Vec3<double> rgb2hsv_d (const Vec3<double>& rgb);
+IMATH_EXPORT Vec3<double> rgb2hsv_d (const Vec3<double>& rgb) noexcept;
 
-IMATH_EXPORT Color4<double> rgb2hsv_d (const Color4<double>& rgb);
+IMATH_EXPORT Color4<double> rgb2hsv_d (const Color4<double>& rgb) noexcept;
 
 //
 //	Color conversion functions and general color algorithms
@@ -65,7 +65,7 @@ IMATH_EXPORT Color4<double> rgb2hsv_d (const Color4<double>& rgb);
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T>
-hsv2rgb (const Vec3<T>& hsv)
+hsv2rgb (const Vec3<T>& hsv) noexcept
 {
     if (limits<T>::isIntegral())
     {
@@ -87,7 +87,7 @@ hsv2rgb (const Vec3<T>& hsv)
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4<T>
-hsv2rgb (const Color4<T>& hsv)
+hsv2rgb (const Color4<T>& hsv) noexcept
 {
     if (limits<T>::isIntegral())
     {
@@ -111,7 +111,7 @@ hsv2rgb (const Color4<T>& hsv)
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T>
-rgb2hsv (const Vec3<T>& rgb)
+rgb2hsv (const Vec3<T>& rgb) noexcept
 {
     if (limits<T>::isIntegral())
     {
@@ -133,7 +133,7 @@ rgb2hsv (const Vec3<T>& rgb)
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4<T>
-rgb2hsv (const Color4<T>& rgb)
+rgb2hsv (const Color4<T>& rgb) noexcept
 {
     if (limits<T>::isIntegral())
     {
@@ -157,7 +157,7 @@ rgb2hsv (const Color4<T>& rgb)
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 PackedColor
-rgb2packed (const Vec3<T>& c)
+rgb2packed (const Vec3<T>& c) noexcept
 {
     if (limits<T>::isIntegral())
     {
@@ -178,7 +178,7 @@ rgb2packed (const Vec3<T>& c)
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 PackedColor
-rgb2packed (const Color4<T>& c)
+rgb2packed (const Color4<T>& c) noexcept
 {
     if (limits<T>::isIntegral())
     {
@@ -207,7 +207,7 @@ rgb2packed (const Color4<T>& c)
 
 template <class T>
 IMATH_HOSTDEVICE void
-packed2rgb (PackedColor packed, Vec3<T>& out)
+packed2rgb (PackedColor packed, Vec3<T>& out) noexcept
 {
     if (limits<T>::isIntegral())
     {
@@ -227,7 +227,7 @@ packed2rgb (PackedColor packed, Vec3<T>& out)
 
 template <class T>
 IMATH_HOSTDEVICE void
-packed2rgb (PackedColor packed, Color4<T>& out)
+packed2rgb (PackedColor packed, Color4<T>& out) noexcept
 {
     if (limits<T>::isIntegral())
     {

--- a/src/Imath/ImathEuler.h
+++ b/src/Imath/ImathEuler.h
@@ -219,17 +219,17 @@ template <class T> class Euler : public Vec3<T>
     // function, defined in ImathMatrixAlgo.h.
     //--------------------------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr Euler();
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Euler&);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (Order p);
+    IMATH_HOSTDEVICE constexpr Euler() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Euler&) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (Order p) noexcept;
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Vec3<T>& v,
                                               Order o       = Default,
-                                              InputLayout l = IJKLayout);
+                                              InputLayout l = IJKLayout) noexcept;
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14
-    Euler (T i, T j, T k, Order o = Default, InputLayout l = IJKLayout);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Euler<T>& euler, Order newp);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Matrix33<T>&, Order o = Default);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Matrix44<T>&, Order o = Default);
+    Euler (T i, T j, T k, Order o = Default, InputLayout l = IJKLayout) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Euler<T>& euler, Order newp) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Matrix33<T>&, Order o = Default) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Matrix44<T>&, Order o = Default) noexcept;
 
     //-------------
     //  Destructor
@@ -241,8 +241,8 @@ template <class T> class Euler : public Vec3<T>
     //  Algebraic functions/ Operators
     //---------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Euler<T>& operator= (const Euler<T>&);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Euler<T>& operator= (const Vec3<T>&);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Euler<T>& operator= (const Euler<T>&) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Euler<T>& operator= (const Vec3<T>&) noexcept;
 
     //--------------------------------------------------------
     //	Set the euler value
@@ -250,14 +250,14 @@ template <class T> class Euler : public Vec3<T>
     //	does reorder the input vector.
     //--------------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static bool legal (Order);
+    IMATH_HOSTDEVICE constexpr static bool legal (Order) noexcept;
 
-    IMATH_HOSTDEVICE void setXYZVector (const Vec3<T>&);
+    IMATH_HOSTDEVICE void setXYZVector (const Vec3<T>&) noexcept;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Order order() const;
-    IMATH_HOSTDEVICE void setOrder (Order);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Order order() const noexcept;
+    IMATH_HOSTDEVICE void setOrder (Order) noexcept;
 
-    IMATH_HOSTDEVICE void set (Axis initial, bool relative, bool parityEven, bool firstRepeats);
+    IMATH_HOSTDEVICE void set (Axis initial, bool relative, bool parityEven, bool firstRepeats) noexcept;
 
     //------------------------------------------------------------
     //	Conversions, toXYZVector() reorders the angles so that
@@ -273,26 +273,26 @@ template <class T> class Euler : public Vec3<T>
     // in ImathMatrixAlgo.h.
     //------------------------------------------------------------
 
-    IMATH_HOSTDEVICE void extract (const Matrix33<T>&);
-    IMATH_HOSTDEVICE void extract (const Matrix44<T>&);
-    IMATH_HOSTDEVICE void extract (const Quat<T>&);
-    IMATH_HOSTDEVICE Matrix33<T> toMatrix33() const;
-    IMATH_HOSTDEVICE Matrix44<T> toMatrix44() const;
-    IMATH_HOSTDEVICE Quat<T> toQuat() const;
-    IMATH_HOSTDEVICE Vec3<T> toXYZVector() const;
+    IMATH_HOSTDEVICE void extract (const Matrix33<T>&) noexcept;
+    IMATH_HOSTDEVICE void extract (const Matrix44<T>&) noexcept;
+    IMATH_HOSTDEVICE void extract (const Quat<T>&) noexcept;
+    IMATH_HOSTDEVICE Matrix33<T> toMatrix33() const noexcept;
+    IMATH_HOSTDEVICE Matrix44<T> toMatrix44() const noexcept;
+    IMATH_HOSTDEVICE Quat<T> toQuat() const noexcept;
+    IMATH_HOSTDEVICE Vec3<T> toXYZVector() const noexcept;
 
     //---------------------------------------------------
     //	Use this function to unpack angles from ijk form
     //---------------------------------------------------
 
-    IMATH_HOSTDEVICE void angleOrder (int& i, int& j, int& k) const;
+    IMATH_HOSTDEVICE void angleOrder (int& i, int& j, int& k) const noexcept;
 
     //---------------------------------------------------
     //	Use this function to determine mapping from xyz to ijk
     // - reshuffles the xyz to match the order
     //---------------------------------------------------
 
-    IMATH_HOSTDEVICE void angleMapping (int& i, int& j, int& k) const;
+    IMATH_HOSTDEVICE void angleMapping (int& i, int& j, int& k) const noexcept;
 
     //----------------------------------------------------------------------
     //
@@ -318,13 +318,13 @@ template <class T> class Euler : public Vec3<T>
     //
     //-----------------------------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 static float angleMod (T angle);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 static float angleMod (T angle) noexcept;
 
-    IMATH_HOSTDEVICE static void simpleXYZRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot);
+    IMATH_HOSTDEVICE static void simpleXYZRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot) noexcept;
     IMATH_HOSTDEVICE static void
-    nearestRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot, Order order = XYZ);
+    nearestRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot, Order order = XYZ) noexcept;
 
-    IMATH_HOSTDEVICE void makeNear (const Euler<T>& target);
+    IMATH_HOSTDEVICE void makeNear (const Euler<T>& target) noexcept;
 
     IMATH_HOSTDEVICE constexpr bool frameStatic() const { return _frameStatic; }
     IMATH_HOSTDEVICE constexpr bool initialRepeated() const { return _initialRepeated; }
@@ -355,7 +355,7 @@ typedef Euler<double> Eulerd;
 
 template <class T>
 inline void
-Euler<T>::angleOrder (int& i, int& j, int& k) const
+Euler<T>::angleOrder (int& i, int& j, int& k) const noexcept
 {
     i = _initialAxis;
     j = _parityEven ? (i + 1) % 3 : (i > 0 ? i - 1 : 2);
@@ -364,7 +364,7 @@ Euler<T>::angleOrder (int& i, int& j, int& k) const
 
 template <class T>
 inline void
-Euler<T>::angleMapping (int& i, int& j, int& k) const
+Euler<T>::angleMapping (int& i, int& j, int& k) const noexcept
 {
     int m[3];
 
@@ -378,7 +378,7 @@ Euler<T>::angleMapping (int& i, int& j, int& k) const
 
 template <class T>
 inline void
-Euler<T>::setXYZVector (const Vec3<T>& v)
+Euler<T>::setXYZVector (const Vec3<T>& v) noexcept
 {
     int i, j, k;
     angleMapping (i, j, k);
@@ -389,7 +389,7 @@ Euler<T>::setXYZVector (const Vec3<T>& v)
 
 template <class T>
 inline Vec3<T>
-Euler<T>::toXYZVector() const
+Euler<T>::toXYZVector() const noexcept
 {
     int i, j, k;
     angleMapping (i, j, k);
@@ -397,7 +397,7 @@ Euler<T>::toXYZVector() const
 }
 
 template <class T>
-constexpr inline Euler<T>::Euler()
+constexpr inline Euler<T>::Euler() noexcept
     : Vec3<T> (0, 0, 0),
       _frameStatic (true),
       _initialRepeated (false),
@@ -406,7 +406,7 @@ constexpr inline Euler<T>::Euler()
 {}
 
 template <class T>
-IMATH_CONSTEXPR14 inline Euler<T>::Euler (typename Euler<T>::Order p)
+IMATH_CONSTEXPR14 inline Euler<T>::Euler (typename Euler<T>::Order p) noexcept
     : Vec3<T> (0, 0, 0),
       _frameStatic (true),
       _initialRepeated (false),
@@ -419,7 +419,7 @@ IMATH_CONSTEXPR14 inline Euler<T>::Euler (typename Euler<T>::Order p)
 template <class T>
 IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Vec3<T>& v,
                                           typename Euler<T>::Order p,
-                                          typename Euler<T>::InputLayout l)
+                                          typename Euler<T>::InputLayout l) noexcept
 {
     setOrder (p);
     if (l == XYZLayout)
@@ -432,12 +432,12 @@ IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Vec3<T>& v,
     }
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Euler<T>& euler)
+template <class T> IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Euler<T>& euler) noexcept
 {
     operator= (euler);
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Euler<T>& euler, Order p)
+template <class T> IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Euler<T>& euler, Order p) noexcept
 {
     setOrder (p);
     Matrix33<T> M = euler.toMatrix33();
@@ -449,7 +449,7 @@ IMATH_CONSTEXPR14 inline Euler<T>::Euler (T xi,
                                           T yi,
                                           T zi,
                                           typename Euler<T>::Order p,
-                                          typename Euler<T>::InputLayout l)
+                                          typename Euler<T>::InputLayout l) noexcept
 {
     setOrder (p);
     if (l == XYZLayout)
@@ -463,14 +463,14 @@ IMATH_CONSTEXPR14 inline Euler<T>::Euler (T xi,
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Matrix33<T>& M, typename Euler::Order p)
+IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Matrix33<T>& M, typename Euler::Order p) noexcept
 {
     setOrder (p);
     extract (M);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Matrix44<T>& M, typename Euler::Order p)
+IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Matrix44<T>& M, typename Euler::Order p) noexcept
 {
     setOrder (p);
     extract (M);
@@ -478,14 +478,14 @@ IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Matrix44<T>& M, typename Euler::
 
 template <class T>
 inline void
-Euler<T>::extract (const Quat<T>& q)
+Euler<T>::extract (const Quat<T>& q) noexcept
 {
     extract (q.toMatrix33());
 }
 
 template <class T>
 void
-Euler<T>::extract (const Matrix33<T>& M)
+Euler<T>::extract (const Matrix33<T>& M) noexcept
 {
     int i, j, k;
     angleOrder (i, j, k);
@@ -592,7 +592,7 @@ Euler<T>::extract (const Matrix33<T>& M)
 
 template <class T>
 void
-Euler<T>::extract (const Matrix44<T>& M)
+Euler<T>::extract (const Matrix44<T>& M) noexcept
 {
     int i, j, k;
     angleOrder (i, j, k);
@@ -669,7 +669,7 @@ Euler<T>::extract (const Matrix44<T>& M)
 
 template <class T>
 Matrix33<T>
-Euler<T>::toMatrix33() const
+Euler<T>::toMatrix33() const noexcept
 {
     int i, j, k;
     angleOrder (i, j, k);
@@ -728,7 +728,7 @@ Euler<T>::toMatrix33() const
 
 template <class T>
 Matrix44<T>
-Euler<T>::toMatrix44() const
+Euler<T>::toMatrix44() const noexcept
 {
     int i, j, k;
     angleOrder (i, j, k);
@@ -787,7 +787,7 @@ Euler<T>::toMatrix44() const
 
 template <class T>
 Quat<T>
-Euler<T>::toQuat() const
+Euler<T>::toQuat() const noexcept
 {
     Vec3<T> angles;
     int i, j, k;
@@ -842,14 +842,14 @@ Euler<T>::toQuat() const
 
 template <class T>
 constexpr inline bool
-Euler<T>::legal (typename Euler<T>::Order order)
+Euler<T>::legal (typename Euler<T>::Order order) noexcept
 {
     return (order & ~Legal) ? false : true;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 typename Euler<T>::Order
-Euler<T>::order() const
+Euler<T>::order() const noexcept
 {
     int foo = (_initialAxis == Z ? 0x2000 : (_initialAxis == Y ? 0x1000 : 0));
 
@@ -865,7 +865,7 @@ Euler<T>::order() const
 
 template <class T>
 inline void
-Euler<T>::setOrder (typename Euler<T>::Order p)
+Euler<T>::setOrder (typename Euler<T>::Order p) noexcept
 {
     set (p & 0x2000 ? Z : (p & 0x1000 ? Y : X), // initial axis
          !(p & 0x1),                            // static?
@@ -875,7 +875,7 @@ Euler<T>::setOrder (typename Euler<T>::Order p)
 
 template <class T>
 inline void
-Euler<T>::set (typename Euler<T>::Axis axis, bool relative, bool parityEven, bool firstRepeats)
+Euler<T>::set (typename Euler<T>::Axis axis, bool relative, bool parityEven, bool firstRepeats) noexcept
 {
     _initialAxis     = axis;
     _frameStatic     = !relative;
@@ -885,7 +885,7 @@ Euler<T>::set (typename Euler<T>::Axis axis, bool relative, bool parityEven, boo
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Euler<T>&
-Euler<T>::operator= (const Euler<T>& euler)
+Euler<T>::operator= (const Euler<T>& euler) noexcept
 {
     x                = euler.x;
     y                = euler.y;
@@ -899,7 +899,7 @@ Euler<T>::operator= (const Euler<T>& euler)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Euler<T>&
-Euler<T>::operator= (const Vec3<T>& v)
+Euler<T>::operator= (const Vec3<T>& v) noexcept
 {
     x = v.x;
     y = v.y;
@@ -909,7 +909,7 @@ Euler<T>::operator= (const Vec3<T>& v)
 
 template <class T>
 std::ostream&
-operator<< (std::ostream& o, const Euler<T>& euler)
+operator<< (std::ostream& o, const Euler<T>& euler) noexcept
 {
     char a[3] = { 'X', 'Y', 'Z' };
 
@@ -926,7 +926,7 @@ operator<< (std::ostream& o, const Euler<T>& euler)
 
 template <class T>
 IMATH_CONSTEXPR14 inline float
-Euler<T>::angleMod (T angle)
+Euler<T>::angleMod (T angle) noexcept
 {
     const T pi = static_cast<T> (M_PI);
     angle      = fmod (T (angle), T (2 * pi));
@@ -941,7 +941,7 @@ Euler<T>::angleMod (T angle)
 
 template <class T>
 inline void
-Euler<T>::simpleXYZRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot)
+Euler<T>::simpleXYZRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot) noexcept
 {
     Vec3<T> d = xyzRot - targetXyzRot;
     xyzRot[0] = targetXyzRot[0] + angleMod (d[0]);
@@ -951,7 +951,7 @@ Euler<T>::simpleXYZRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot)
 
 template <class T>
 void
-Euler<T>::nearestRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot, Order order)
+Euler<T>::nearestRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot, Order order) noexcept
 {
     int i, j, k;
     Euler<T> e (0, 0, 0, order);
@@ -979,7 +979,7 @@ Euler<T>::nearestRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot, Order o
 
 template <class T>
 void
-Euler<T>::makeNear (const Euler<T>& target)
+Euler<T>::makeNear (const Euler<T>& target) noexcept
 {
     Vec3<T> xyzRot = toXYZVector();
     Vec3<T> targetXyz;

--- a/src/Imath/ImathFrame.h
+++ b/src/Imath/ImathFrame.h
@@ -63,19 +63,19 @@ template <class T> class Matrix44;
 template <class T>
 Matrix44<T> constexpr firstFrame (const Vec3<T>&,  // First point
                                   const Vec3<T>&,  // Second point
-                                  const Vec3<T>&); // Third point
+                                  const Vec3<T>&) noexcept; // Third point
 
 template <class T>
 Matrix44<T> constexpr nextFrame (const Matrix44<T>&, // Previous matrix
                                  const Vec3<T>&,     // Previous point
                                  const Vec3<T>&,     // Current point
                                  Vec3<T>&,           // Previous tangent
-                                 Vec3<T>&);          // Current tangent
+                                 Vec3<T>&) noexcept;          // Current tangent
 
 template <class T>
 Matrix44<T> constexpr lastFrame (const Matrix44<T>&, // Previous matrix
                                  const Vec3<T>&,     // Previous point
-                                 const Vec3<T>&);    // Last point
+                                 const Vec3<T>&) noexcept;    // Last point
 
 //
 //  firstFrame - Compute the first reference frame along a curve.
@@ -91,7 +91,7 @@ Matrix44<T> constexpr lastFrame (const Matrix44<T>&, // Previous matrix
 template <class T>
 Matrix44<T> constexpr firstFrame (const Vec3<T>& pi, // First point
                                   const Vec3<T>& pj, // Second point
-                                  const Vec3<T>& pk) // Third point
+                                  const Vec3<T>& pk) noexcept // Third point
 {
     Vec3<T> t = pj - pi;
     t.normalizeExc();
@@ -144,7 +144,7 @@ Matrix44<T> constexpr nextFrame (const Matrix44<T>& Mi, // Previous matrix
                                  const Vec3<T>& pi,     // Previous point
                                  const Vec3<T>& pj,     // Current point
                                  Vec3<T>& ti,           // Previous tangent vector
-                                 Vec3<T>& tj)           // Current tangent vector
+                                 Vec3<T>& tj) noexcept  // Current tangent vector
 {
     Vec3<T> a (0.0, 0.0, 0.0); // Rotation axis.
     T r = 0.0;                 // Rotation angle.
@@ -199,7 +199,7 @@ Matrix44<T> constexpr nextFrame (const Matrix44<T>& Mi, // Previous matrix
 template <class T>
 Matrix44<T> constexpr lastFrame (const Matrix44<T>& Mi, // Previous matrix
                                  const Vec3<T>& pi,     // Previous point
-                                 const Vec3<T>& pj)     // Last point
+                                 const Vec3<T>& pj) noexcept // Last point
 {
     Matrix44<T> Tr;
     Tr.translate (pj - pi);

--- a/src/Imath/ImathFrustum.h
+++ b/src/Imath/ImathFrustum.h
@@ -63,32 +63,32 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 template <class T> class Frustum
 {
   public:
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Frustum();
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Frustum (const Frustum&);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Frustum() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Frustum (const Frustum&) noexcept;
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14
-    Frustum (T nearPlane, T farPlane, T left, T right, T top, T bottom, bool ortho = false);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Frustum (T nearPlane, T farPlane, T fovx, T fovy, T aspect);
-    virtual ~Frustum();
+    Frustum (T nearPlane, T farPlane, T left, T right, T top, T bottom, bool ortho = false) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Frustum (T nearPlane, T farPlane, T fovx, T fovy, T aspect) noexcept;
+    virtual ~Frustum() noexcept;
 
     //--------------------
     // Assignment operator
     //--------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Frustum& operator= (const Frustum&);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Frustum& operator= (const Frustum&) noexcept;
 
     //--------------------
     //  Operators:  ==, !=
     //--------------------
 
-    IMATH_HOSTDEVICE constexpr bool operator== (const Frustum<T>& src) const;
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Frustum<T>& src) const;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Frustum<T>& src) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Frustum<T>& src) const noexcept;
 
     //--------------------------------------------------------
     //  Set functions change the entire state of the Frustum
     //--------------------------------------------------------
 
     IMATH_HOSTDEVICE void
-    set (T nearPlane, T farPlane, T left, T right, T top, T bottom, bool ortho = false);
+    set (T nearPlane, T farPlane, T left, T right, T top, T bottom, bool ortho = false) noexcept;
 
     IMATH_HOSTDEVICE void set (T nearPlane, T farPlane, T fovx, T fovy, T aspect) noexcept;
     void setExc (T nearPlane, T farPlane, T fovx, T fovy, T aspect);
@@ -97,22 +97,22 @@ template <class T> class Frustum
     //	These functions modify an already valid frustum state
     //------------------------------------------------------
 
-    IMATH_HOSTDEVICE void modifyNearAndFar (T nearPlane, T farPlane);
-    IMATH_HOSTDEVICE void setOrthographic (bool);
+    IMATH_HOSTDEVICE void modifyNearAndFar (T nearPlane, T farPlane) noexcept;
+    IMATH_HOSTDEVICE void setOrthographic (bool) noexcept;
 
     //--------------
     //  Access
     //--------------
 
-    IMATH_HOSTDEVICE constexpr bool orthographic() const { return _orthographic; }
-    IMATH_HOSTDEVICE constexpr T nearPlane() const { return _nearPlane; }
-    IMATH_HOSTDEVICE constexpr T hither() const { return _nearPlane; }
-    IMATH_HOSTDEVICE constexpr T farPlane() const { return _farPlane; }
-    IMATH_HOSTDEVICE constexpr T yon() const { return _farPlane; }
-    IMATH_HOSTDEVICE constexpr T left() const { return _left; }
-    IMATH_HOSTDEVICE constexpr T right() const { return _right; }
-    IMATH_HOSTDEVICE constexpr T bottom() const { return _bottom; }
-    IMATH_HOSTDEVICE constexpr T top() const { return _top; }
+    IMATH_HOSTDEVICE constexpr bool orthographic() const noexcept { return _orthographic; }
+    IMATH_HOSTDEVICE constexpr T nearPlane() const noexcept { return _nearPlane; }
+    IMATH_HOSTDEVICE constexpr T hither() const noexcept { return _nearPlane; }
+    IMATH_HOSTDEVICE constexpr T farPlane() const noexcept { return _farPlane; }
+    IMATH_HOSTDEVICE constexpr T yon() const noexcept { return _farPlane; }
+    IMATH_HOSTDEVICE constexpr T left() const noexcept { return _left; }
+    IMATH_HOSTDEVICE constexpr T right() const noexcept { return _right; }
+    IMATH_HOSTDEVICE constexpr T bottom() const noexcept { return _bottom; }
+    IMATH_HOSTDEVICE constexpr T top() const noexcept { return _top; }
 
     //-----------------------------------------------------------------------
     //  Sets the planes in p to be the six bounding planes of the frustum, in
@@ -122,20 +122,20 @@ template <class T> class Frustum
     //  to transform the frustum before setting the planes.
     //-----------------------------------------------------------------------
 
-    IMATH_HOSTDEVICE void planes (Plane3<T> p[6]) const;
-    IMATH_HOSTDEVICE void planes (Plane3<T> p[6], const Matrix44<T>& M) const;
+    IMATH_HOSTDEVICE void planes (Plane3<T> p[6]) const noexcept;
+    IMATH_HOSTDEVICE void planes (Plane3<T> p[6], const Matrix44<T>& M) const noexcept;
 
     //----------------------
     //  Derived Quantities
     //----------------------
 
-    IMATH_HOSTDEVICE constexpr T fovx() const;
-    IMATH_HOSTDEVICE constexpr T fovy() const;
+    IMATH_HOSTDEVICE constexpr T fovx() const noexcept;
+    IMATH_HOSTDEVICE constexpr T fovy() const noexcept;
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T aspect() const noexcept;
     IMATH_CONSTEXPR14 T aspectExc() const;
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44<T> projectionMatrix() const noexcept;
     IMATH_CONSTEXPR14 Matrix44<T> projectionMatrixExc() const;
-    IMATH_HOSTDEVICE constexpr bool degenerate() const;
+    IMATH_HOSTDEVICE constexpr bool degenerate() const noexcept;
 
     //-----------------------------------------------------------------------
     //  Takes a rectangle in the screen space (i.e., -1 <= left <= right <= 1
@@ -145,13 +145,13 @@ template <class T> class Frustum
     //-----------------------------------------------------------------------
 
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 IMATH_HOSTDEVICE Frustum<T>
-    window (T left, T right, T top, T bottom) const;
+    window (T left, T right, T top, T bottom) const noexcept;
 
     //----------------------------------------------------------
     // Projection is in screen space / Conversion from Z-Buffer
     //----------------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Line3<T> projectScreenToRay (const Vec2<T>&) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Line3<T> projectScreenToRay (const Vec2<T>&) const noexcept;
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2<T> projectPointToScreen (const Vec3<T>&) const noexcept;
     IMATH_CONSTEXPR14 Vec2<T> projectPointToScreenExc (const Vec3<T>&) const;
 
@@ -164,14 +164,14 @@ template <class T> class Frustum
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 long
     DepthToZ (T depth, long zmin, long zmax) const noexcept;
     IMATH_CONSTEXPR14 long DepthToZExc (T depth, long zmin, long zmax) const;
-    
+
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T worldRadius (const Vec3<T>& p, T radius) const noexcept;
     IMATH_CONSTEXPR14 T worldRadiusExc (const Vec3<T>& p, T radius) const;
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T screenRadius (const Vec3<T>& p, T radius) const noexcept;
     IMATH_CONSTEXPR14 T screenRadiusExc (const Vec3<T>& p, T radius) const;
 
   protected:
-    IMATH_HOSTDEVICE constexpr Vec2<T> screenToLocal (const Vec2<T>&) const;
+    IMATH_HOSTDEVICE constexpr Vec2<T> screenToLocal (const Vec2<T>&) const noexcept;
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2<T>
     localToScreen (const Vec2<T>&) const noexcept;
     IMATH_CONSTEXPR14 Vec2<T> localToScreenExc (const Vec2<T>&) const;
@@ -186,34 +186,34 @@ template <class T> class Frustum
     bool _orthographic;
 };
 
-template <class T> IMATH_CONSTEXPR14 inline Frustum<T>::Frustum()
+template <class T> IMATH_CONSTEXPR14 inline Frustum<T>::Frustum() noexcept
 {
     set (T (0.1), T (1000.0), T (-1.0), T (1.0), T (1.0), T (-1.0), false);
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Frustum<T>::Frustum (const Frustum& f)
+template <class T> IMATH_CONSTEXPR14 inline Frustum<T>::Frustum (const Frustum& f) noexcept
 {
     *this = f;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Frustum<T>::Frustum (T n, T f, T l, T r, T t, T b, bool o)
+IMATH_CONSTEXPR14 inline Frustum<T>::Frustum (T n, T f, T l, T r, T t, T b, bool o) noexcept
 {
     set (n, f, l, r, t, b, o);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Frustum<T>::Frustum (T nearPlane, T farPlane, T fovx, T fovy, T aspect)
+IMATH_CONSTEXPR14 inline Frustum<T>::Frustum (T nearPlane, T farPlane, T fovx, T fovy, T aspect) noexcept
 {
     set (nearPlane, farPlane, fovx, fovy, aspect);
 }
 
-template <class T> Frustum<T>::~Frustum()
+template <class T> Frustum<T>::~Frustum() noexcept
 {}
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Frustum<T>&
-Frustum<T>::operator= (const Frustum& f)
+Frustum<T>::operator= (const Frustum& f) noexcept
 {
     _nearPlane    = f._nearPlane;
     _farPlane     = f._farPlane;
@@ -228,7 +228,7 @@ Frustum<T>::operator= (const Frustum& f)
 
 template <class T>
 constexpr inline bool
-Frustum<T>::operator== (const Frustum<T>& src) const
+Frustum<T>::operator== (const Frustum<T>& src) const noexcept
 {
     return _nearPlane == src._nearPlane && _farPlane == src._farPlane && _left == src._left &&
            _right == src._right && _top == src._top && _bottom == src._bottom &&
@@ -237,14 +237,14 @@ Frustum<T>::operator== (const Frustum<T>& src) const
 
 template <class T>
 constexpr inline bool
-Frustum<T>::operator!= (const Frustum<T>& src) const
+Frustum<T>::operator!= (const Frustum<T>& src) const noexcept
 {
     return !operator== (src);
 }
 
 template <class T>
 inline void
-Frustum<T>::set (T n, T f, T l, T r, T t, T b, bool o)
+Frustum<T>::set (T n, T f, T l, T r, T t, T b, bool o) noexcept
 {
     _nearPlane    = n;
     _farPlane     = f;
@@ -257,7 +257,7 @@ Frustum<T>::set (T n, T f, T l, T r, T t, T b, bool o)
 
 template <class T>
 inline void
-Frustum<T>::modifyNearAndFar (T n, T f)
+Frustum<T>::modifyNearAndFar (T n, T f) noexcept
 {
     if (_orthographic)
     {
@@ -287,7 +287,7 @@ Frustum<T>::modifyNearAndFar (T n, T f)
 
 template <class T>
 inline void
-Frustum<T>::setOrthographic (bool ortho)
+Frustum<T>::setOrthographic (bool ortho) noexcept
 {
     _orthographic = ortho;
 }
@@ -347,14 +347,14 @@ Frustum<T>::set (T nearPlane, T farPlane, T fovx, T fovy, T aspect) noexcept
 
 template <class T>
 constexpr inline T
-Frustum<T>::fovx() const
+Frustum<T>::fovx() const noexcept
 {
     return std::atan2 (_right, _nearPlane) - std::atan2 (_left, _nearPlane);
 }
 
 template <class T>
 constexpr inline T
-Frustum<T>::fovy() const
+Frustum<T>::fovy() const noexcept
 {
     return std::atan2 (_top, _nearPlane) - std::atan2 (_bottom, _nearPlane);
 }
@@ -506,14 +506,14 @@ Frustum<T>::projectionMatrix() const noexcept
 
 template <class T>
 constexpr inline bool
-Frustum<T>::degenerate() const
+Frustum<T>::degenerate() const noexcept
 {
     return (_nearPlane == _farPlane) || (_left == _right) || (_top == _bottom);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline Frustum<T>
-Frustum<T>::window (T l, T r, T t, T b) const
+Frustum<T>::window (T l, T r, T t, T b) const noexcept
 {
     // move it to 0->1 space
 
@@ -525,7 +525,7 @@ Frustum<T>::window (T l, T r, T t, T b) const
 
 template <class T>
 constexpr inline Vec2<T>
-Frustum<T>::screenToLocal (const Vec2<T>& s) const
+Frustum<T>::screenToLocal (const Vec2<T>& s) const noexcept
 {
     return Vec2<T> (_left + (_right - _left) * (1.f + s.x) / 2.f,
                     _bottom + (_top - _bottom) * (1.f + s.y) / 2.f);
@@ -566,7 +566,7 @@ Frustum<T>::localToScreen (const Vec2<T>& p) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline Line3<T>
-Frustum<T>::projectScreenToRay (const Vec2<T>& p) const
+Frustum<T>::projectScreenToRay (const Vec2<T>& p) const noexcept
 {
     Vec2<T> point = screenToLocal (p);
     if (orthographic())
@@ -813,7 +813,7 @@ Frustum<T>::worldRadius (const Vec3<T>& p, T radius) const noexcept
 
 template <class T>
 void
-Frustum<T>::planes (Plane3<T> p[6]) const
+Frustum<T>::planes (Plane3<T> p[6]) const noexcept
 {
     //
     //        Plane order: Top, Right, Bottom, Left, Near, Far.
@@ -846,7 +846,7 @@ Frustum<T>::planes (Plane3<T> p[6]) const
 
 template <class T>
 void
-Frustum<T>::planes (Plane3<T> p[6], const Matrix44<T>& M) const
+Frustum<T>::planes (Plane3<T> p[6], const Matrix44<T>& M) const noexcept
 {
     //
     //  Plane order: Top, Right, Bottom, Left, Near, Far.

--- a/src/Imath/ImathFrustumTest.h
+++ b/src/Imath/ImathFrustumTest.h
@@ -119,14 +119,14 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 template <class T> class FrustumTest
 {
   public:
-    FrustumTest()
+    FrustumTest() noexcept
     {
         Frustum<T> frust;
         Matrix44<T> cameraMat;
         cameraMat.makeIdentity();
         setFrustum (frust, cameraMat);
     }
-    FrustumTest (const Frustum<T>& frustum, const Matrix44<T>& cameraMat)
+    FrustumTest (const Frustum<T>& frustum, const Matrix44<T>& cameraMat) noexcept
     {
         setFrustum (frustum, cameraMat);
     }
@@ -135,26 +135,26 @@ template <class T> class FrustumTest
     // setFrustum()
     // This updates the frustum test with a new frustum and matrix.
     // This should usually be called just once per frame.
-    void setFrustum (const Frustum<T>& frustum, const Matrix44<T>& cameraMat);
+    void setFrustum (const Frustum<T>& frustum, const Matrix44<T>& cameraMat) noexcept;
 
     ////////////////////////////////////////////////////////////////////
     // isVisible()
     // Check to see if shapes are visible.
-    bool isVisible (const Sphere3<T>& sphere) const;
-    bool isVisible (const Box<Vec3<T>>& box) const;
-    bool isVisible (const Vec3<T>& vec) const;
+    bool isVisible (const Sphere3<T>& sphere) const noexcept;
+    bool isVisible (const Box<Vec3<T>>& box) const noexcept;
+    bool isVisible (const Vec3<T>& vec) const noexcept;
 
     ////////////////////////////////////////////////////////////////////
     // completelyContains()
     // Check to see if shapes are entirely contained.
-    bool completelyContains (const Sphere3<T>& sphere) const;
-    bool completelyContains (const Box<Vec3<T>>& box) const;
+    bool completelyContains (const Sphere3<T>& sphere) const noexcept;
+    bool completelyContains (const Box<Vec3<T>>& box) const noexcept;
 
     // These next items are kept primarily for debugging tools.
     // It's useful for drawing the culling environment, and also
     // for getting an "outside view" of the culling frustum.
-    IMATH_INTERNAL_NAMESPACE::Matrix44<T> cameraMat() const { return cameraMatrix; }
-    IMATH_INTERNAL_NAMESPACE::Frustum<T> currentFrustum() const { return currFrustum; }
+    IMATH_INTERNAL_NAMESPACE::Matrix44<T> cameraMat() const noexcept { return cameraMatrix; }
+    IMATH_INTERNAL_NAMESPACE::Frustum<T> currentFrustum() const noexcept { return currFrustum; }
 
   protected:
     // To understand why the planes are stored this way, see
@@ -181,7 +181,7 @@ template <class T> class FrustumTest
 // often the camera moves.
 template <class T>
 void
-FrustumTest<T>::setFrustum (const Frustum<T>& frustum, const Matrix44<T>& cameraMat)
+FrustumTest<T>::setFrustum (const Frustum<T>& frustum, const Matrix44<T>& cameraMat) noexcept
 {
     Plane3<T> frustumPlanes[6];
     frustum.planes (frustumPlanes, cameraMat);
@@ -202,15 +202,15 @@ FrustumTest<T>::setFrustum (const Frustum<T>& frustum, const Matrix44<T>& camera
                                  frustumPlanes[index + 1].normal.z,
                                  frustumPlanes[index + 2].normal.z);
 
-        planeNormAbsX[i] = Vec3<T> (IMATH_INTERNAL_NAMESPACE::abs (planeNormX[i].x),
-                                    IMATH_INTERNAL_NAMESPACE::abs (planeNormX[i].y),
-                                    IMATH_INTERNAL_NAMESPACE::abs (planeNormX[i].z));
-        planeNormAbsY[i] = Vec3<T> (IMATH_INTERNAL_NAMESPACE::abs (planeNormY[i].x),
-                                    IMATH_INTERNAL_NAMESPACE::abs (planeNormY[i].y),
-                                    IMATH_INTERNAL_NAMESPACE::abs (planeNormY[i].z));
-        planeNormAbsZ[i] = Vec3<T> (IMATH_INTERNAL_NAMESPACE::abs (planeNormZ[i].x),
-                                    IMATH_INTERNAL_NAMESPACE::abs (planeNormZ[i].y),
-                                    IMATH_INTERNAL_NAMESPACE::abs (planeNormZ[i].z));
+        planeNormAbsX[i] = Vec3<T> (std::abs (planeNormX[i].x),
+                                    std::abs (planeNormX[i].y),
+                                    std::abs (planeNormX[i].z));
+        planeNormAbsY[i] = Vec3<T> (std::abs (planeNormY[i].x),
+                                    std::abs (planeNormY[i].y),
+                                    std::abs (planeNormY[i].z));
+        planeNormAbsZ[i] = Vec3<T> (std::abs (planeNormZ[i].x),
+                                    std::abs (planeNormZ[i].y),
+                                    std::abs (planeNormZ[i].z));
 
         planeOffsetVec[i] = Vec3<T> (frustumPlanes[index + 0].distance,
                                      frustumPlanes[index + 1].distance,
@@ -228,7 +228,7 @@ FrustumTest<T>::setFrustum (const Frustum<T>& frustum, const Matrix44<T>& camera
 //
 template <typename T>
 bool
-FrustumTest<T>::isVisible (const Sphere3<T>& sphere) const
+FrustumTest<T>::isVisible (const Sphere3<T>& sphere) const noexcept
 {
     Vec3<T> center    = sphere.center;
     Vec3<T> radiusVec = Vec3<T> (sphere.radius, sphere.radius, sphere.radius);
@@ -257,7 +257,7 @@ FrustumTest<T>::isVisible (const Sphere3<T>& sphere) const
 //
 template <typename T>
 bool
-FrustumTest<T>::completelyContains (const Sphere3<T>& sphere) const
+FrustumTest<T>::completelyContains (const Sphere3<T>& sphere) const noexcept
 {
     Vec3<T> center    = sphere.center;
     Vec3<T> radiusVec = Vec3<T> (sphere.radius, sphere.radius, sphere.radius);
@@ -286,7 +286,7 @@ FrustumTest<T>::completelyContains (const Sphere3<T>& sphere) const
 //
 template <typename T>
 bool
-FrustumTest<T>::isVisible (const Box<Vec3<T>>& box) const
+FrustumTest<T>::isVisible (const Box<Vec3<T>>& box) const noexcept
 {
     if (box.isEmpty())
         return false;
@@ -320,7 +320,7 @@ FrustumTest<T>::isVisible (const Box<Vec3<T>>& box) const
 //
 template <typename T>
 bool
-FrustumTest<T>::completelyContains (const Box<Vec3<T>>& box) const
+FrustumTest<T>::completelyContains (const Box<Vec3<T>>& box) const noexcept
 {
     if (box.isEmpty())
         return false;
@@ -352,7 +352,7 @@ FrustumTest<T>::completelyContains (const Box<Vec3<T>>& box) const
 //
 template <typename T>
 bool
-FrustumTest<T>::isVisible (const Vec3<T>& vec) const
+FrustumTest<T>::isVisible (const Vec3<T>& vec) const noexcept
 {
     // This is a vertical dot-product on three vectors at once.
     Vec3<T> d0 = (planeNormX[0] * vec.x) + (planeNormY[0] * vec.y) + (planeNormZ[0] * vec.z) -

--- a/src/Imath/ImathFun.cpp
+++ b/src/Imath/ImathFun.cpp
@@ -37,7 +37,7 @@
 IMATH_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 float
-succf (float f)
+succf (float f) noexcept
 {
     union
     {
@@ -75,7 +75,7 @@ succf (float f)
 }
 
 float
-predf (float f)
+predf (float f) noexcept
 {
     union
     {
@@ -113,7 +113,7 @@ predf (float f)
 }
 
 double
-succd (double d)
+succd (double d) noexcept
 {
     union
     {
@@ -151,7 +151,7 @@ succd (double d)
 }
 
 double
-predd (double d)
+predd (double d) noexcept
 {
     union
     {

--- a/src/Imath/ImathFun.h
+++ b/src/Imath/ImathFun.h
@@ -51,35 +51,35 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline T
-abs (T a)
+abs (T a) noexcept
 {
     return (a > T (0)) ? a : -a;
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline int
-sign (T a)
+sign (T a) noexcept
 {
     return (a > T (0)) ? 1 : ((a < T (0)) ? -1 : 0);
 }
 
 template <class T, class Q>
 IMATH_HOSTDEVICE constexpr inline T
-lerp (T a, T b, Q t)
+lerp (T a, T b, Q t) noexcept
 {
     return (T) (a * (1 - t) + b * t);
 }
 
 template <class T, class Q>
 IMATH_HOSTDEVICE constexpr inline T
-ulerp (T a, T b, Q t)
+ulerp (T a, T b, Q t) noexcept
 {
     return (T) ((a > b) ? (a - (a - b) * t) : (a + (b - a) * t));
 }
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T
-lerpfactor (T m, T a, T b)
+lerpfactor (T m, T a, T b) noexcept
 {
     //
     // Return how far m is between a and b, that is return t such that
@@ -102,56 +102,56 @@ lerpfactor (T m, T a, T b)
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline T
-clamp (T a, T l, T h)
+clamp (T a, T l, T h) noexcept
 {
     return (a < l) ? l : ((a > h) ? h : a);
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline int
-cmp (T a, T b)
+cmp (T a, T b) noexcept
 {
     return IMATH_INTERNAL_NAMESPACE::sign (a - b);
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline int
-cmpt (T a, T b, T t)
+cmpt (T a, T b, T t) noexcept
 {
     return (IMATH_INTERNAL_NAMESPACE::abs (a - b) <= t) ? 0 : cmp (a, b);
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline bool
-iszero (T a, T t)
+iszero (T a, T t) noexcept
 {
     return (IMATH_INTERNAL_NAMESPACE::abs (a) <= t) ? 1 : 0;
 }
 
 template <class T1, class T2, class T3>
 IMATH_HOSTDEVICE constexpr inline bool
-equal (T1 a, T2 b, T3 t)
+equal (T1 a, T2 b, T3 t) noexcept
 {
     return IMATH_INTERNAL_NAMESPACE::abs (a - b) <= t;
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline int
-floor (T x)
+floor (T x) noexcept
 {
     return (x >= 0) ? int (x) : -(int (-x) + (-x > int (-x)));
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline int
-ceil (T x)
+ceil (T x) noexcept
 {
     return -floor (-x);
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline int
-trunc (T x)
+trunc (T x) noexcept
 {
     return (x >= 0) ? int (x) : -int (-x);
 }
@@ -165,13 +165,13 @@ trunc (T x)
 //
 
 IMATH_HOSTDEVICE constexpr inline int
-divs (int x, int y)
+divs (int x, int y) noexcept
 {
     return (x >= 0) ? ((y >= 0) ? (x / y) : -(x / -y)) : ((y >= 0) ? -(-x / y) : (-x / -y));
 }
 
 IMATH_HOSTDEVICE constexpr inline int
-mods (int x, int y)
+mods (int x, int y) noexcept
 {
     return (x >= 0) ? ((y >= 0) ? (x % y) : (x % -y)) : ((y >= 0) ? -(-x % y) : -(-x % -y));
 }
@@ -185,14 +185,14 @@ mods (int x, int y)
 //
 
 IMATH_HOSTDEVICE constexpr inline int
-divp (int x, int y)
+divp (int x, int y) noexcept
 {
     return (x >= 0) ? ((y >= 0) ? (x / y) : -(x / -y))
                     : ((y >= 0) ? -((y - 1 - x) / y) : ((-y - 1 - x) / -y));
 }
 
 IMATH_HOSTDEVICE constexpr inline int
-modp (int x, int y)
+modp (int x, int y) noexcept
 {
     return x - y * divp (x, y);
 }
@@ -218,18 +218,18 @@ modp (int x, int y)
 //
 //----------------------------------------------------------
 
-IMATH_EXPORT float succf (float f);
-IMATH_EXPORT float predf (float f);
+IMATH_EXPORT float succf (float f) noexcept;
+IMATH_EXPORT float predf (float f) noexcept;
 
-IMATH_EXPORT double succd (double d);
-IMATH_EXPORT double predd (double d);
+IMATH_EXPORT double succd (double d) noexcept;
+IMATH_EXPORT double predd (double d) noexcept;
 
 //
 // Return true if the number is not a NaN or Infinity.
 //
 
 inline bool IMATH_HOSTDEVICE
-finitef (float f)
+finitef (float f) noexcept
 {
     union
     {
@@ -242,7 +242,7 @@ finitef (float f)
 }
 
 inline bool IMATH_HOSTDEVICE
-finited (double d)
+finited (double d) noexcept
 {
     union
     {

--- a/src/Imath/ImathHalfLimits.h
+++ b/src/Imath/ImathHalfLimits.h
@@ -50,12 +50,12 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 template <> struct limits<half>
 {
-    constexpr static float min() { return -HALF_MAX; }
-    constexpr static float max() { return HALF_MAX; }
-    constexpr static float smallest() { return HALF_MIN; }
-    constexpr static float epsilon() { return HALF_EPSILON; }
-    constexpr static bool isIntegral() { return false; }
-    constexpr static bool isSigned() { return true; }
+    constexpr static constexpr float min() noexcept { return -HALF_MAX; }
+    constexpr static constexpr float max() noexcept { return HALF_MAX; }
+    constexpr static constexpr float smallest() noexcept { return HALF_MIN; }
+    constexpr static constexpr float epsilon() noexcept { return HALF_EPSILON; }
+    constexpr static constexpr bool isIntegral() noexcept { return false; }
+    constexpr static constexpr bool isSigned() noexcept { return true; }
 };
 
 IMATH_INTERNAL_NAMESPACE_HEADER_EXIT

--- a/src/Imath/ImathInterval.h
+++ b/src/Imath/ImathInterval.h
@@ -65,42 +65,42 @@ template <class T> class Interval
     //	Constructors - an "empty" Interval is created by default
     //-----------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Interval();
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Interval (const T& point);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Interval (const T& minT, const T& maxT);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Interval() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Interval (const T& point) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Interval (const T& minT, const T& maxT) noexcept;
 
     //--------------------------------
     //  Operators:  we get != from STL
     //--------------------------------
 
-    IMATH_HOSTDEVICE constexpr bool operator== (const Interval<T>& src) const;
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Interval<T>& src) const;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Interval<T>& src) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Interval<T>& src) const noexcept;
 
     //------------------
     //	Interval manipulation
     //------------------
 
-    IMATH_HOSTDEVICE void makeEmpty();
-    IMATH_HOSTDEVICE void extendBy (const T& point);
-    IMATH_HOSTDEVICE void extendBy (const Interval<T>& interval);
-    IMATH_HOSTDEVICE void makeInfinite();
+    IMATH_HOSTDEVICE void makeEmpty() noexcept;
+    IMATH_HOSTDEVICE void extendBy (const T& point) noexcept;
+    IMATH_HOSTDEVICE void extendBy (const Interval<T>& interval) noexcept;
+    IMATH_HOSTDEVICE void makeInfinite() noexcept;
 
     //---------------------------------------------------
     //	Query functions - these compute results each time
     //---------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T size() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T center() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const T& point) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Interval<T>& interval) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T size() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T center() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const T& point) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Interval<T>& interval) const noexcept;
 
     //----------------
     //	Classification
     //----------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const noexcept;
 };
 
 template <class T> std::ostream& operator<< (std::ostream& s, const Interval<T>& v);
@@ -118,18 +118,18 @@ typedef Interval<int> Intervali;
 //  Implementation
 //----------------
 
-template <class T> inline IMATH_CONSTEXPR14 Interval<T>::Interval()
+template <class T> inline IMATH_CONSTEXPR14 Interval<T>::Interval() noexcept
 {
     makeEmpty();
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Interval<T>::Interval (const T& point)
+template <class T> IMATH_CONSTEXPR14 inline Interval<T>::Interval (const T& point) noexcept
 {
     min = point;
     max = point;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Interval<T>::Interval (const T& minV, const T& maxV)
+template <class T> IMATH_CONSTEXPR14 inline Interval<T>::Interval (const T& minV, const T& maxV) noexcept
 {
     min = minV;
     max = maxV;
@@ -137,21 +137,21 @@ template <class T> IMATH_CONSTEXPR14 inline Interval<T>::Interval (const T& minV
 
 template <class T>
 constexpr inline bool
-Interval<T>::operator== (const Interval<T>& src) const
+Interval<T>::operator== (const Interval<T>& src) const noexcept
 {
     return (min == src.min && max == src.max);
 }
 
 template <class T>
 constexpr inline bool
-Interval<T>::operator!= (const Interval<T>& src) const
+Interval<T>::operator!= (const Interval<T>& src) const noexcept
 {
     return (min != src.min || max != src.max);
 }
 
 template <class T>
 inline void
-Interval<T>::makeEmpty()
+Interval<T>::makeEmpty() noexcept
 {
     min = limits<T>::max();
     max = limits<T>::min();
@@ -159,7 +159,7 @@ Interval<T>::makeEmpty()
 
 template <class T>
 inline void
-Interval<T>::makeInfinite()
+Interval<T>::makeInfinite() noexcept
 {
     min = limits<T>::min();
     max = limits<T>::max();
@@ -168,7 +168,7 @@ Interval<T>::makeInfinite()
 
 template <class T>
 inline void
-Interval<T>::extendBy (const T& point)
+Interval<T>::extendBy (const T& point) noexcept
 {
     if (point < min)
         min = point;
@@ -179,7 +179,7 @@ Interval<T>::extendBy (const T& point)
 
 template <class T>
 inline void
-Interval<T>::extendBy (const Interval<T>& interval)
+Interval<T>::extendBy (const Interval<T>& interval) noexcept
 {
     if (interval.min < min)
         min = interval.min;
@@ -190,21 +190,21 @@ Interval<T>::extendBy (const Interval<T>& interval)
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Interval<T>::intersects (const T& point) const
+Interval<T>::intersects (const T& point) const noexcept
 {
     return point >= min && point <= max;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Interval<T>::intersects (const Interval<T>& interval) const
+Interval<T>::intersects (const Interval<T>& interval) const noexcept
 {
     return interval.max >= min && interval.min <= max;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Interval<T>::size() const
+Interval<T>::size() const noexcept
 {
     if (isEmpty())
         return T(0);
@@ -214,28 +214,28 @@ Interval<T>::size() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Interval<T>::center() const
+Interval<T>::center() const noexcept
 {
     return (max + min) / 2;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Interval<T>::isEmpty() const
+Interval<T>::isEmpty() const noexcept
 {
     return max < min;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Interval<T>::hasVolume() const
+Interval<T>::hasVolume() const noexcept
 {
     return max > min;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Interval<T>::isInfinite() const
+Interval<T>::isInfinite() const noexcept
 {
     if (min != limits<T>::min() || max != limits<T>::max())
         return false;

--- a/src/Imath/ImathLimits.h
+++ b/src/Imath/ImathLimits.h
@@ -113,12 +113,12 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 template <class T> struct limits
 {
-    IMATH_HOSTDEVICE static T min();
-    IMATH_HOSTDEVICE static T max();
-    IMATH_HOSTDEVICE static T smallest();
-    IMATH_HOSTDEVICE static T epsilon();
-    IMATH_HOSTDEVICE static bool isIntegral();
-    IMATH_HOSTDEVICE static bool isSigned();
+    IMATH_HOSTDEVICE static constexpr T min() noexcept;
+    IMATH_HOSTDEVICE static constexpr T max() noexcept;
+    IMATH_HOSTDEVICE static constexpr T smallest() noexcept;
+    IMATH_HOSTDEVICE static constexpr T epsilon() noexcept;
+    IMATH_HOSTDEVICE static constexpr bool isIntegral() noexcept;
+    IMATH_HOSTDEVICE static constexpr bool isSigned() noexcept;
 };
 
 //---------------
@@ -127,122 +127,122 @@ template <class T> struct limits
 
 template <> struct limits<char>
 {
-    IMATH_HOSTDEVICE static char min() { return CHAR_MIN; }
-    IMATH_HOSTDEVICE static char max() { return CHAR_MAX; }
-    IMATH_HOSTDEVICE static char smallest() { return 1; }
-    IMATH_HOSTDEVICE static char epsilon() { return 1; }
-    IMATH_HOSTDEVICE static bool isIntegral() { return true; }
-    IMATH_HOSTDEVICE static bool isSigned() { return (char) ~0 < 0; }
+    IMATH_HOSTDEVICE static constexpr char min() noexcept { return CHAR_MIN; }
+    IMATH_HOSTDEVICE static constexpr char max() noexcept { return CHAR_MAX; }
+    IMATH_HOSTDEVICE static constexpr char smallest() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr char epsilon() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr bool isIntegral() noexcept { return true; }
+    IMATH_HOSTDEVICE static constexpr bool isSigned() noexcept { return (char) ~0 < 0; }
 };
 
 template <> struct limits<signed char>
 {
-    IMATH_HOSTDEVICE static signed char min() { return SCHAR_MIN; }
-    IMATH_HOSTDEVICE static signed char max() { return SCHAR_MAX; }
-    IMATH_HOSTDEVICE static signed char smallest() { return 1; }
-    IMATH_HOSTDEVICE static signed char epsilon() { return 1; }
-    IMATH_HOSTDEVICE static bool isIntegral() { return true; }
-    IMATH_HOSTDEVICE static bool isSigned() { return true; }
+    IMATH_HOSTDEVICE static constexpr signed char min() noexcept { return SCHAR_MIN; }
+    IMATH_HOSTDEVICE static constexpr signed char max() noexcept { return SCHAR_MAX; }
+    IMATH_HOSTDEVICE static constexpr signed char smallest() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr signed char epsilon() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr bool isIntegral() noexcept { return true; }
+    IMATH_HOSTDEVICE static constexpr bool isSigned() noexcept { return true; }
 };
 
 template <> struct limits<unsigned char>
 {
-    IMATH_HOSTDEVICE static unsigned char min() { return 0; }
-    IMATH_HOSTDEVICE static unsigned char max() { return UCHAR_MAX; }
-    IMATH_HOSTDEVICE static unsigned char smallest() { return 1; }
-    IMATH_HOSTDEVICE static unsigned char epsilon() { return 1; }
-    IMATH_HOSTDEVICE static bool isIntegral() { return true; }
-    IMATH_HOSTDEVICE static bool isSigned() { return false; }
+    IMATH_HOSTDEVICE static constexpr unsigned char min() noexcept { return 0; }
+    IMATH_HOSTDEVICE static constexpr unsigned char max() noexcept { return UCHAR_MAX; }
+    IMATH_HOSTDEVICE static constexpr unsigned char smallest() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr unsigned char epsilon() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr bool isIntegral() noexcept { return true; }
+    IMATH_HOSTDEVICE static constexpr bool isSigned() noexcept { return false; }
 };
 
 template <> struct limits<short>
 {
-    IMATH_HOSTDEVICE static short min() { return SHRT_MIN; }
-    IMATH_HOSTDEVICE static short max() { return SHRT_MAX; }
-    IMATH_HOSTDEVICE static short smallest() { return 1; }
-    IMATH_HOSTDEVICE static short epsilon() { return 1; }
-    IMATH_HOSTDEVICE static bool isIntegral() { return true; }
-    IMATH_HOSTDEVICE static bool isSigned() { return true; }
+    IMATH_HOSTDEVICE static constexpr short min() noexcept { return SHRT_MIN; }
+    IMATH_HOSTDEVICE static constexpr short max() noexcept { return SHRT_MAX; }
+    IMATH_HOSTDEVICE static constexpr short smallest() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr short epsilon() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr bool isIntegral() noexcept { return true; }
+    IMATH_HOSTDEVICE static constexpr bool isSigned() noexcept { return true; }
 };
 
 template <> struct limits<unsigned short>
 {
-    IMATH_HOSTDEVICE static unsigned short min() { return 0; }
-    IMATH_HOSTDEVICE static unsigned short max() { return USHRT_MAX; }
-    IMATH_HOSTDEVICE static unsigned short smallest() { return 1; }
-    IMATH_HOSTDEVICE static unsigned short epsilon() { return 1; }
-    IMATH_HOSTDEVICE static bool isIntegral() { return true; }
-    IMATH_HOSTDEVICE static bool isSigned() { return false; }
+    IMATH_HOSTDEVICE static constexpr unsigned short min() noexcept { return 0; }
+    IMATH_HOSTDEVICE static constexpr unsigned short max() noexcept { return USHRT_MAX; }
+    IMATH_HOSTDEVICE static constexpr unsigned short smallest() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr unsigned short epsilon() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr bool isIntegral() noexcept { return true; }
+    IMATH_HOSTDEVICE static constexpr bool isSigned() noexcept { return false; }
 };
 
 template <> struct limits<int>
 {
-    IMATH_HOSTDEVICE static int min() { return INT_MIN; }
-    IMATH_HOSTDEVICE static int max() { return INT_MAX; }
-    IMATH_HOSTDEVICE static int smallest() { return 1; }
-    IMATH_HOSTDEVICE static int epsilon() { return 1; }
-    IMATH_HOSTDEVICE static bool isIntegral() { return true; }
-    IMATH_HOSTDEVICE static bool isSigned() { return true; }
+    IMATH_HOSTDEVICE static constexpr int min() noexcept { return INT_MIN; }
+    IMATH_HOSTDEVICE static constexpr int max() noexcept { return INT_MAX; }
+    IMATH_HOSTDEVICE static constexpr int smallest() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr int epsilon() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr bool isIntegral() noexcept { return true; }
+    IMATH_HOSTDEVICE static constexpr bool isSigned() noexcept { return true; }
 };
 
 template <> struct limits<unsigned int>
 {
-    IMATH_HOSTDEVICE static unsigned int min() { return 0; }
-    IMATH_HOSTDEVICE static unsigned int max() { return UINT_MAX; }
-    IMATH_HOSTDEVICE static unsigned int smallest() { return 1; }
-    IMATH_HOSTDEVICE static unsigned int epsilon() { return 1; }
-    IMATH_HOSTDEVICE static bool isIntegral() { return true; }
-    IMATH_HOSTDEVICE static bool isSigned() { return false; }
+    IMATH_HOSTDEVICE static constexpr unsigned int min() noexcept { return 0; }
+    IMATH_HOSTDEVICE static constexpr unsigned int max() noexcept { return UINT_MAX; }
+    IMATH_HOSTDEVICE static constexpr unsigned int smallest() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr unsigned int epsilon() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr bool isIntegral() noexcept { return true; }
+    IMATH_HOSTDEVICE static constexpr bool isSigned() noexcept { return false; }
 };
 
 template <> struct limits<long>
 {
-    IMATH_HOSTDEVICE static long min() { return LONG_MIN; }
-    IMATH_HOSTDEVICE static long max() { return LONG_MAX; }
-    IMATH_HOSTDEVICE static long smallest() { return 1; }
-    IMATH_HOSTDEVICE static long epsilon() { return 1; }
-    IMATH_HOSTDEVICE static bool isIntegral() { return true; }
-    IMATH_HOSTDEVICE static bool isSigned() { return true; }
+    IMATH_HOSTDEVICE static constexpr long min() noexcept { return LONG_MIN; }
+    IMATH_HOSTDEVICE static constexpr long max() noexcept { return LONG_MAX; }
+    IMATH_HOSTDEVICE static constexpr long smallest() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr long epsilon() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr bool isIntegral() noexcept { return true; }
+    IMATH_HOSTDEVICE static constexpr bool isSigned() noexcept { return true; }
 };
 
 template <> struct limits<unsigned long>
 {
-    IMATH_HOSTDEVICE static unsigned long min() { return 0; }
-    IMATH_HOSTDEVICE static unsigned long max() { return ULONG_MAX; }
-    IMATH_HOSTDEVICE static unsigned long smallest() { return 1; }
-    IMATH_HOSTDEVICE static unsigned long epsilon() { return 1; }
-    IMATH_HOSTDEVICE static bool isIntegral() { return true; }
-    IMATH_HOSTDEVICE static bool isSigned() { return false; }
+    IMATH_HOSTDEVICE static constexpr unsigned long min() noexcept { return 0; }
+    IMATH_HOSTDEVICE static constexpr unsigned long max() noexcept { return ULONG_MAX; }
+    IMATH_HOSTDEVICE static constexpr unsigned long smallest() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr unsigned long epsilon() noexcept { return 1; }
+    IMATH_HOSTDEVICE static constexpr bool isIntegral() noexcept { return true; }
+    IMATH_HOSTDEVICE static constexpr bool isSigned() noexcept { return false; }
 };
 
 template <> struct limits<float>
 {
-    IMATH_HOSTDEVICE static float min() { return -FLT_MAX; }
-    IMATH_HOSTDEVICE static float max() { return FLT_MAX; }
-    IMATH_HOSTDEVICE static float smallest() { return FLT_MIN; }
-    IMATH_HOSTDEVICE static float epsilon() { return FLT_EPSILON; }
-    IMATH_HOSTDEVICE static bool isIntegral() { return false; }
-    IMATH_HOSTDEVICE static bool isSigned() { return true; }
+    IMATH_HOSTDEVICE static constexpr float min() noexcept { return -FLT_MAX; }
+    IMATH_HOSTDEVICE static constexpr float max() noexcept { return FLT_MAX; }
+    IMATH_HOSTDEVICE static constexpr float smallest() noexcept { return FLT_MIN; }
+    IMATH_HOSTDEVICE static constexpr float epsilon() noexcept { return FLT_EPSILON; }
+    IMATH_HOSTDEVICE static constexpr bool isIntegral() noexcept { return false; }
+    IMATH_HOSTDEVICE static constexpr bool isSigned() noexcept { return true; }
 };
 
 template <> struct limits<double>
 {
-    IMATH_HOSTDEVICE static double min() { return -DBL_MAX; }
-    IMATH_HOSTDEVICE static double max() { return DBL_MAX; }
-    IMATH_HOSTDEVICE static double smallest() { return DBL_MIN; }
-    IMATH_HOSTDEVICE static double epsilon() { return DBL_EPSILON; }
-    IMATH_HOSTDEVICE static bool isIntegral() { return false; }
-    IMATH_HOSTDEVICE static bool isSigned() { return true; }
+    IMATH_HOSTDEVICE static constexpr double min() noexcept { return -DBL_MAX; }
+    IMATH_HOSTDEVICE static constexpr double max() noexcept { return DBL_MAX; }
+    IMATH_HOSTDEVICE static constexpr double smallest() noexcept { return DBL_MIN; }
+    IMATH_HOSTDEVICE static constexpr double epsilon() noexcept { return DBL_EPSILON; }
+    IMATH_HOSTDEVICE static constexpr bool isIntegral() noexcept { return false; }
+    IMATH_HOSTDEVICE static constexpr bool isSigned() noexcept { return true; }
 };
 
 template <> struct limits<long double>
 {
-    IMATH_HOSTDEVICE static long double min() { return -LDBL_MAX; }
-    IMATH_HOSTDEVICE static long double max() { return LDBL_MAX; }
-    IMATH_HOSTDEVICE static long double smallest() { return LDBL_MIN; }
-    IMATH_HOSTDEVICE static long double epsilon() { return LDBL_EPSILON; }
-    IMATH_HOSTDEVICE static bool isIntegral() { return false; }
-    IMATH_HOSTDEVICE static bool isSigned() { return true; }
+    IMATH_HOSTDEVICE static constexpr long double min() noexcept { return -LDBL_MAX; }
+    IMATH_HOSTDEVICE static constexpr long double max() noexcept { return LDBL_MAX; }
+    IMATH_HOSTDEVICE static constexpr long double smallest() noexcept { return LDBL_MIN; }
+    IMATH_HOSTDEVICE static constexpr long double epsilon() noexcept { return LDBL_EPSILON; }
+    IMATH_HOSTDEVICE static constexpr bool isIntegral() noexcept { return false; }
+    IMATH_HOSTDEVICE static constexpr bool isSigned() noexcept { return true; }
 };
 
 IMATH_INTERNAL_NAMESPACE_HEADER_EXIT

--- a/src/Imath/ImathLine.h
+++ b/src/Imath/ImathLine.h
@@ -58,29 +58,29 @@ template <class T> class Line3
     //	Constructors - default is normalized units along direction
     //-------------------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr Line3() {}
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Line3 (const Vec3<T>& point1, const Vec3<T>& point2);
+    IMATH_HOSTDEVICE constexpr Line3() noexcept {}
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Line3 (const Vec3<T>& point1, const Vec3<T>& point2) noexcept;
 
     //------------------
     //	State Query/Set
     //------------------
 
-    IMATH_HOSTDEVICE void set (const Vec3<T>& point1, const Vec3<T>& point2);
+    IMATH_HOSTDEVICE void set (const Vec3<T>& point1, const Vec3<T>& point2) noexcept;
 
     //-------
     //	F(t)
     //-------
 
-    IMATH_HOSTDEVICE constexpr Vec3<T> operator() (T parameter) const;
+    IMATH_HOSTDEVICE constexpr Vec3<T> operator() (T parameter) const noexcept;
 
     //---------
     //	Query
     //---------
 
-    IMATH_HOSTDEVICE constexpr T distanceTo (const Vec3<T>& point) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T distanceTo (const Line3<T>& line) const;
-    IMATH_HOSTDEVICE constexpr Vec3<T> closestPointTo (const Vec3<T>& point) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T> closestPointTo (const Line3<T>& line) const;
+    IMATH_HOSTDEVICE constexpr T distanceTo (const Vec3<T>& point) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T distanceTo (const Line3<T>& line) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3<T> closestPointTo (const Vec3<T>& point) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T> closestPointTo (const Line3<T>& line) const noexcept;
 };
 
 //--------------------
@@ -94,14 +94,14 @@ typedef Line3<double> Line3d;
 // Implementation
 //---------------
 
-template <class T> IMATH_CONSTEXPR14 inline Line3<T>::Line3 (const Vec3<T>& p0, const Vec3<T>& p1)
+template <class T> IMATH_CONSTEXPR14 inline Line3<T>::Line3 (const Vec3<T>& p0, const Vec3<T>& p1) noexcept
 {
     set (p0, p1);
 }
 
 template <class T>
 inline void
-Line3<T>::set (const Vec3<T>& p0, const Vec3<T>& p1)
+Line3<T>::set (const Vec3<T>& p0, const Vec3<T>& p1) noexcept
 {
     pos = p0;
     dir = p1 - p0;
@@ -110,28 +110,28 @@ Line3<T>::set (const Vec3<T>& p0, const Vec3<T>& p1)
 
 template <class T>
 constexpr inline Vec3<T>
-Line3<T>::operator() (T parameter) const
+Line3<T>::operator() (T parameter) const noexcept
 {
     return pos + dir * parameter;
 }
 
 template <class T>
 constexpr inline T
-Line3<T>::distanceTo (const Vec3<T>& point) const
+Line3<T>::distanceTo (const Vec3<T>& point) const noexcept
 {
     return (closestPointTo (point) - point).length();
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Line3<T>::closestPointTo (const Vec3<T>& point) const
+Line3<T>::closestPointTo (const Vec3<T>& point) const noexcept
 {
     return ((point - pos) ^ dir) * dir + pos;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Line3<T>::distanceTo (const Line3<T>& line) const
+Line3<T>::distanceTo (const Line3<T>& line) const noexcept
 {
     T d = (dir % line.dir) ^ (line.pos - pos);
     return (d >= 0) ? d : -d;
@@ -139,7 +139,7 @@ Line3<T>::distanceTo (const Line3<T>& line) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline Vec3<T>
-Line3<T>::closestPointTo (const Line3<T>& line) const
+Line3<T>::closestPointTo (const Line3<T>& line) const noexcept
 {
     // Assumes the lines are normalized
 
@@ -173,7 +173,7 @@ operator<< (std::ostream& o, const Line3<T>& line)
 
 template <class S, class T>
 constexpr inline Line3<S>
-operator* (const Line3<S>& line, const Matrix44<T>& M)
+operator* (const Line3<S>& line, const Matrix44<T>& M) noexcept
 {
     return Line3<S> (line.pos * M, (line.pos + line.dir) * M);
 }

--- a/src/Imath/ImathLineAlgo.h
+++ b/src/Imath/ImathLineAlgo.h
@@ -78,7 +78,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 template <class T>
 IMATH_CONSTEXPR14 bool
-closestPoints (const Line3<T>& line1, const Line3<T>& line2, Vec3<T>& point1, Vec3<T>& point2)
+closestPoints (const Line3<T>& line1, const Line3<T>& line2, Vec3<T>& point1, Vec3<T>& point2) noexcept
 {
     //
     // Compute point1 and point2 such that point1 is on line1, point2
@@ -117,7 +117,7 @@ intersect (const Line3<T>& line,
            const Vec3<T>& v2,
            Vec3<T>& pt,
            Vec3<T>& barycentric,
-           bool& front)
+           bool& front) noexcept
 {
     //
     // Given a line and a triangle (v0, v1, v2), the intersect() function
@@ -214,7 +214,7 @@ intersect (const Line3<T>& line,
 
 template <class T>
 IMATH_CONSTEXPR14 Vec3<T>
-closestVertex (const Vec3<T>& v0, const Vec3<T>& v1, const Vec3<T>& v2, const Line3<T>& l)
+closestVertex (const Vec3<T>& v0, const Vec3<T>& v1, const Vec3<T>& v2, const Line3<T>& l) noexcept
 {
     Vec3<T> nearest = v0;
     T neardot       = (v0 - l.closestPointTo (v0)).length2();
@@ -239,7 +239,7 @@ closestVertex (const Vec3<T>& v0, const Vec3<T>& v1, const Vec3<T>& v2, const Li
 
 template <class T>
 IMATH_CONSTEXPR14 Vec3<T>
-rotatePoint (const Vec3<T> p, Line3<T> l, T angle)
+rotatePoint (const Vec3<T> p, Line3<T> l, T angle) noexcept
 {
     //
     // Rotate the point p around the line l by the given angle.

--- a/src/Imath/ImathMath.h
+++ b/src/Imath/ImathMath.h
@@ -165,15 +165,15 @@ sinx_over_x (T x)
 //--------------------------------------------------------------------------
 
 template <class T>
-IMATH_HOSTDEVICE inline bool
-equalWithAbsError (T x1, T x2, T e)
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
+equalWithAbsError (T x1, T x2, T e) noexcept
 {
     return ((x1 > x2) ? x1 - x2 : x2 - x1) <= e;
 }
 
 template <class T>
-IMATH_HOSTDEVICE inline bool
-equalWithRelError (T x1, T x2, T e)
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
+equalWithRelError (T x1, T x2, T e) noexcept
 {
     return ((x1 > x2) ? x1 - x2 : x2 - x1) <= e * ((x1 > 0) ? x1 : -x1);
 }

--- a/src/Imath/ImathMatrix.h
+++ b/src/Imath/ImathMatrix.h
@@ -73,28 +73,28 @@ template <class T> class Matrix22
 
     T x[2][2];
 
-    IMATH_HOSTDEVICE T* operator[] (int i);
-    IMATH_HOSTDEVICE const T* operator[] (int i) const;
+    IMATH_HOSTDEVICE T* operator[] (int i) noexcept;
+    IMATH_HOSTDEVICE const T* operator[] (int i) const noexcept;
 
     //-------------
     // Constructors
     //-------------
 
-    IMATH_HOSTDEVICE Matrix22 (Uninitialized) {}
+    IMATH_HOSTDEVICE Matrix22 (Uninitialized) noexcept {}
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22();
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22() noexcept;
     // 1 0
     // 0 1
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (T a);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (T a) noexcept;
     // a a
     // a a
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (const T a[2][2]);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (const T a[2][2]) noexcept;
     // a[0][0] a[0][1]
     // a[1][0] a[1][1]
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (T a, T b, T c, T d);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (T a, T b, T c, T d) noexcept;
     // a b
     // c d
 
@@ -102,43 +102,43 @@ template <class T> class Matrix22
     // Copy constructor and assignment
     //--------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (const Matrix22& v);
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix22 (const Matrix22<S>& v);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (const Matrix22& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix22 (const Matrix22<S>& v) noexcept;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator= (const Matrix22& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator= (T a);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator= (const Matrix22& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator= (T a) noexcept;
 
     //------------
     // Destructor
     //------------
 
-    ~Matrix22() = default;
+    ~Matrix22() noexcept = default;
 
     //----------------------
     // Compatibility with Sb
     //----------------------
 
-    IMATH_HOSTDEVICE T* getValue();
-    IMATH_HOSTDEVICE const T* getValue() const;
+    IMATH_HOSTDEVICE T* getValue() noexcept;
+    IMATH_HOSTDEVICE const T* getValue() const noexcept;
 
-    template <class S> IMATH_HOSTDEVICE void getValue (Matrix22<S>& v) const;
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22& setValue (const Matrix22<S>& v);
+    template <class S> IMATH_HOSTDEVICE void getValue (Matrix22<S>& v) const noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22& setValue (const Matrix22<S>& v) noexcept;
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22& setTheMatrix (const Matrix22<S>& v);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22& setTheMatrix (const Matrix22<S>& v) noexcept;
 
     //---------
     // Identity
     //---------
 
-    IMATH_HOSTDEVICE void makeIdentity();
+    IMATH_HOSTDEVICE void makeIdentity() noexcept;
 
     //---------
     // Equality
     //---------
 
-    IMATH_HOSTDEVICE constexpr bool operator== (const Matrix22& v) const;
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Matrix22& v) const;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Matrix22& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Matrix22& v) const noexcept;
 
     //-----------------------------------------------------------------------
     // Compare two matrices and test if they are "approximately equal":
@@ -158,45 +158,45 @@ template <class T> class Matrix22
     //      abs (this[i] - v[i][j]) <= e * abs (this[i][j])
     //-----------------------------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Matrix22<T>& v, T e) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Matrix22<T>& v, T e) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Matrix22<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Matrix22<T>& v, T e) const noexcept;
 
     //------------------------
     // Component-wise addition
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator+= (const Matrix22& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator+= (T a);
-    IMATH_HOSTDEVICE constexpr Matrix22 operator+ (const Matrix22& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator+= (const Matrix22& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator+= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix22 operator+ (const Matrix22& v) const noexcept;
 
     //---------------------------
     // Component-wise subtraction
     //---------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator-= (const Matrix22& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator-= (T a);
-    IMATH_HOSTDEVICE constexpr Matrix22 operator- (const Matrix22& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator-= (const Matrix22& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator-= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix22 operator- (const Matrix22& v) const noexcept;
 
     //------------------------------------
     // Component-wise multiplication by -1
     //------------------------------------
 
-    IMATH_HOSTDEVICE constexpr Matrix22 operator-() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& negate();
+    IMATH_HOSTDEVICE constexpr Matrix22 operator-() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& negate() noexcept;
 
     //------------------------------
     // Component-wise multiplication
     //------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator*= (T a);
-    IMATH_HOSTDEVICE constexpr Matrix22 operator* (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator*= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix22 operator* (T a) const noexcept;
 
     //-----------------------------------
     // Matrix-times-matrix multiplication
     //-----------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator*= (const Matrix22& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 operator* (const Matrix22& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator*= (const Matrix22& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 operator* (const Matrix22& v) const noexcept;
 
     //-----------------------------------------------------------------
     // Vector-times-matrix multiplication; see also the "operator *"
@@ -205,21 +205,21 @@ template <class T> class Matrix22
     // m.multDirMatrix(src,dst) multiplies src by the matrix m.
     //-----------------------------------------------------------------
 
-    template <class S> IMATH_HOSTDEVICE void multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const;
+    template <class S> IMATH_HOSTDEVICE void multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept;
 
     //------------------------
     // Component-wise division
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator/= (T a);
-    IMATH_HOSTDEVICE constexpr Matrix22 operator/ (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator/= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix22 operator/ (T a) const noexcept;
 
     //------------------
     // Transposed matrix
     //------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& transpose();
-    IMATH_HOSTDEVICE constexpr Matrix22 transposed() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& transpose() noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix22 transposed() const noexcept;
 
     //------------------------------------------------------------
     // Inverse matrix: If singExc is false, inverting a singular
@@ -231,63 +231,63 @@ template <class T> class Matrix22
     //------------------------------------------------------------
 
     IMATH_CONSTEXPR14 const Matrix22& invert (bool singExc);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& invert();
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& invert() noexcept;
 
     IMATH_CONSTEXPR14 Matrix22<T> inverse (bool singExc) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22<T> inverse() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22<T> inverse() const noexcept;
 
     //------------
     // Determinant
     //------------
 
-    IMATH_HOSTDEVICE constexpr T determinant() const;
+    IMATH_HOSTDEVICE constexpr T determinant() const noexcept;
 
     //-----------------------------------------
     // Set matrix to rotation by r (in radians)
     //-----------------------------------------
 
-    template <class S> IMATH_HOSTDEVICE const Matrix22& setRotation (S r);
+    template <class S> IMATH_HOSTDEVICE const Matrix22& setRotation (S r) noexcept;
 
     //-----------------------------
     // Rotate the given matrix by r
     //-----------------------------
 
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& rotate (S r);
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& rotate (S r) noexcept;
 
     //--------------------------------------------
     // Set matrix to scale by given uniform factor
     //--------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& setScale (T s);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& setScale (T s) noexcept;
 
     //------------------------------------
     // Set matrix to scale by given vector
     //------------------------------------
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& setScale (const Vec2<S>& s);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& setScale (const Vec2<S>& s) noexcept;
 
     //----------------------
     // Scale the matrix by s
     //----------------------
 
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& scale (const Vec2<S>& s);
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& scale (const Vec2<S>& s) noexcept;
 
     //--------------------------------------------------------
     // Number of the row and column dimensions, since
     // Matrix22 is a square matrix.
     //--------------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() { return 2; }
+    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() noexcept { return 2; }
 
     //-------------------------------------------------
     // Limitations of type T (see also class limits<T>)
     //-------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static T baseTypeMin() { return limits<T>::min(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() { return limits<T>::max(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() { return limits<T>::smallest(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() { return limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMin() noexcept { return limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return limits<T>::smallest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return limits<T>::epsilon(); }
 
     typedef T BaseType;
     typedef Vec2<T> BaseVecType;
@@ -319,31 +319,31 @@ template <class T> class Matrix33
 
     T x[3][3];
 
-    IMATH_HOSTDEVICE T* operator[] (int i);
-    IMATH_HOSTDEVICE const T* operator[] (int i) const;
+    IMATH_HOSTDEVICE T* operator[] (int i) noexcept;
+    IMATH_HOSTDEVICE const T* operator[] (int i) const noexcept;
 
     //-------------
     // Constructors
     //-------------
 
-    IMATH_HOSTDEVICE Matrix33 (Uninitialized) {}
+    IMATH_HOSTDEVICE Matrix33 (Uninitialized) noexcept {}
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33();
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33() noexcept;
     // 1 0 0
     // 0 1 0
     // 0 0 1
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (T a);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (T a) noexcept;
     // a a a
     // a a a
     // a a a
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (const T a[3][3]);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (const T a[3][3]) noexcept;
     // a[0][0] a[0][1] a[0][2]
     // a[1][0] a[1][1] a[1][2]
     // a[2][0] a[2][1] a[2][2]
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (T a, T b, T c, T d, T e, T f, T g, T h, T i);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (T a, T b, T c, T d, T e, T f, T g, T h, T i) noexcept;
     // a b c
     // d e f
     // g h i
@@ -352,43 +352,43 @@ template <class T> class Matrix33
     // Copy constructor and assignment
     //--------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (const Matrix33& v);
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix33 (const Matrix33<S>& v);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (const Matrix33& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix33 (const Matrix33<S>& v) noexcept;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator= (const Matrix33& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator= (T a);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator= (const Matrix33& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator= (T a) noexcept;
 
     //------------
     // Destructor
     //------------
 
-    ~Matrix33() = default;
+    ~Matrix33() noexcept = default;
 
     //----------------------
     // Compatibility with Sb
     //----------------------
 
-    IMATH_HOSTDEVICE T* getValue();
-    IMATH_HOSTDEVICE const T* getValue() const;
+    IMATH_HOSTDEVICE T* getValue() noexcept;
+    IMATH_HOSTDEVICE const T* getValue() const noexcept;
 
-    template <class S> IMATH_HOSTDEVICE void getValue (Matrix33<S>& v) const;
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33& setValue (const Matrix33<S>& v);
+    template <class S> IMATH_HOSTDEVICE void getValue (Matrix33<S>& v) const noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33& setValue (const Matrix33<S>& v) noexcept;
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33& setTheMatrix (const Matrix33<S>& v);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33& setTheMatrix (const Matrix33<S>& v) noexcept;
 
     //---------
     // Identity
     //---------
 
-    IMATH_HOSTDEVICE void makeIdentity();
+    IMATH_HOSTDEVICE void makeIdentity() noexcept;
 
     //---------
     // Equality
     //---------
 
-    IMATH_HOSTDEVICE constexpr bool operator== (const Matrix33& v) const;
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Matrix33& v) const;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Matrix33& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Matrix33& v) const noexcept;
 
     //-----------------------------------------------------------------------
     // Compare two matrices and test if they are "approximately equal":
@@ -408,45 +408,45 @@ template <class T> class Matrix33
     //      abs (this[i] - v[i][j]) <= e * abs (this[i][j])
     //-----------------------------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Matrix33<T>& v, T e) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Matrix33<T>& v, T e) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Matrix33<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Matrix33<T>& v, T e) const noexcept;
 
     //------------------------
     // Component-wise addition
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator+= (const Matrix33& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator+= (T a);
-    IMATH_HOSTDEVICE constexpr Matrix33 operator+ (const Matrix33& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator+= (const Matrix33& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator+= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix33 operator+ (const Matrix33& v) const noexcept;
 
     //---------------------------
     // Component-wise subtraction
     //---------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator-= (const Matrix33& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator-= (T a);
-    IMATH_HOSTDEVICE constexpr Matrix33 operator- (const Matrix33& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator-= (const Matrix33& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator-= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix33 operator- (const Matrix33& v) const noexcept;
 
     //------------------------------------
     // Component-wise multiplication by -1
     //------------------------------------
 
-    IMATH_HOSTDEVICE constexpr Matrix33 operator-() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& negate();
+    IMATH_HOSTDEVICE constexpr Matrix33 operator-() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& negate() noexcept;
 
     //------------------------------
     // Component-wise multiplication
     //------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator*= (T a);
-    IMATH_HOSTDEVICE constexpr Matrix33 operator* (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator*= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix33 operator* (T a) const noexcept;
 
     //-----------------------------------
     // Matrix-times-matrix multiplication
     //-----------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator*= (const Matrix33& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 operator* (const Matrix33& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator*= (const Matrix33& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 operator* (const Matrix33& v) const noexcept;
 
     //-----------------------------------------------------------------
     // Vector-times-matrix multiplication; see also the "operator *"
@@ -460,23 +460,23 @@ template <class T> class Matrix33
     // submatrix, ignoring the rest of matrix m.
     //-----------------------------------------------------------------
 
-    template <class S> IMATH_HOSTDEVICE void multVecMatrix (const Vec2<S>& src, Vec2<S>& dst) const;
+    template <class S> IMATH_HOSTDEVICE void multVecMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept;
 
-    template <class S> IMATH_HOSTDEVICE void multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const;
+    template <class S> IMATH_HOSTDEVICE void multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept;
 
     //------------------------
     // Component-wise division
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator/= (T a);
-    IMATH_HOSTDEVICE constexpr Matrix33 operator/ (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator/= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix33 operator/ (T a) const noexcept;
 
     //------------------
     // Transposed matrix
     //------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& transpose();
-    IMATH_HOSTDEVICE constexpr Matrix33 transposed() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& transpose() noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix33 transposed() const noexcept;
 
     //------------------------------------------------------------
     // Inverse matrix: If singExc is false, inverting a singular
@@ -493,92 +493,92 @@ template <class T> class Matrix33
     //------------------------------------------------------------
 
     IMATH_CONSTEXPR14 const Matrix33& invert (bool singExc);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& invert();
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& invert() noexcept;
 
     IMATH_CONSTEXPR14 Matrix33<T> inverse (bool singExc) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33<T> inverse() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33<T> inverse() const noexcept;
 
     const Matrix33& gjInvert (bool singExc);
-    IMATH_HOSTDEVICE const Matrix33& gjInvert();
+    IMATH_HOSTDEVICE const Matrix33& gjInvert() noexcept;
 
     Matrix33<T> gjInverse (bool singExc) const;
-    IMATH_HOSTDEVICE Matrix33<T> gjInverse() const;
+    IMATH_HOSTDEVICE Matrix33<T> gjInverse() const noexcept;
 
     //------------------------------------------------
     // Calculate the matrix minor of the (r,c) element
     //------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T minorOf (const int r, const int c) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T minorOf (const int r, const int c) const noexcept;
 
     //---------------------------------------------------
     // Build a minor using the specified rows and columns
     //---------------------------------------------------
 
     IMATH_HOSTDEVICE
-    constexpr T fastMinor (const int r0, const int r1, const int c0, const int c1) const;
+    constexpr T fastMinor (const int r0, const int r1, const int c0, const int c1) const noexcept;
 
     //------------
     // Determinant
     //------------
 
-    IMATH_HOSTDEVICE constexpr T determinant() const;
+    IMATH_HOSTDEVICE constexpr T determinant() const noexcept;
 
     //-----------------------------------------
     // Set matrix to rotation by r (in radians)
     //-----------------------------------------
 
-    template <class S> IMATH_HOSTDEVICE const Matrix33& setRotation (S r);
+    template <class S> IMATH_HOSTDEVICE const Matrix33& setRotation (S r) noexcept;
 
     //-----------------------------
     // Rotate the given matrix by r
     //-----------------------------
 
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& rotate (S r);
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& rotate (S r) noexcept;
 
     //--------------------------------------------
     // Set matrix to scale by given uniform factor
     //--------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setScale (T s);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setScale (T s) noexcept;
 
     //------------------------------------
     // Set matrix to scale by given vector
     //------------------------------------
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setScale (const Vec2<S>& s);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setScale (const Vec2<S>& s) noexcept;
 
     //----------------------
     // Scale the matrix by s
     //----------------------
 
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& scale (const Vec2<S>& s);
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& scale (const Vec2<S>& s) noexcept;
 
     //------------------------------------------
     // Set matrix to translation by given vector
     //------------------------------------------
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setTranslation (const Vec2<S>& t);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setTranslation (const Vec2<S>& t) noexcept;
 
     //-----------------------------
     // Return translation component
     //-----------------------------
 
-    IMATH_HOSTDEVICE constexpr Vec2<T> translation() const;
+    IMATH_HOSTDEVICE constexpr Vec2<T> translation() const noexcept;
 
     //--------------------------
     // Translate the matrix by t
     //--------------------------
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& translate (const Vec2<S>& t);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& translate (const Vec2<S>& t) noexcept;
 
     //-----------------------------------------------------------
     // Set matrix to shear x for each y coord. by given factor xy
     //-----------------------------------------------------------
 
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setShear (const S& h);
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setShear (const S& h) noexcept;
 
     //-------------------------------------------------------------
     // Set matrix to shear x for each y coord. by given factor h[0]
@@ -586,36 +586,36 @@ template <class T> class Matrix33
     //-------------------------------------------------------------
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setShear (const Vec2<S>& h);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setShear (const Vec2<S>& h) noexcept;
 
     //-----------------------------------------------------------
     // Shear the matrix in x for each y coord. by given factor xy
     //-----------------------------------------------------------
 
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& shear (const S& xy);
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& shear (const S& xy) noexcept;
 
     //-----------------------------------------------------------
     // Shear the matrix in x for each y coord. by given factor xy
     // and shear y for each x coord. by given factor yx
     //-----------------------------------------------------------
 
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& shear (const Vec2<S>& h);
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& shear (const Vec2<S>& h) noexcept;
 
     //--------------------------------------------------------
     // Number of the row and column dimensions, since
     // Matrix33 is a square matrix.
     //--------------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() { return 3; }
+    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() noexcept { return 3; }
 
     //-------------------------------------------------
     // Limitations of type T (see also class limits<T>)
     //-------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static T baseTypeMin() { return limits<T>::min(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() { return limits<T>::max(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() { return limits<T>::smallest(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() { return limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMin() noexcept { return limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return limits<T>::smallest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return limits<T>::epsilon(); }
 
     typedef T BaseType;
     typedef Vec3<T> BaseVecType;
@@ -647,42 +647,42 @@ template <class T> class Matrix44
 
     T x[4][4];
 
-    IMATH_HOSTDEVICE T* operator[] (int i);
-    IMATH_HOSTDEVICE const T* operator[] (int i) const;
+    IMATH_HOSTDEVICE T* operator[] (int i) noexcept;
+    IMATH_HOSTDEVICE const T* operator[] (int i) const noexcept;
 
     //-------------
     // Constructors
     //-------------
 
-    IMATH_HOSTDEVICE constexpr Matrix44 (Uninitialized) {}
+    IMATH_HOSTDEVICE constexpr Matrix44 (Uninitialized) noexcept {}
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44();
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44() noexcept;
     // 1 0 0 0
     // 0 1 0 0
     // 0 0 1 0
     // 0 0 0 1
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (T a);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (T a) noexcept;
     // a a a a
     // a a a a
     // a a a a
     // a a a a
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (const T a[4][4]);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (const T a[4][4]) noexcept;
     // a[0][0] a[0][1] a[0][2] a[0][3]
     // a[1][0] a[1][1] a[1][2] a[1][3]
     // a[2][0] a[2][1] a[2][2] a[2][3]
     // a[3][0] a[3][1] a[3][2] a[3][3]
 
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14
-    Matrix44 (T a, T b, T c, T d, T e, T f, T g, T h, T i, T j, T k, T l, T m, T n, T o, T p);
+    Matrix44 (T a, T b, T c, T d, T e, T f, T g, T h, T i, T j, T k, T l, T m, T n, T o, T p) noexcept;
 
     // a b c d
     // e f g h
     // i j k l
     // m n o p
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (Matrix33<T> r, Vec3<T> t);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (Matrix33<T> r, Vec3<T> t) noexcept;
     // r r r 0
     // r r r 0
     // r r r 0
@@ -692,43 +692,43 @@ template <class T> class Matrix44
     // Destructor
     //------------
 
-    ~Matrix44() = default;
+    ~Matrix44() noexcept = default;
 
     //--------------------------------
     // Copy constructor and assignment
     //--------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (const Matrix44& v);
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix44 (const Matrix44<S>& v);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (const Matrix44& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix44 (const Matrix44<S>& v) noexcept;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator= (const Matrix44& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator= (T a);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator= (const Matrix44& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator= (T a) noexcept;
 
     //----------------------
     // Compatibility with Sb
     //----------------------
 
-    IMATH_HOSTDEVICE T* getValue();
-    IMATH_HOSTDEVICE const T* getValue() const;
+    IMATH_HOSTDEVICE T* getValue() noexcept;
+    IMATH_HOSTDEVICE const T* getValue() const noexcept;
 
-    template <class S> IMATH_HOSTDEVICE void getValue (Matrix44<S>& v) const;
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44& setValue (const Matrix44<S>& v);
+    template <class S> IMATH_HOSTDEVICE void getValue (Matrix44<S>& v) const noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44& setValue (const Matrix44<S>& v) noexcept;
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44& setTheMatrix (const Matrix44<S>& v);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44& setTheMatrix (const Matrix44<S>& v) noexcept;
 
     //---------
     // Identity
     //---------
 
-    IMATH_HOSTDEVICE void makeIdentity();
+    IMATH_HOSTDEVICE void makeIdentity() noexcept;
 
     //---------
     // Equality
     //---------
 
-    IMATH_HOSTDEVICE constexpr bool operator== (const Matrix44& v) const;
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Matrix44& v) const;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Matrix44& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Matrix44& v) const noexcept;
 
     //-----------------------------------------------------------------------
     // Compare two matrices and test if they are "approximately equal":
@@ -748,50 +748,50 @@ template <class T> class Matrix44
     //      abs (this[i] - v[i][j]) <= e * abs (this[i][j])
     //-----------------------------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Matrix44<T>& v, T e) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Matrix44<T>& v, T e) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Matrix44<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Matrix44<T>& v, T e) const noexcept;
 
     //------------------------
     // Component-wise addition
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator+= (const Matrix44& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator+= (T a);
-    IMATH_HOSTDEVICE constexpr Matrix44 operator+ (const Matrix44& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator+= (const Matrix44& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator+= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix44 operator+ (const Matrix44& v) const noexcept;
 
     //---------------------------
     // Component-wise subtraction
     //---------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator-= (const Matrix44& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator-= (T a);
-    IMATH_HOSTDEVICE constexpr Matrix44 operator- (const Matrix44& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator-= (const Matrix44& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator-= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix44 operator- (const Matrix44& v) const noexcept;
 
     //------------------------------------
     // Component-wise multiplication by -1
     //------------------------------------
 
-    IMATH_HOSTDEVICE constexpr Matrix44 operator-() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& negate();
+    IMATH_HOSTDEVICE constexpr Matrix44 operator-() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& negate() noexcept;
 
     //------------------------------
     // Component-wise multiplication
     //------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator*= (T a);
-    IMATH_HOSTDEVICE constexpr Matrix44 operator* (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator*= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix44 operator* (T a) const noexcept;
 
     //-----------------------------------
     // Matrix-times-matrix multiplication
     //-----------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator*= (const Matrix44& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 operator* (const Matrix44& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator*= (const Matrix44& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 operator* (const Matrix44& v) const noexcept;
 
     IMATH_HOSTDEVICE
-    static void multiply (const Matrix44& a, // assumes that
-                          const Matrix44& b, // &a != &c and
-                          Matrix44& c);      // &b != &c.
+    static void multiply (const Matrix44& a,     // assumes that
+                          const Matrix44& b,     // &a != &c and
+                          Matrix44& c) noexcept; // &b != &c.
 
     //-----------------------------------------------------------------
     // Vector-times-matrix multiplication; see also the "operator *"
@@ -805,23 +805,23 @@ template <class T> class Matrix44
     // submatrix, ignoring the rest of matrix m.
     //-----------------------------------------------------------------
 
-    template <class S> IMATH_HOSTDEVICE void multVecMatrix (const Vec3<S>& src, Vec3<S>& dst) const;
+    template <class S> IMATH_HOSTDEVICE void multVecMatrix (const Vec3<S>& src, Vec3<S>& dst) const noexcept;
 
-    template <class S> IMATH_HOSTDEVICE void multDirMatrix (const Vec3<S>& src, Vec3<S>& dst) const;
+    template <class S> IMATH_HOSTDEVICE void multDirMatrix (const Vec3<S>& src, Vec3<S>& dst) const noexcept;
 
     //------------------------
     // Component-wise division
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator/= (T a);
-    IMATH_HOSTDEVICE constexpr Matrix44 operator/ (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator/= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix44 operator/ (T a) const noexcept;
 
     //------------------
     // Transposed matrix
     //------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& transpose();
-    IMATH_HOSTDEVICE constexpr Matrix44 transposed() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& transpose() noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix44 transposed() const noexcept;
 
     //------------------------------------------------------------
     // Inverse matrix: If singExc is false, inverting a singular
@@ -838,22 +838,22 @@ template <class T> class Matrix44
     //------------------------------------------------------------
 
     IMATH_CONSTEXPR14 const Matrix44& invert (bool singExc);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& invert();
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& invert() noexcept;
 
     IMATH_CONSTEXPR14 Matrix44<T> inverse (bool singExc) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44<T> inverse() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44<T> inverse() const noexcept;
 
     IMATH_CONSTEXPR14 const Matrix44& gjInvert (bool singExc);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& gjInvert();
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& gjInvert() noexcept;
 
     Matrix44<T> gjInverse (bool singExc) const;
-    IMATH_HOSTDEVICE Matrix44<T> gjInverse() const;
+    IMATH_HOSTDEVICE Matrix44<T> gjInverse() const noexcept;
 
     //------------------------------------------------
     // Calculate the matrix minor of the (r,c) element
     //------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T minorOf (const int r, const int c) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T minorOf (const int r, const int c) const noexcept;
 
     //---------------------------------------------------
     // Build a minor using the specified rows and columns
@@ -865,71 +865,71 @@ template <class T> class Matrix44
                            const int r2,
                            const int c0,
                            const int c1,
-                           const int c2) const;
+                           const int c2) const noexcept;
 
     //------------
     // Determinant
     //------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T determinant() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T determinant() const noexcept;
 
     //--------------------------------------------------------
     // Set matrix to rotation by XYZ euler angles (in radians)
     //--------------------------------------------------------
 
-    template <class S> IMATH_HOSTDEVICE const Matrix44& setEulerAngles (const Vec3<S>& r);
+    template <class S> IMATH_HOSTDEVICE const Matrix44& setEulerAngles (const Vec3<S>& r) noexcept;
 
     //--------------------------------------------------------
     // Set matrix to rotation around given axis by given angle
     //--------------------------------------------------------
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setAxisAngle (const Vec3<S>& ax, S ang);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setAxisAngle (const Vec3<S>& ax, S ang) noexcept;
 
     //-------------------------------------------
     // Rotate the matrix by XYZ euler angles in r
     //-------------------------------------------
 
-    template <class S> IMATH_HOSTDEVICE const Matrix44& rotate (const Vec3<S>& r);
+    template <class S> IMATH_HOSTDEVICE const Matrix44& rotate (const Vec3<S>& r) noexcept;
 
     //--------------------------------------------
     // Set matrix to scale by given uniform factor
     //--------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setScale (T s);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setScale (T s) noexcept;
 
     //------------------------------------
     // Set matrix to scale by given vector
     //------------------------------------
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setScale (const Vec3<S>& s);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setScale (const Vec3<S>& s) noexcept;
 
     //----------------------
     // Scale the matrix by s
     //----------------------
 
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& scale (const Vec3<S>& s);
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& scale (const Vec3<S>& s) noexcept;
 
     //------------------------------------------
     // Set matrix to translation by given vector
     //------------------------------------------
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setTranslation (const Vec3<S>& t);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setTranslation (const Vec3<S>& t) noexcept;
 
     //-----------------------------
     // Return translation component
     //-----------------------------
 
-    IMATH_HOSTDEVICE constexpr const Vec3<T> translation() const;
+    IMATH_HOSTDEVICE constexpr const Vec3<T> translation() const noexcept;
 
     //--------------------------
     // Translate the matrix by t
     //--------------------------
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& translate (const Vec3<S>& t);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& translate (const Vec3<S>& t) noexcept;
 
     //-------------------------------------------------------------
     // Set matrix to shear by given vector h.  The resulting matrix
@@ -939,7 +939,7 @@ template <class T> class Matrix44
     //-------------------------------------------------------------
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setShear (const Vec3<S>& h);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setShear (const Vec3<S>& h) noexcept;
 
     //------------------------------------------------------------
     // Set matrix to shear by given factors.  The resulting matrix
@@ -952,7 +952,7 @@ template <class T> class Matrix44
     //------------------------------------------------------------
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setShear (const Shear6<S>& h);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setShear (const Shear6<S>& h) noexcept;
 
     //--------------------------------------------------------
     // Shear the matrix by given vector.  The composed matrix
@@ -962,14 +962,14 @@ template <class T> class Matrix44
     //    will shear y for each z coord. by a factor of h[2] .
     //--------------------------------------------------------
 
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& shear (const Vec3<S>& h);
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& shear (const Vec3<S>& h) noexcept;
 
     //--------------------------------------------------------
     // Number of the row and column dimensions, since
     // Matrix44 is a square matrix.
     //--------------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() { return 4; }
+    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() noexcept { return 4; }
 
     //------------------------------------------------------------
     // Shear the matrix by the given factors.  The composed matrix
@@ -983,16 +983,16 @@ template <class T> class Matrix44
     //------------------------------------------------------------
 
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& shear (const Shear6<S>& h);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& shear (const Shear6<S>& h) noexcept;
 
     //-------------------------------------------------
     // Limitations of type T (see also class limits<T>)
     //-------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static T baseTypeMin() { return limits<T>::min(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() { return limits<T>::max(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() { return limits<T>::smallest(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() { return limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMin() noexcept { return limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return limits<T>::smallest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return limits<T>::epsilon(); }
 
     typedef T BaseType;
     typedef Vec4<T> BaseVecType;
@@ -1030,34 +1030,34 @@ template <class T> std::ostream& operator<< (std::ostream& s, const Matrix44<T>&
 //---------------------------------------------
 
 template <class S, class T>
-IMATH_HOSTDEVICE inline const Vec2<S>& operator*= (Vec2<S>& v, const Matrix22<T>& m);
+IMATH_HOSTDEVICE inline const Vec2<S>& operator*= (Vec2<S>& v, const Matrix22<T>& m) noexcept;
 
 template <class S, class T>
-IMATH_HOSTDEVICE inline Vec2<S> operator* (const Vec2<S>& v, const Matrix22<T>& m);
+IMATH_HOSTDEVICE inline Vec2<S> operator* (const Vec2<S>& v, const Matrix22<T>& m) noexcept;
 
 template <class S, class T>
-IMATH_HOSTDEVICE inline const Vec2<S>& operator*= (Vec2<S>& v, const Matrix33<T>& m);
+IMATH_HOSTDEVICE inline const Vec2<S>& operator*= (Vec2<S>& v, const Matrix33<T>& m) noexcept;
 
 template <class S, class T>
-IMATH_HOSTDEVICE inline Vec2<S> operator* (const Vec2<S>& v, const Matrix33<T>& m);
+IMATH_HOSTDEVICE inline Vec2<S> operator* (const Vec2<S>& v, const Matrix33<T>& m) noexcept;
 
 template <class S, class T>
-IMATH_HOSTDEVICE inline const Vec3<S>& operator*= (Vec3<S>& v, const Matrix33<T>& m);
+IMATH_HOSTDEVICE inline const Vec3<S>& operator*= (Vec3<S>& v, const Matrix33<T>& m) noexcept;
 
 template <class S, class T>
-IMATH_HOSTDEVICE inline Vec3<S> operator* (const Vec3<S>& v, const Matrix33<T>& m);
+IMATH_HOSTDEVICE inline Vec3<S> operator* (const Vec3<S>& v, const Matrix33<T>& m) noexcept;
 
 template <class S, class T>
-IMATH_HOSTDEVICE inline const Vec3<S>& operator*= (Vec3<S>& v, const Matrix44<T>& m);
+IMATH_HOSTDEVICE inline const Vec3<S>& operator*= (Vec3<S>& v, const Matrix44<T>& m) noexcept;
 
 template <class S, class T>
-IMATH_HOSTDEVICE inline Vec3<S> operator* (const Vec3<S>& v, const Matrix44<T>& m);
+IMATH_HOSTDEVICE inline Vec3<S> operator* (const Vec3<S>& v, const Matrix44<T>& m) noexcept;
 
 template <class S, class T>
-IMATH_HOSTDEVICE inline const Vec4<S>& operator*= (Vec4<S>& v, const Matrix44<T>& m);
+IMATH_HOSTDEVICE inline const Vec4<S>& operator*= (Vec4<S>& v, const Matrix44<T>& m) noexcept;
 
 template <class S, class T>
-IMATH_HOSTDEVICE inline Vec4<S> operator* (const Vec4<S>& v, const Matrix44<T>& m);
+IMATH_HOSTDEVICE inline Vec4<S> operator* (const Vec4<S>& v, const Matrix44<T>& m) noexcept;
 
 //-------------------------
 // Typedefs for convenience
@@ -1076,19 +1076,19 @@ typedef Matrix44<double> M44d;
 
 template <class T>
 inline T*
-Matrix22<T>::operator[] (int i)
+Matrix22<T>::operator[] (int i) noexcept
 {
     return x[i];
 }
 
 template <class T>
 inline const T*
-Matrix22<T>::operator[] (int i) const
+Matrix22<T>::operator[] (int i) const noexcept
 {
     return x[i];
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22()
+template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22() noexcept
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -1096,7 +1096,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22()
     x[1][1] = 1;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a)
+template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a) noexcept
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -1104,7 +1104,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a)
     x[1][1] = a;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const T a[2][2])
+template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const T a[2][2]) noexcept
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so instead of this:
@@ -1116,7 +1116,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const T a[2][
     x[1][1] = a[1][1];
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a, T b, T c, T d)
+template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a, T b, T c, T d) noexcept
 {
     x[0][0] = a;
     x[0][1] = b;
@@ -1124,7 +1124,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a, T b, T c
     x[1][1] = d;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22& v)
+template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22& v) noexcept
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so we don't do this:
@@ -1138,7 +1138,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix2
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22<S>& v)
+IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22<S>& v) noexcept
 {
     x[0][0] = T (v.x[0][0]);
     x[0][1] = T (v.x[0][1]);
@@ -1148,7 +1148,7 @@ IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22<S>& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator= (const Matrix22& v)
+Matrix22<T>::operator= (const Matrix22& v) noexcept
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so we don't do this:
@@ -1163,7 +1163,7 @@ Matrix22<T>::operator= (const Matrix22& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator= (T a)
+Matrix22<T>::operator= (T a) noexcept
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -1174,14 +1174,14 @@ Matrix22<T>::operator= (T a)
 
 template <class T>
 inline T*
-Matrix22<T>::getValue()
+Matrix22<T>::getValue() noexcept
 {
     return (T*) &x[0][0];
 }
 
 template <class T>
 inline const T*
-Matrix22<T>::getValue() const
+Matrix22<T>::getValue() const noexcept
 {
     return (const T*) &x[0][0];
 }
@@ -1189,7 +1189,7 @@ Matrix22<T>::getValue() const
 template <class T>
 template <class S>
 inline void
-Matrix22<T>::getValue (Matrix22<S>& v) const
+Matrix22<T>::getValue (Matrix22<S>& v) const noexcept
 {
     v.x[0][0] = x[0][0];
     v.x[0][1] = x[0][1];
@@ -1200,7 +1200,7 @@ Matrix22<T>::getValue (Matrix22<S>& v) const
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline Matrix22<T>&
-Matrix22<T>::setValue (const Matrix22<S>& v)
+Matrix22<T>::setValue (const Matrix22<S>& v) noexcept
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -1212,7 +1212,7 @@ Matrix22<T>::setValue (const Matrix22<S>& v)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline Matrix22<T>&
-Matrix22<T>::setTheMatrix (const Matrix22<S>& v)
+Matrix22<T>::setTheMatrix (const Matrix22<S>& v) noexcept
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -1223,7 +1223,7 @@ Matrix22<T>::setTheMatrix (const Matrix22<S>& v)
 
 template <class T>
 inline void
-Matrix22<T>::makeIdentity()
+Matrix22<T>::makeIdentity() noexcept
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -1233,7 +1233,7 @@ Matrix22<T>::makeIdentity()
 
 template <class T>
 constexpr inline bool
-Matrix22<T>::operator== (const Matrix22& v) const
+Matrix22<T>::operator== (const Matrix22& v) const noexcept
 {
     return x[0][0] == v.x[0][0] && x[0][1] == v.x[0][1] && x[1][0] == v.x[1][0] &&
            x[1][1] == v.x[1][1];
@@ -1241,7 +1241,7 @@ Matrix22<T>::operator== (const Matrix22& v) const
 
 template <class T>
 constexpr inline bool
-Matrix22<T>::operator!= (const Matrix22& v) const
+Matrix22<T>::operator!= (const Matrix22& v) const noexcept
 {
     return x[0][0] != v.x[0][0] || x[0][1] != v.x[0][1] || x[1][0] != v.x[1][0] ||
            x[1][1] != v.x[1][1];
@@ -1249,7 +1249,7 @@ Matrix22<T>::operator!= (const Matrix22& v) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Matrix22<T>::equalWithAbsError (const Matrix22<T>& m, T e) const
+Matrix22<T>::equalWithAbsError (const Matrix22<T>& m, T e) const noexcept
 {
     for (int i = 0; i < 2; i++)
         for (int j = 0; j < 2; j++)
@@ -1261,7 +1261,7 @@ Matrix22<T>::equalWithAbsError (const Matrix22<T>& m, T e) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Matrix22<T>::equalWithRelError (const Matrix22<T>& m, T e) const
+Matrix22<T>::equalWithRelError (const Matrix22<T>& m, T e) const noexcept
 {
     for (int i = 0; i < 2; i++)
         for (int j = 0; j < 2; j++)
@@ -1273,7 +1273,7 @@ Matrix22<T>::equalWithRelError (const Matrix22<T>& m, T e) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator+= (const Matrix22<T>& v)
+Matrix22<T>::operator+= (const Matrix22<T>& v) noexcept
 {
     x[0][0] += v.x[0][0];
     x[0][1] += v.x[0][1];
@@ -1285,7 +1285,7 @@ Matrix22<T>::operator+= (const Matrix22<T>& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator+= (T a)
+Matrix22<T>::operator+= (T a) noexcept
 {
     x[0][0] += a;
     x[0][1] += a;
@@ -1297,7 +1297,7 @@ Matrix22<T>::operator+= (T a)
 
 template <class T>
 constexpr inline Matrix22<T>
-Matrix22<T>::operator+ (const Matrix22<T>& v) const
+Matrix22<T>::operator+ (const Matrix22<T>& v) const noexcept
 {
     return Matrix22 (x[0][0] + v.x[0][0],
                      x[0][1] + v.x[0][1],
@@ -1307,7 +1307,7 @@ Matrix22<T>::operator+ (const Matrix22<T>& v) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator-= (const Matrix22<T>& v)
+Matrix22<T>::operator-= (const Matrix22<T>& v) noexcept
 {
     x[0][0] -= v.x[0][0];
     x[0][1] -= v.x[0][1];
@@ -1319,7 +1319,7 @@ Matrix22<T>::operator-= (const Matrix22<T>& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator-= (T a)
+Matrix22<T>::operator-= (T a) noexcept
 {
     x[0][0] -= a;
     x[0][1] -= a;
@@ -1331,7 +1331,7 @@ Matrix22<T>::operator-= (T a)
 
 template <class T>
 constexpr inline Matrix22<T>
-Matrix22<T>::operator- (const Matrix22<T>& v) const
+Matrix22<T>::operator- (const Matrix22<T>& v) const noexcept
 {
     return Matrix22 (x[0][0] - v.x[0][0],
                      x[0][1] - v.x[0][1],
@@ -1341,14 +1341,14 @@ Matrix22<T>::operator- (const Matrix22<T>& v) const
 
 template <class T>
 constexpr inline Matrix22<T>
-Matrix22<T>::operator-() const
+Matrix22<T>::operator-() const noexcept
 {
     return Matrix22 (-x[0][0], -x[0][1], -x[1][0], -x[1][1]);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::negate()
+Matrix22<T>::negate() noexcept
 {
     x[0][0] = -x[0][0];
     x[0][1] = -x[0][1];
@@ -1360,7 +1360,7 @@ Matrix22<T>::negate()
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator*= (T a)
+Matrix22<T>::operator*= (T a) noexcept
 {
     x[0][0] *= a;
     x[0][1] *= a;
@@ -1372,21 +1372,21 @@ Matrix22<T>::operator*= (T a)
 
 template <class T>
 constexpr inline Matrix22<T>
-Matrix22<T>::operator* (T a) const
+Matrix22<T>::operator* (T a) const noexcept
 {
     return Matrix22 (x[0][0] * a, x[0][1] * a, x[1][0] * a, x[1][1] * a);
 }
 
 template <class T>
 inline Matrix22<T>
-operator* (T a, const Matrix22<T>& v)
+operator* (T a, const Matrix22<T>& v) noexcept
 {
     return v * a;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator*= (const Matrix22<T>& v)
+Matrix22<T>::operator*= (const Matrix22<T>& v) noexcept
 {
     Matrix22 tmp (T (0));
 
@@ -1401,7 +1401,7 @@ Matrix22<T>::operator*= (const Matrix22<T>& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix22<T>
-Matrix22<T>::operator* (const Matrix22<T>& v) const
+Matrix22<T>::operator* (const Matrix22<T>& v) const noexcept
 {
     Matrix22 tmp (T (0));
 
@@ -1416,7 +1416,7 @@ Matrix22<T>::operator* (const Matrix22<T>& v) const
 template <class T>
 template <class S>
 inline void
-Matrix22<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const
+Matrix22<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept
 {
     S a, b;
 
@@ -1429,7 +1429,7 @@ Matrix22<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator/= (T a)
+Matrix22<T>::operator/= (T a) noexcept
 {
     x[0][0] /= a;
     x[0][1] /= a;
@@ -1441,14 +1441,14 @@ Matrix22<T>::operator/= (T a)
 
 template <class T>
 constexpr inline Matrix22<T>
-Matrix22<T>::operator/ (T a) const
+Matrix22<T>::operator/ (T a) const noexcept
 {
     return Matrix22 (x[0][0] / a, x[0][1] / a, x[1][0] / a, x[1][1] / a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::transpose()
+Matrix22<T>::transpose() noexcept
 {
     Matrix22 tmp (x[0][0], x[1][0], x[0][1], x[1][1]);
     *this = tmp;
@@ -1457,7 +1457,7 @@ Matrix22<T>::transpose()
 
 template <class T>
 constexpr inline Matrix22<T>
-Matrix22<T>::transposed() const
+Matrix22<T>::transposed() const noexcept
 {
     return Matrix22 (x[0][0], x[1][0], x[0][1], x[1][1]);
 }
@@ -1472,7 +1472,7 @@ Matrix22<T>::invert (bool singExc)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::invert()
+Matrix22<T>::invert() noexcept
 {
     *this = inverse();
     return *this;
@@ -1523,7 +1523,7 @@ Matrix22<T>::inverse (bool singExc) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix22<T>
-Matrix22<T>::inverse() const
+Matrix22<T>::inverse() const noexcept
 {
     Matrix22 s (x[1][1], -x[0][1], -x[1][0], x[0][0]);
 
@@ -1563,7 +1563,7 @@ Matrix22<T>::inverse() const
 
 template <class T>
 constexpr inline T
-Matrix22<T>::determinant() const
+Matrix22<T>::determinant() const noexcept
 {
     return x[0][0] * x[1][1] - x[1][0] * x[0][1];
 }
@@ -1571,7 +1571,7 @@ Matrix22<T>::determinant() const
 template <class T>
 template <class S>
 inline const Matrix22<T>&
-Matrix22<T>::setRotation (S r)
+Matrix22<T>::setRotation (S r) noexcept
 {
     S cos_r, sin_r;
 
@@ -1591,7 +1591,7 @@ template <class T>
 template <class S>
 
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::rotate (S r)
+Matrix22<T>::rotate (S r) noexcept
 {
     *this *= Matrix22<T>().setRotation (r);
     return *this;
@@ -1600,7 +1600,7 @@ Matrix22<T>::rotate (S r)
 template <class T>
 
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::setScale (T s)
+Matrix22<T>::setScale (T s) noexcept
 {
     x[0][0] = s;
     x[0][1] = static_cast<T> (0);
@@ -1614,7 +1614,7 @@ template <class T>
 template <class S>
 
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::setScale (const Vec2<S>& s)
+Matrix22<T>::setScale (const Vec2<S>& s) noexcept
 {
     x[0][0] = s.x;
     x[0][1] = static_cast<T> (0);
@@ -1628,7 +1628,7 @@ template <class T>
 template <class S>
 
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::scale (const Vec2<S>& s)
+Matrix22<T>::scale (const Vec2<S>& s) noexcept
 {
     x[0][0] *= s.x;
     x[0][1] *= s.x;
@@ -1645,21 +1645,21 @@ Matrix22<T>::scale (const Vec2<S>& s)
 
 template <class T>
 inline T*
-Matrix33<T>::operator[] (int i)
+Matrix33<T>::operator[] (int i) noexcept
 {
     return x[i];
 }
 
 template <class T>
 inline const T*
-Matrix33<T>::operator[] (int i) const
+Matrix33<T>::operator[] (int i) const noexcept
 {
     return x[i];
 }
 
 template <class T>
 inline IMATH_CONSTEXPR14
-Matrix33<T>::Matrix33()
+Matrix33<T>::Matrix33() noexcept
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -1672,7 +1672,7 @@ Matrix33<T>::Matrix33()
     x[2][2] = 1;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a)
+template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a) noexcept
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -1685,7 +1685,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a)
     x[2][2] = a;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const T a[3][3])
+template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const T a[3][3]) noexcept
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so instead of this:
@@ -1704,7 +1704,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const T a[3][
 
 template <class T>
 
-IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a, T b, T c, T d, T e, T f, T g, T h, T i)
+IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a, T b, T c, T d, T e, T f, T g, T h, T i) noexcept
 {
     x[0][0] = a;
     x[0][1] = b;
@@ -1717,7 +1717,7 @@ IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a, T b, T c, T d, T e, T f, T 
     x[2][2] = i;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33& v)
+template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33& v) noexcept
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so instead of this:
@@ -1737,7 +1737,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix3
 template <class T>
 template <class S>
 
-IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33<S>& v)
+IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33<S>& v) noexcept
 {
     x[0][0] = T (v.x[0][0]);
     x[0][1] = T (v.x[0][1]);
@@ -1753,7 +1753,7 @@ IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33<S>& v)
 template <class T>
 
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator= (const Matrix33& v)
+Matrix33<T>::operator= (const Matrix33& v) noexcept
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so instead of this:
@@ -1774,7 +1774,7 @@ Matrix33<T>::operator= (const Matrix33& v)
 template <class T>
 
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator= (T a)
+Matrix33<T>::operator= (T a) noexcept
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -1790,14 +1790,14 @@ Matrix33<T>::operator= (T a)
 
 template <class T>
 inline T*
-Matrix33<T>::getValue()
+Matrix33<T>::getValue() noexcept
 {
     return (T*) &x[0][0];
 }
 
 template <class T>
 inline const T*
-Matrix33<T>::getValue() const
+Matrix33<T>::getValue() const noexcept
 {
     return (const T*) &x[0][0];
 }
@@ -1805,7 +1805,7 @@ Matrix33<T>::getValue() const
 template <class T>
 template <class S>
 inline void
-Matrix33<T>::getValue (Matrix33<S>& v) const
+Matrix33<T>::getValue (Matrix33<S>& v) const noexcept
 {
     v.x[0][0] = x[0][0];
     v.x[0][1] = x[0][1];
@@ -1821,7 +1821,7 @@ Matrix33<T>::getValue (Matrix33<S>& v) const
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline Matrix33<T>&
-Matrix33<T>::setValue (const Matrix33<S>& v)
+Matrix33<T>::setValue (const Matrix33<S>& v) noexcept
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -1838,7 +1838,7 @@ Matrix33<T>::setValue (const Matrix33<S>& v)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline Matrix33<T>&
-Matrix33<T>::setTheMatrix (const Matrix33<S>& v)
+Matrix33<T>::setTheMatrix (const Matrix33<S>& v) noexcept
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -1854,7 +1854,7 @@ Matrix33<T>::setTheMatrix (const Matrix33<S>& v)
 
 template <class T>
 inline void
-Matrix33<T>::makeIdentity()
+Matrix33<T>::makeIdentity() noexcept
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -1869,7 +1869,7 @@ Matrix33<T>::makeIdentity()
 
 template <class T>
 constexpr inline bool
-Matrix33<T>::operator== (const Matrix33& v) const
+Matrix33<T>::operator== (const Matrix33& v) const noexcept
 {
     return x[0][0] == v.x[0][0] && x[0][1] == v.x[0][1] && x[0][2] == v.x[0][2] &&
            x[1][0] == v.x[1][0] && x[1][1] == v.x[1][1] && x[1][2] == v.x[1][2] &&
@@ -1878,7 +1878,7 @@ Matrix33<T>::operator== (const Matrix33& v) const
 
 template <class T>
 constexpr inline bool
-Matrix33<T>::operator!= (const Matrix33& v) const
+Matrix33<T>::operator!= (const Matrix33& v) const noexcept
 {
     return x[0][0] != v.x[0][0] || x[0][1] != v.x[0][1] || x[0][2] != v.x[0][2] ||
            x[1][0] != v.x[1][0] || x[1][1] != v.x[1][1] || x[1][2] != v.x[1][2] ||
@@ -1887,7 +1887,7 @@ Matrix33<T>::operator!= (const Matrix33& v) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Matrix33<T>::equalWithAbsError (const Matrix33<T>& m, T e) const
+Matrix33<T>::equalWithAbsError (const Matrix33<T>& m, T e) const noexcept
 {
     for (int i = 0; i < 3; i++)
         for (int j = 0; j < 3; j++)
@@ -1899,7 +1899,7 @@ Matrix33<T>::equalWithAbsError (const Matrix33<T>& m, T e) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Matrix33<T>::equalWithRelError (const Matrix33<T>& m, T e) const
+Matrix33<T>::equalWithRelError (const Matrix33<T>& m, T e) const noexcept
 {
     for (int i = 0; i < 3; i++)
         for (int j = 0; j < 3; j++)
@@ -1911,7 +1911,7 @@ Matrix33<T>::equalWithRelError (const Matrix33<T>& m, T e) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator+= (const Matrix33<T>& v)
+Matrix33<T>::operator+= (const Matrix33<T>& v) noexcept
 {
     x[0][0] += v.x[0][0];
     x[0][1] += v.x[0][1];
@@ -1928,7 +1928,7 @@ Matrix33<T>::operator+= (const Matrix33<T>& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator+= (T a)
+Matrix33<T>::operator+= (T a) noexcept
 {
     x[0][0] += a;
     x[0][1] += a;
@@ -1945,7 +1945,7 @@ Matrix33<T>::operator+= (T a)
 
 template <class T>
 constexpr inline Matrix33<T>
-Matrix33<T>::operator+ (const Matrix33<T>& v) const
+Matrix33<T>::operator+ (const Matrix33<T>& v) const noexcept
 {
     return Matrix33 (x[0][0] + v.x[0][0],
                      x[0][1] + v.x[0][1],
@@ -1960,7 +1960,7 @@ Matrix33<T>::operator+ (const Matrix33<T>& v) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator-= (const Matrix33<T>& v)
+Matrix33<T>::operator-= (const Matrix33<T>& v) noexcept
 {
     x[0][0] -= v.x[0][0];
     x[0][1] -= v.x[0][1];
@@ -1977,7 +1977,7 @@ Matrix33<T>::operator-= (const Matrix33<T>& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator-= (T a)
+Matrix33<T>::operator-= (T a) noexcept
 {
     x[0][0] -= a;
     x[0][1] -= a;
@@ -1994,7 +1994,7 @@ Matrix33<T>::operator-= (T a)
 
 template <class T>
 constexpr inline Matrix33<T>
-Matrix33<T>::operator- (const Matrix33<T>& v) const
+Matrix33<T>::operator- (const Matrix33<T>& v) const noexcept
 {
     return Matrix33 (x[0][0] - v.x[0][0],
                      x[0][1] - v.x[0][1],
@@ -2009,7 +2009,7 @@ Matrix33<T>::operator- (const Matrix33<T>& v) const
 
 template <class T>
 constexpr inline Matrix33<T>
-Matrix33<T>::operator-() const
+Matrix33<T>::operator-() const noexcept
 {
     return Matrix33 (-x[0][0],
                      -x[0][1],
@@ -2024,7 +2024,7 @@ Matrix33<T>::operator-() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::negate()
+Matrix33<T>::negate() noexcept
 {
     x[0][0] = -x[0][0];
     x[0][1] = -x[0][1];
@@ -2041,7 +2041,7 @@ Matrix33<T>::negate()
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator*= (T a)
+Matrix33<T>::operator*= (T a) noexcept
 {
     x[0][0] *= a;
     x[0][1] *= a;
@@ -2058,7 +2058,7 @@ Matrix33<T>::operator*= (T a)
 
 template <class T>
 constexpr inline Matrix33<T>
-Matrix33<T>::operator* (T a) const
+Matrix33<T>::operator* (T a) const noexcept
 {
     return Matrix33 (x[0][0] * a,
                      x[0][1] * a,
@@ -2073,14 +2073,14 @@ Matrix33<T>::operator* (T a) const
 
 template <class T>
 inline Matrix33<T> constexpr
-operator* (T a, const Matrix33<T>& v)
+operator* (T a, const Matrix33<T>& v) noexcept
 {
     return v * a;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator*= (const Matrix33<T>& v)
+Matrix33<T>::operator*= (const Matrix33<T>& v) noexcept
 {
     // Avoid initializing with 0 values before immediately overwriting them,
     // and unroll all loops for the best autovectorization.
@@ -2104,7 +2104,7 @@ Matrix33<T>::operator*= (const Matrix33<T>& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix33<T>
-Matrix33<T>::operator* (const Matrix33<T>& v) const
+Matrix33<T>::operator* (const Matrix33<T>& v) const noexcept
 {
     // Avoid initializing with 0 values before immediately overwriting them,
     // and unroll all loops for the best autovectorization.
@@ -2128,7 +2128,7 @@ Matrix33<T>::operator* (const Matrix33<T>& v) const
 template <class T>
 template <class S>
 inline void
-Matrix33<T>::multVecMatrix (const Vec2<S>& src, Vec2<S>& dst) const
+Matrix33<T>::multVecMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept
 {
     S a, b, w;
 
@@ -2143,7 +2143,7 @@ Matrix33<T>::multVecMatrix (const Vec2<S>& src, Vec2<S>& dst) const
 template <class T>
 template <class S>
 inline void
-Matrix33<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const
+Matrix33<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept
 {
     S a, b;
 
@@ -2156,7 +2156,7 @@ Matrix33<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator/= (T a)
+Matrix33<T>::operator/= (T a) noexcept
 {
     x[0][0] /= a;
     x[0][1] /= a;
@@ -2173,7 +2173,7 @@ Matrix33<T>::operator/= (T a)
 
 template <class T>
 constexpr inline Matrix33<T>
-Matrix33<T>::operator/ (T a) const
+Matrix33<T>::operator/ (T a) const noexcept
 {
     return Matrix33 (x[0][0] / a,
                      x[0][1] / a,
@@ -2188,7 +2188,7 @@ Matrix33<T>::operator/ (T a) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::transpose()
+Matrix33<T>::transpose() noexcept
 {
     Matrix33 tmp (x[0][0], x[1][0], x[2][0], x[0][1], x[1][1], x[2][1], x[0][2], x[1][2], x[2][2]);
     *this = tmp;
@@ -2197,7 +2197,7 @@ Matrix33<T>::transpose()
 
 template <class T>
 constexpr inline Matrix33<T>
-Matrix33<T>::transposed() const
+Matrix33<T>::transposed() const noexcept
 {
     return Matrix33 (x[0][0],
                      x[1][0],
@@ -2220,7 +2220,7 @@ Matrix33<T>::gjInvert (bool singExc)
 
 template <class T>
 const inline Matrix33<T>&
-Matrix33<T>::gjInvert()
+Matrix33<T>::gjInvert() noexcept
 {
     *this = gjInverse();
     return *this;
@@ -2332,7 +2332,7 @@ Matrix33<T>::gjInverse (bool singExc) const
 
 template <class T>
 inline Matrix33<T>
-Matrix33<T>::gjInverse() const
+Matrix33<T>::gjInverse() const noexcept
 {
     int i, j, k;
     Matrix33 s;
@@ -2438,7 +2438,7 @@ Matrix33<T>::invert (bool singExc)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::invert()
+Matrix33<T>::invert() noexcept
 {
     *this = inverse();
     return *this;
@@ -2557,7 +2557,7 @@ Matrix33<T>::inverse (bool singExc) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix33<T>
-Matrix33<T>::inverse() const
+Matrix33<T>::inverse() const noexcept
 {
     if (x[0][2] != 0 || x[1][2] != 0 || x[2][2] != 1)
     {
@@ -2662,7 +2662,7 @@ Matrix33<T>::inverse() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Matrix33<T>::minorOf (const int r, const int c) const
+Matrix33<T>::minorOf (const int r, const int c) const noexcept
 {
     int r0 = 0 + (r < 1 ? 1 : 0);
     int r1 = 1 + (r < 2 ? 1 : 0);
@@ -2674,14 +2674,14 @@ Matrix33<T>::minorOf (const int r, const int c) const
 
 template <class T>
 constexpr inline T
-Matrix33<T>::fastMinor (const int r0, const int r1, const int c0, const int c1) const
+Matrix33<T>::fastMinor (const int r0, const int r1, const int c0, const int c1) const noexcept
 {
     return x[r0][c0] * x[r1][c1] - x[r0][c1] * x[r1][c0];
 }
 
 template <class T>
 constexpr inline T
-Matrix33<T>::determinant() const
+Matrix33<T>::determinant() const noexcept
 {
     return x[0][0] * (x[1][1] * x[2][2] - x[1][2] * x[2][1]) +
            x[0][1] * (x[1][2] * x[2][0] - x[1][0] * x[2][2]) +
@@ -2691,7 +2691,7 @@ Matrix33<T>::determinant() const
 template <class T>
 template <class S>
 inline const Matrix33<T>&
-Matrix33<T>::setRotation (S r)
+Matrix33<T>::setRotation (S r) noexcept
 {
     S cos_r, sin_r;
 
@@ -2716,7 +2716,7 @@ Matrix33<T>::setRotation (S r)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::rotate (S r)
+Matrix33<T>::rotate (S r) noexcept
 {
     *this *= Matrix33<T>().setRotation (r);
     return *this;
@@ -2724,7 +2724,7 @@ Matrix33<T>::rotate (S r)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::setScale (T s)
+Matrix33<T>::setScale (T s) noexcept
 {
     x[0][0] = s;
     x[0][1] = 0;
@@ -2747,7 +2747,7 @@ Matrix33<T>::setScale (T s)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::setScale (const Vec2<S>& s)
+Matrix33<T>::setScale (const Vec2<S>& s) noexcept
 {
     x[0][0] = s.x;
     x[0][1] = 0;
@@ -2764,7 +2764,7 @@ Matrix33<T>::setScale (const Vec2<S>& s)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::scale (const Vec2<S>& s)
+Matrix33<T>::scale (const Vec2<S>& s) noexcept
 {
     x[0][0] *= s.x;
     x[0][1] *= s.x;
@@ -2780,7 +2780,7 @@ Matrix33<T>::scale (const Vec2<S>& s)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::setTranslation (const Vec2<S>& t)
+Matrix33<T>::setTranslation (const Vec2<S>& t) noexcept
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -2799,7 +2799,7 @@ Matrix33<T>::setTranslation (const Vec2<S>& t)
 
 template <class T>
 constexpr inline Vec2<T>
-Matrix33<T>::translation() const
+Matrix33<T>::translation() const noexcept
 {
     return Vec2<T> (x[2][0], x[2][1]);
 }
@@ -2807,7 +2807,7 @@ Matrix33<T>::translation() const
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::translate (const Vec2<S>& t)
+Matrix33<T>::translate (const Vec2<S>& t) noexcept
 {
     x[2][0] += t.x * x[0][0] + t.y * x[1][0];
     x[2][1] += t.x * x[0][1] + t.y * x[1][1];
@@ -2819,7 +2819,7 @@ Matrix33<T>::translate (const Vec2<S>& t)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::setShear (const S& xy)
+Matrix33<T>::setShear (const S& xy) noexcept
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -2839,7 +2839,7 @@ Matrix33<T>::setShear (const S& xy)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::setShear (const Vec2<S>& h)
+Matrix33<T>::setShear (const Vec2<S>& h) noexcept
 {
     x[0][0] = 1;
     x[0][1] = h.y;
@@ -2859,7 +2859,7 @@ Matrix33<T>::setShear (const Vec2<S>& h)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::shear (const S& xy)
+Matrix33<T>::shear (const S& xy) noexcept
 {
     //
     // In this case, we don't need a temp. copy of the matrix
@@ -2877,7 +2877,7 @@ Matrix33<T>::shear (const S& xy)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::shear (const Vec2<S>& h)
+Matrix33<T>::shear (const Vec2<S>& h) noexcept
 {
     Matrix33<T> P (*this);
 
@@ -2898,19 +2898,19 @@ Matrix33<T>::shear (const Vec2<S>& h)
 
 template <class T>
 inline T*
-Matrix44<T>::operator[] (int i)
+Matrix44<T>::operator[] (int i) noexcept
 {
     return x[i];
 }
 
 template <class T>
 inline const T*
-Matrix44<T>::operator[] (int i) const
+Matrix44<T>::operator[] (int i) const noexcept
 {
     return x[i];
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44()
+template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44() noexcept
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -2930,7 +2930,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44()
     x[3][3] = 1;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (T a)
+template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (T a) noexcept
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -2950,7 +2950,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (T a)
     x[3][3] = a;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const T a[4][4])
+template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const T a[4][4]) noexcept
 {
     x[0][0] = a[0][0];
     x[0][1] = a[0][1];
@@ -2972,7 +2972,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const T a[4][
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix44<
-    T>::Matrix44 (T a, T b, T c, T d, T e, T f, T g, T h, T i, T j, T k, T l, T m, T n, T o, T p)
+    T>::Matrix44 (T a, T b, T c, T d, T e, T f, T g, T h, T i, T j, T k, T l, T m, T n, T o, T p) noexcept
 {
     x[0][0] = a;
     x[0][1] = b;
@@ -2992,7 +2992,7 @@ IMATH_CONSTEXPR14 inline Matrix44<
     x[3][3] = p;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (Matrix33<T> r, Vec3<T> t)
+template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (Matrix33<T> r, Vec3<T> t) noexcept
 {
     x[0][0] = r[0][0];
     x[0][1] = r[0][1];
@@ -3012,7 +3012,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (Matrix33<T> r
     x[3][3] = 1;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44& v)
+template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44& v) noexcept
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -3034,7 +3034,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix4
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44<S>& v)
+IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44<S>& v) noexcept
 {
     x[0][0] = T (v.x[0][0]);
     x[0][1] = T (v.x[0][1]);
@@ -3056,7 +3056,7 @@ IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44<S>& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator= (const Matrix44& v)
+Matrix44<T>::operator= (const Matrix44& v) noexcept
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -3079,7 +3079,7 @@ Matrix44<T>::operator= (const Matrix44& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator= (T a)
+Matrix44<T>::operator= (T a) noexcept
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -3102,14 +3102,14 @@ Matrix44<T>::operator= (T a)
 
 template <class T>
 inline T*
-Matrix44<T>::getValue()
+Matrix44<T>::getValue() noexcept
 {
     return (T*) &x[0][0];
 }
 
 template <class T>
 inline const T*
-Matrix44<T>::getValue() const
+Matrix44<T>::getValue() const noexcept
 {
     return (const T*) &x[0][0];
 }
@@ -3117,7 +3117,7 @@ Matrix44<T>::getValue() const
 template <class T>
 template <class S>
 inline void
-Matrix44<T>::getValue (Matrix44<S>& v) const
+Matrix44<T>::getValue (Matrix44<S>& v) const noexcept
 {
     v.x[0][0] = x[0][0];
     v.x[0][1] = x[0][1];
@@ -3140,7 +3140,7 @@ Matrix44<T>::getValue (Matrix44<S>& v) const
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline Matrix44<T>&
-Matrix44<T>::setValue (const Matrix44<S>& v)
+Matrix44<T>::setValue (const Matrix44<S>& v) noexcept
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -3164,7 +3164,7 @@ Matrix44<T>::setValue (const Matrix44<S>& v)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline Matrix44<T>&
-Matrix44<T>::setTheMatrix (const Matrix44<S>& v)
+Matrix44<T>::setTheMatrix (const Matrix44<S>& v) noexcept
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -3187,7 +3187,7 @@ Matrix44<T>::setTheMatrix (const Matrix44<S>& v)
 
 template <class T>
 inline void
-Matrix44<T>::makeIdentity()
+Matrix44<T>::makeIdentity() noexcept
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -3209,7 +3209,7 @@ Matrix44<T>::makeIdentity()
 
 template <class T>
 constexpr inline bool
-Matrix44<T>::operator== (const Matrix44& v) const
+Matrix44<T>::operator== (const Matrix44& v) const noexcept
 {
     return x[0][0] == v.x[0][0] && x[0][1] == v.x[0][1] && x[0][2] == v.x[0][2] &&
            x[0][3] == v.x[0][3] && x[1][0] == v.x[1][0] && x[1][1] == v.x[1][1] &&
@@ -3221,7 +3221,7 @@ Matrix44<T>::operator== (const Matrix44& v) const
 
 template <class T>
 constexpr inline bool
-Matrix44<T>::operator!= (const Matrix44& v) const
+Matrix44<T>::operator!= (const Matrix44& v) const noexcept
 {
     return x[0][0] != v.x[0][0] || x[0][1] != v.x[0][1] || x[0][2] != v.x[0][2] ||
            x[0][3] != v.x[0][3] || x[1][0] != v.x[1][0] || x[1][1] != v.x[1][1] ||
@@ -3233,7 +3233,7 @@ Matrix44<T>::operator!= (const Matrix44& v) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Matrix44<T>::equalWithAbsError (const Matrix44<T>& m, T e) const
+Matrix44<T>::equalWithAbsError (const Matrix44<T>& m, T e) const noexcept
 {
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)
@@ -3245,7 +3245,7 @@ Matrix44<T>::equalWithAbsError (const Matrix44<T>& m, T e) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Matrix44<T>::equalWithRelError (const Matrix44<T>& m, T e) const
+Matrix44<T>::equalWithRelError (const Matrix44<T>& m, T e) const noexcept
 {
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)
@@ -3257,7 +3257,7 @@ Matrix44<T>::equalWithRelError (const Matrix44<T>& m, T e) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator+= (const Matrix44<T>& v)
+Matrix44<T>::operator+= (const Matrix44<T>& v) noexcept
 {
     x[0][0] += v.x[0][0];
     x[0][1] += v.x[0][1];
@@ -3281,7 +3281,7 @@ Matrix44<T>::operator+= (const Matrix44<T>& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator+= (T a)
+Matrix44<T>::operator+= (T a) noexcept
 {
     x[0][0] += a;
     x[0][1] += a;
@@ -3305,7 +3305,7 @@ Matrix44<T>::operator+= (T a)
 
 template <class T>
 constexpr inline Matrix44<T>
-Matrix44<T>::operator+ (const Matrix44<T>& v) const
+Matrix44<T>::operator+ (const Matrix44<T>& v) const noexcept
 {
     return Matrix44 (x[0][0] + v.x[0][0],
                      x[0][1] + v.x[0][1],
@@ -3327,7 +3327,7 @@ Matrix44<T>::operator+ (const Matrix44<T>& v) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator-= (const Matrix44<T>& v)
+Matrix44<T>::operator-= (const Matrix44<T>& v) noexcept
 {
     x[0][0] -= v.x[0][0];
     x[0][1] -= v.x[0][1];
@@ -3351,7 +3351,7 @@ Matrix44<T>::operator-= (const Matrix44<T>& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator-= (T a)
+Matrix44<T>::operator-= (T a) noexcept
 {
     x[0][0] -= a;
     x[0][1] -= a;
@@ -3375,7 +3375,7 @@ Matrix44<T>::operator-= (T a)
 
 template <class T>
 constexpr inline Matrix44<T>
-Matrix44<T>::operator- (const Matrix44<T>& v) const
+Matrix44<T>::operator- (const Matrix44<T>& v) const noexcept
 {
     return Matrix44 (x[0][0] - v.x[0][0],
                      x[0][1] - v.x[0][1],
@@ -3397,7 +3397,7 @@ Matrix44<T>::operator- (const Matrix44<T>& v) const
 
 template <class T>
 constexpr inline Matrix44<T>
-Matrix44<T>::operator-() const
+Matrix44<T>::operator-() const noexcept
 {
     return Matrix44 (-x[0][0],
                      -x[0][1],
@@ -3419,7 +3419,7 @@ Matrix44<T>::operator-() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::negate()
+Matrix44<T>::negate() noexcept
 {
     x[0][0] = -x[0][0];
     x[0][1] = -x[0][1];
@@ -3443,7 +3443,7 @@ Matrix44<T>::negate()
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator*= (T a)
+Matrix44<T>::operator*= (T a) noexcept
 {
     x[0][0] *= a;
     x[0][1] *= a;
@@ -3467,7 +3467,7 @@ Matrix44<T>::operator*= (T a)
 
 template <class T>
 constexpr inline Matrix44<T>
-Matrix44<T>::operator* (T a) const
+Matrix44<T>::operator* (T a) const noexcept
 {
     return Matrix44 (x[0][0] * a,
                      x[0][1] * a,
@@ -3489,14 +3489,14 @@ Matrix44<T>::operator* (T a) const
 
 template <class T>
 inline Matrix44<T>
-operator* (T a, const Matrix44<T>& v)
+operator* (T a, const Matrix44<T>& v) noexcept
 {
     return v * a;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator*= (const Matrix44<T>& v)
+Matrix44<T>::operator*= (const Matrix44<T>& v) noexcept
 {
     Matrix44 tmp (T (0));
 
@@ -3507,7 +3507,7 @@ Matrix44<T>::operator*= (const Matrix44<T>& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix44<T>
-Matrix44<T>::operator* (const Matrix44<T>& v) const
+Matrix44<T>::operator* (const Matrix44<T>& v) const noexcept
 {
     Matrix44 tmp (T (0));
 
@@ -3517,7 +3517,7 @@ Matrix44<T>::operator* (const Matrix44<T>& v) const
 
 template <class T>
 inline void
-Matrix44<T>::multiply (const Matrix44<T>& a, const Matrix44<T>& b, Matrix44<T>& c)
+Matrix44<T>::multiply (const Matrix44<T>& a, const Matrix44<T>& b, Matrix44<T>& c) noexcept
 {
     const T* IMATH_RESTRICT ap = &a.x[0][0];
     const T* IMATH_RESTRICT bp = &b.x[0][0];
@@ -3569,7 +3569,7 @@ Matrix44<T>::multiply (const Matrix44<T>& a, const Matrix44<T>& b, Matrix44<T>& 
 template <class T>
 template <class S>
 inline void
-Matrix44<T>::multVecMatrix (const Vec3<S>& src, Vec3<S>& dst) const
+Matrix44<T>::multVecMatrix (const Vec3<S>& src, Vec3<S>& dst) const noexcept
 {
     S a, b, c, w;
 
@@ -3586,7 +3586,7 @@ Matrix44<T>::multVecMatrix (const Vec3<S>& src, Vec3<S>& dst) const
 template <class T>
 template <class S>
 inline void
-Matrix44<T>::multDirMatrix (const Vec3<S>& src, Vec3<S>& dst) const
+Matrix44<T>::multDirMatrix (const Vec3<S>& src, Vec3<S>& dst) const noexcept
 {
     S a, b, c;
 
@@ -3601,7 +3601,7 @@ Matrix44<T>::multDirMatrix (const Vec3<S>& src, Vec3<S>& dst) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator/= (T a)
+Matrix44<T>::operator/= (T a) noexcept
 {
     x[0][0] /= a;
     x[0][1] /= a;
@@ -3625,7 +3625,7 @@ Matrix44<T>::operator/= (T a)
 
 template <class T>
 constexpr inline Matrix44<T>
-Matrix44<T>::operator/ (T a) const
+Matrix44<T>::operator/ (T a) const noexcept
 {
     return Matrix44 (x[0][0] / a,
                      x[0][1] / a,
@@ -3647,7 +3647,7 @@ Matrix44<T>::operator/ (T a) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::transpose()
+Matrix44<T>::transpose() noexcept
 {
     Matrix44 tmp (x[0][0],
                   x[1][0],
@@ -3671,7 +3671,7 @@ Matrix44<T>::transpose()
 
 template <class T>
 constexpr inline Matrix44<T>
-Matrix44<T>::transposed() const
+Matrix44<T>::transposed() const noexcept
 {
     return Matrix44 (x[0][0],
                      x[1][0],
@@ -3701,7 +3701,7 @@ Matrix44<T>::gjInvert (bool singExc)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::gjInvert()
+Matrix44<T>::gjInvert() noexcept
 {
     *this = gjInverse();
     return *this;
@@ -3813,7 +3813,7 @@ Matrix44<T>::gjInverse (bool singExc) const
 
 template <class T>
 inline Matrix44<T>
-Matrix44<T>::gjInverse() const
+Matrix44<T>::gjInverse() const noexcept
 {
     int i, j, k;
     Matrix44 s;
@@ -3919,7 +3919,7 @@ Matrix44<T>::invert (bool singExc)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::invert()
+Matrix44<T>::invert() noexcept
 {
     *this = inverse();
     return *this;
@@ -3996,7 +3996,7 @@ Matrix44<T>::inverse (bool singExc) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix44<T>
-Matrix44<T>::inverse() const
+Matrix44<T>::inverse() const noexcept
 {
     if (x[0][3] != 0 || x[1][3] != 0 || x[2][3] != 0 || x[3][3] != 1)
         return gjInverse();
@@ -4067,7 +4067,7 @@ Matrix44<T>::fastMinor (const int r0,
                         const int r2,
                         const int c0,
                         const int c1,
-                        const int c2) const
+                        const int c2) const noexcept
 {
     return x[r0][c0] * (x[r1][c1] * x[r2][c2] - x[r1][c2] * x[r2][c1]) +
            x[r0][c1] * (x[r1][c2] * x[r2][c0] - x[r1][c0] * x[r2][c2]) +
@@ -4076,7 +4076,7 @@ Matrix44<T>::fastMinor (const int r0,
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Matrix44<T>::minorOf (const int r, const int c) const
+Matrix44<T>::minorOf (const int r, const int c) const noexcept
 {
     int r0 = 0 + (r < 1 ? 1 : 0);
     int r1 = 1 + (r < 2 ? 1 : 0);
@@ -4100,7 +4100,7 @@ Matrix44<T>::minorOf (const int r, const int c) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Matrix44<T>::determinant() const
+Matrix44<T>::determinant() const noexcept
 {
     T sum = (T) 0;
 
@@ -4119,7 +4119,7 @@ Matrix44<T>::determinant() const
 template <class T>
 template <class S>
 inline const Matrix44<T>&
-Matrix44<T>::setEulerAngles (const Vec3<S>& r)
+Matrix44<T>::setEulerAngles (const Vec3<S>& r) noexcept
 {
     S cos_rz, sin_rz, cos_ry, sin_ry, cos_rx, sin_rx;
 
@@ -4157,7 +4157,7 @@ Matrix44<T>::setEulerAngles (const Vec3<S>& r)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::setAxisAngle (const Vec3<S>& axis, S angle)
+Matrix44<T>::setAxisAngle (const Vec3<S>& axis, S angle) noexcept
 {
     Vec3<S> unit (axis.normalized());
     S sine   = std::sin (angle);
@@ -4189,7 +4189,7 @@ Matrix44<T>::setAxisAngle (const Vec3<S>& axis, S angle)
 template <class T>
 template <class S>
 inline const Matrix44<T>&
-Matrix44<T>::rotate (const Vec3<S>& r)
+Matrix44<T>::rotate (const Vec3<S>& r) noexcept
 {
     S cos_rz, sin_rz, cos_ry, sin_ry, cos_rx, sin_rx;
     S m00, m01, m02;
@@ -4236,7 +4236,7 @@ Matrix44<T>::rotate (const Vec3<S>& r)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::setScale (T s)
+Matrix44<T>::setScale (T s) noexcept
 {
     x[0][0] = s;
     x[0][1] = 0;
@@ -4260,7 +4260,7 @@ Matrix44<T>::setScale (T s)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::setScale (const Vec3<S>& s)
+Matrix44<T>::setScale (const Vec3<S>& s) noexcept
 {
     x[0][0] = s.x;
     x[0][1] = 0;
@@ -4284,7 +4284,7 @@ Matrix44<T>::setScale (const Vec3<S>& s)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::scale (const Vec3<S>& s)
+Matrix44<T>::scale (const Vec3<S>& s) noexcept
 {
     x[0][0] *= s.x;
     x[0][1] *= s.x;
@@ -4307,7 +4307,7 @@ Matrix44<T>::scale (const Vec3<S>& s)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::setTranslation (const Vec3<S>& t)
+Matrix44<T>::setTranslation (const Vec3<S>& t) noexcept
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -4334,7 +4334,7 @@ Matrix44<T>::setTranslation (const Vec3<S>& t)
 
 template <class T>
 constexpr inline const Vec3<T>
-Matrix44<T>::translation() const
+Matrix44<T>::translation() const noexcept
 {
     return Vec3<T> (x[3][0], x[3][1], x[3][2]);
 }
@@ -4342,7 +4342,7 @@ Matrix44<T>::translation() const
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::translate (const Vec3<S>& t)
+Matrix44<T>::translate (const Vec3<S>& t) noexcept
 {
     x[3][0] += t.x * x[0][0] + t.y * x[1][0] + t.z * x[2][0];
     x[3][1] += t.x * x[0][1] + t.y * x[1][1] + t.z * x[2][1];
@@ -4355,7 +4355,7 @@ Matrix44<T>::translate (const Vec3<S>& t)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::setShear (const Vec3<S>& h)
+Matrix44<T>::setShear (const Vec3<S>& h) noexcept
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -4383,7 +4383,7 @@ Matrix44<T>::setShear (const Vec3<S>& h)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::setShear (const Shear6<S>& h)
+Matrix44<T>::setShear (const Shear6<S>& h) noexcept
 {
     x[0][0] = 1;
     x[0][1] = h.yx;
@@ -4411,7 +4411,7 @@ Matrix44<T>::setShear (const Shear6<S>& h)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::shear (const Vec3<S>& h)
+Matrix44<T>::shear (const Vec3<S>& h) noexcept
 {
     //
     // In this case, we don't need a temp. copy of the matrix
@@ -4431,7 +4431,7 @@ Matrix44<T>::shear (const Vec3<S>& h)
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::shear (const Shear6<S>& h)
+Matrix44<T>::shear (const Shear6<S>& h) noexcept
 {
     Matrix44<T> P (*this);
 
@@ -4555,7 +4555,7 @@ operator<< (std::ostream& s, const Matrix44<T>& m)
 
 template <class S, class T>
 inline const Vec2<S>&
-operator*= (Vec2<S>& v, const Matrix22<T>& m)
+operator*= (Vec2<S>& v, const Matrix22<T>& m) noexcept
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1]);
@@ -4568,7 +4568,7 @@ operator*= (Vec2<S>& v, const Matrix22<T>& m)
 
 template <class S, class T>
 inline Vec2<S>
-operator* (const Vec2<S>& v, const Matrix22<T>& m)
+operator* (const Vec2<S>& v, const Matrix22<T>& m) noexcept
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1]);
@@ -4578,7 +4578,7 @@ operator* (const Vec2<S>& v, const Matrix22<T>& m)
 
 template <class S, class T>
 inline const Vec2<S>&
-operator*= (Vec2<S>& v, const Matrix33<T>& m)
+operator*= (Vec2<S>& v, const Matrix33<T>& m) noexcept
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + m[2][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + m[2][1]);
@@ -4592,7 +4592,7 @@ operator*= (Vec2<S>& v, const Matrix33<T>& m)
 
 template <class S, class T>
 inline Vec2<S>
-operator* (const Vec2<S>& v, const Matrix33<T>& m)
+operator* (const Vec2<S>& v, const Matrix33<T>& m) noexcept
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + m[2][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + m[2][1]);
@@ -4603,7 +4603,7 @@ operator* (const Vec2<S>& v, const Matrix33<T>& m)
 
 template <class S, class T>
 inline const Vec3<S>&
-operator*= (Vec3<S>& v, const Matrix33<T>& m)
+operator*= (Vec3<S>& v, const Matrix33<T>& m) noexcept
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1]);
@@ -4618,7 +4618,7 @@ operator*= (Vec3<S>& v, const Matrix33<T>& m)
 
 template <class S, class T>
 inline Vec3<S>
-operator* (const Vec3<S>& v, const Matrix33<T>& m)
+operator* (const Vec3<S>& v, const Matrix33<T>& m) noexcept
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1]);
@@ -4629,7 +4629,7 @@ operator* (const Vec3<S>& v, const Matrix33<T>& m)
 
 template <class S, class T>
 inline const Vec3<S>&
-operator*= (Vec3<S>& v, const Matrix44<T>& m)
+operator*= (Vec3<S>& v, const Matrix44<T>& m) noexcept
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0] + m[3][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1] + m[3][1]);
@@ -4645,7 +4645,7 @@ operator*= (Vec3<S>& v, const Matrix44<T>& m)
 
 template <class S, class T>
 inline Vec3<S>
-operator* (const Vec3<S>& v, const Matrix44<T>& m)
+operator* (const Vec3<S>& v, const Matrix44<T>& m) noexcept
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0] + m[3][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1] + m[3][1]);
@@ -4657,7 +4657,7 @@ operator* (const Vec3<S>& v, const Matrix44<T>& m)
 
 template <class S, class T>
 inline const Vec4<S>&
-operator*= (Vec4<S>& v, const Matrix44<T>& m)
+operator*= (Vec4<S>& v, const Matrix44<T>& m) noexcept
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0] + v.w * m[3][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1] + v.w * m[3][1]);
@@ -4674,7 +4674,7 @@ operator*= (Vec4<S>& v, const Matrix44<T>& m)
 
 template <class S, class T>
 inline Vec4<S>
-operator* (const Vec4<S>& v, const Matrix44<T>& m)
+operator* (const Vec4<S>& v, const Matrix44<T>& m) noexcept
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0] + v.w * m[3][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1] + v.w * m[3][1]);

--- a/src/Imath/ImathPlane.h
+++ b/src/Imath/ImathPlane.h
@@ -62,36 +62,36 @@ template <class T> class Plane3
     Vec3<T> normal;
     T distance;
 
-    IMATH_HOSTDEVICE constexpr Plane3() {}
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Plane3 (const Vec3<T>& normal, T distance);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Plane3 (const Vec3<T>& point, const Vec3<T>& normal);
+    IMATH_HOSTDEVICE constexpr Plane3() noexcept {}
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Plane3 (const Vec3<T>& normal, T distance) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Plane3 (const Vec3<T>& point, const Vec3<T>& normal) noexcept;
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Plane3 (const Vec3<T>& point1,
                                                const Vec3<T>& point2,
-                                               const Vec3<T>& point3);
+                                               const Vec3<T>& point3) noexcept;
 
     //----------------------
     //	Various set methods
     //----------------------
 
-    IMATH_HOSTDEVICE void set (const Vec3<T>& normal, T distance);
+    IMATH_HOSTDEVICE void set (const Vec3<T>& normal, T distance) noexcept;
 
-    IMATH_HOSTDEVICE void set (const Vec3<T>& point, const Vec3<T>& normal);
+    IMATH_HOSTDEVICE void set (const Vec3<T>& point, const Vec3<T>& normal) noexcept;
 
-    IMATH_HOSTDEVICE void set (const Vec3<T>& point1, const Vec3<T>& point2, const Vec3<T>& point3);
+    IMATH_HOSTDEVICE void set (const Vec3<T>& point1, const Vec3<T>& point2, const Vec3<T>& point3) noexcept;
 
     //----------------------
     //	Utilities
     //----------------------
 
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool
-    intersect (const Line3<T>& line, Vec3<T>& intersection) const;
+    intersect (const Line3<T>& line, Vec3<T>& intersection) const noexcept;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersectT (const Line3<T>& line, T& parameter) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersectT (const Line3<T>& line, T& parameter) const noexcept;
 
-    IMATH_HOSTDEVICE constexpr T distanceTo (const Vec3<T>&) const;
+    IMATH_HOSTDEVICE constexpr T distanceTo (const Vec3<T>&) const noexcept;
 
-    IMATH_HOSTDEVICE constexpr Vec3<T> reflectPoint (const Vec3<T>&) const;
-    IMATH_HOSTDEVICE constexpr Vec3<T> reflectVector (const Vec3<T>&) const;
+    IMATH_HOSTDEVICE constexpr Vec3<T> reflectPoint (const Vec3<T>&) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3<T> reflectVector (const Vec3<T>&) const noexcept;
 };
 
 //--------------------
@@ -106,24 +106,24 @@ typedef Plane3<double> Plane3d;
 //---------------
 
 template <class T>
-IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& p0, const Vec3<T>& p1, const Vec3<T>& p2)
+IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& p0, const Vec3<T>& p1, const Vec3<T>& p2) noexcept
 {
     set (p0, p1, p2);
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& n, T d)
+template <class T> IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& n, T d) noexcept
 {
     set (n, d);
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& p, const Vec3<T>& n)
+template <class T> IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& p, const Vec3<T>& n) noexcept
 {
     set (p, n);
 }
 
 template <class T>
 inline void
-Plane3<T>::set (const Vec3<T>& point1, const Vec3<T>& point2, const Vec3<T>& point3)
+Plane3<T>::set (const Vec3<T>& point1, const Vec3<T>& point2, const Vec3<T>& point3) noexcept
 {
     normal = (point2 - point1) % (point3 - point1);
     normal.normalize();
@@ -132,7 +132,7 @@ Plane3<T>::set (const Vec3<T>& point1, const Vec3<T>& point2, const Vec3<T>& poi
 
 template <class T>
 inline void
-Plane3<T>::set (const Vec3<T>& point, const Vec3<T>& n)
+Plane3<T>::set (const Vec3<T>& point, const Vec3<T>& n) noexcept
 {
     normal = n;
     normal.normalize();
@@ -141,7 +141,7 @@ Plane3<T>::set (const Vec3<T>& point, const Vec3<T>& n)
 
 template <class T>
 inline void
-Plane3<T>::set (const Vec3<T>& n, T d)
+Plane3<T>::set (const Vec3<T>& n, T d) noexcept
 {
     normal = n;
     normal.normalize();
@@ -150,28 +150,28 @@ Plane3<T>::set (const Vec3<T>& n, T d)
 
 template <class T>
 constexpr inline T
-Plane3<T>::distanceTo (const Vec3<T>& point) const
+Plane3<T>::distanceTo (const Vec3<T>& point) const noexcept
 {
     return (point ^ normal) - distance;
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Plane3<T>::reflectPoint (const Vec3<T>& point) const
+Plane3<T>::reflectPoint (const Vec3<T>& point) const noexcept
 {
     return normal * distanceTo (point) * -2.0 + point;
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Plane3<T>::reflectVector (const Vec3<T>& v) const
+Plane3<T>::reflectVector (const Vec3<T>& v) const noexcept
 {
     return normal * (normal ^ v) * 2.0 - v;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Plane3<T>::intersect (const Line3<T>& line, Vec3<T>& point) const
+Plane3<T>::intersect (const Line3<T>& line, Vec3<T>& point) const noexcept
 {
     T d = normal ^ line.dir;
     if (d == 0.0)
@@ -183,7 +183,7 @@ Plane3<T>::intersect (const Line3<T>& line, Vec3<T>& point) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Plane3<T>::intersectT (const Line3<T>& line, T& t) const
+Plane3<T>::intersectT (const Line3<T>& line, T& t) const noexcept
 {
     T d = normal ^ line.dir;
     if (d == 0.0)
@@ -201,7 +201,7 @@ operator<< (std::ostream& o, const Plane3<T>& plane)
 
 template <class T>
 IMATH_CONSTEXPR14 Plane3<T>
-operator* (const Plane3<T>& plane, const Matrix44<T>& M)
+operator* (const Plane3<T>& plane, const Matrix44<T>& M) noexcept
 {
     //                        T
     //	                    -1
@@ -236,7 +236,7 @@ operator* (const Plane3<T>& plane, const Matrix44<T>& M)
 
 template <class T>
 constexpr inline Plane3<T>
-operator- (const Plane3<T>& plane)
+operator- (const Plane3<T>& plane) noexcept
 {
     return Plane3<T> (-plane.normal, -plane.distance);
 }

--- a/src/Imath/ImathQuat.h
+++ b/src/Imath/ImathQuat.h
@@ -75,27 +75,27 @@ template <class T> class Quat
     // Constructors - default constructor is identity quat
     //-----------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr Quat();
+    IMATH_HOSTDEVICE constexpr Quat() noexcept;
 
-    template <class S> IMATH_HOSTDEVICE constexpr Quat (const Quat<S>& q);
+    template <class S> IMATH_HOSTDEVICE constexpr Quat (const Quat<S>& q) noexcept;
 
-    IMATH_HOSTDEVICE constexpr Quat (T s, T i, T j, T k);
+    IMATH_HOSTDEVICE constexpr Quat (T s, T i, T j, T k) noexcept;
 
-    IMATH_HOSTDEVICE constexpr Quat (T s, Vec3<T> d);
+    IMATH_HOSTDEVICE constexpr Quat (T s, Vec3<T> d) noexcept;
 
-    IMATH_HOSTDEVICE constexpr static Quat<T> identity();
+    IMATH_HOSTDEVICE constexpr static Quat<T> identity() noexcept;
 
     //-------------------
     // Copy constructor
     //-------------------
 
-    IMATH_HOSTDEVICE constexpr Quat (const Quat& q);
+    IMATH_HOSTDEVICE constexpr Quat (const Quat& q) noexcept;
 
     //-------------
     // Destructor
     //-------------
 
-    ~Quat() = default;
+    ~Quat() noexcept = default;
 
     //-------------------------------------------------
     //	Basic Algebra - Operators and Methods
@@ -113,56 +113,56 @@ template <class T> class Quat
     //	a 4D vector when one of the operands is scalar
     //-------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator= (const Quat<T>& q);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator*= (const Quat<T>& q);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator*= (T t);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator/= (const Quat<T>& q);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator/= (T t);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator+= (const Quat<T>& q);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator-= (const Quat<T>& q);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int index); // as 4D vector
-    IMATH_HOSTDEVICE constexpr T operator[] (int index) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator= (const Quat<T>& q) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator*= (const Quat<T>& q) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator*= (T t) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator/= (const Quat<T>& q) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator/= (T t) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator+= (const Quat<T>& q) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator-= (const Quat<T>& q) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int index) noexcept; // as 4D vector
+    IMATH_HOSTDEVICE constexpr T operator[] (int index) const noexcept;
 
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Quat<S>& q) const;
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Quat<S>& q) const;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Quat<S>& q) const noexcept;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Quat<S>& q) const noexcept;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>& invert(); // this -> 1 / this
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T> inverse() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>& normalize(); // returns this
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T> normalized() const;
-    IMATH_HOSTDEVICE constexpr T length() const; // in R4
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T> rotateVector (const Vec3<T>& original) const;
-    IMATH_HOSTDEVICE constexpr T euclideanInnerProduct (const Quat<T>& q) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>& invert() noexcept; // this -> 1 / this
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T> inverse() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>& normalize() noexcept; // returns this
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T> normalized() const noexcept;
+    IMATH_HOSTDEVICE constexpr T length() const noexcept; // in R4
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T> rotateVector (const Vec3<T>& original) const noexcept;
+    IMATH_HOSTDEVICE constexpr T euclideanInnerProduct (const Quat<T>& q) const noexcept;
 
     //-----------------------
     //	Rotation conversion
     //-----------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>& setAxisAngle (const Vec3<T>& axis, T radians);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>& setAxisAngle (const Vec3<T>& axis, T radians) noexcept;
 
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>&
-    setRotation (const Vec3<T>& fromDirection, const Vec3<T>& toDirection);
+    setRotation (const Vec3<T>& fromDirection, const Vec3<T>& toDirection) noexcept;
 
-    IMATH_HOSTDEVICE constexpr T angle() const;
-    IMATH_HOSTDEVICE constexpr Vec3<T> axis() const;
+    IMATH_HOSTDEVICE constexpr T angle() const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3<T> axis() const noexcept;
 
-    IMATH_HOSTDEVICE constexpr Matrix33<T> toMatrix33() const;
-    IMATH_HOSTDEVICE constexpr Matrix44<T> toMatrix44() const;
-    IMATH_HOSTDEVICE Quat<T> log() const;
-    IMATH_HOSTDEVICE Quat<T> exp() const;
+    IMATH_HOSTDEVICE constexpr Matrix33<T> toMatrix33() const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix44<T> toMatrix44() const noexcept;
+    IMATH_HOSTDEVICE Quat<T> log() const noexcept;
+    IMATH_HOSTDEVICE Quat<T> exp() const noexcept;
 
   private:
-    IMATH_HOSTDEVICE void setRotationInternal (const Vec3<T>& f0, const Vec3<T>& t0, Quat<T>& q);
+    IMATH_HOSTDEVICE void setRotationInternal (const Vec3<T>& f0, const Vec3<T>& t0, Quat<T>& q) noexcept;
 };
 
-template <class T> IMATH_CONSTEXPR14 Quat<T> slerp (const Quat<T>& q1, const Quat<T>& q2, T t);
+template <class T> IMATH_CONSTEXPR14 Quat<T> slerp (const Quat<T>& q1, const Quat<T>& q2, T t) noexcept;
 
 template <class T>
-IMATH_CONSTEXPR14 Quat<T> slerpShortestArc (const Quat<T>& q1, const Quat<T>& q2, T t);
+IMATH_CONSTEXPR14 Quat<T> slerpShortestArc (const Quat<T>& q1, const Quat<T>& q2, T t) noexcept;
 
 template <class T>
 IMATH_CONSTEXPR14 Quat<T>
-squad (const Quat<T>& q1, const Quat<T>& q2, const Quat<T>& qa, const Quat<T>& qb, T t);
+squad (const Quat<T>& q1, const Quat<T>& q2, const Quat<T>& qa, const Quat<T>& qb, T t) noexcept;
 
 template <class T>
 void intermediate (const Quat<T>& q0,
@@ -170,33 +170,33 @@ void intermediate (const Quat<T>& q0,
                    const Quat<T>& q2,
                    const Quat<T>& q3,
                    Quat<T>& qa,
-                   Quat<T>& qb);
+                   Quat<T>& qb) noexcept;
 
-template <class T> constexpr Matrix33<T> operator* (const Matrix33<T>& M, const Quat<T>& q);
+template <class T> constexpr Matrix33<T> operator* (const Matrix33<T>& M, const Quat<T>& q) noexcept;
 
-template <class T> constexpr Matrix33<T> operator* (const Quat<T>& q, const Matrix33<T>& M);
+template <class T> constexpr Matrix33<T> operator* (const Quat<T>& q, const Matrix33<T>& M) noexcept;
 
 template <class T> std::ostream& operator<< (std::ostream& o, const Quat<T>& q);
 
-template <class T> constexpr Quat<T> operator* (const Quat<T>& q1, const Quat<T>& q2);
+template <class T> constexpr Quat<T> operator* (const Quat<T>& q1, const Quat<T>& q2) noexcept;
 
-template <class T> constexpr Quat<T> operator/ (const Quat<T>& q1, const Quat<T>& q2);
+template <class T> constexpr Quat<T> operator/ (const Quat<T>& q1, const Quat<T>& q2) noexcept;
 
-template <class T> constexpr Quat<T> operator/ (const Quat<T>& q, T t);
+template <class T> constexpr Quat<T> operator/ (const Quat<T>& q, T t) noexcept;
 
-template <class T> constexpr Quat<T> operator* (const Quat<T>& q, T t);
+template <class T> constexpr Quat<T> operator* (const Quat<T>& q, T t) noexcept;
 
-template <class T> constexpr Quat<T> operator* (T t, const Quat<T>& q);
+template <class T> constexpr Quat<T> operator* (T t, const Quat<T>& q) noexcept;
 
-template <class T> constexpr Quat<T> operator+ (const Quat<T>& q1, const Quat<T>& q2);
+template <class T> constexpr Quat<T> operator+ (const Quat<T>& q1, const Quat<T>& q2) noexcept;
 
-template <class T> constexpr Quat<T> operator- (const Quat<T>& q1, const Quat<T>& q2);
+template <class T> constexpr Quat<T> operator- (const Quat<T>& q1, const Quat<T>& q2) noexcept;
 
-template <class T> constexpr Quat<T> operator~ (const Quat<T>& q);
+template <class T> constexpr Quat<T> operator~ (const Quat<T>& q) noexcept;
 
-template <class T> constexpr Quat<T> operator- (const Quat<T>& q);
+template <class T> constexpr Quat<T> operator- (const Quat<T>& q) noexcept;
 
-template <class T> IMATH_CONSTEXPR14 Vec3<T> operator* (const Vec3<T>& v, const Quat<T>& q);
+template <class T> IMATH_CONSTEXPR14 Vec3<T> operator* (const Vec3<T>& v, const Quat<T>& q) noexcept;
 
 //--------------------
 // Convenient typedefs
@@ -209,43 +209,43 @@ typedef Quat<double> Quatd;
 // Implementation
 //---------------
 
-template <class T> constexpr inline Quat<T>::Quat() : r (1), v (0, 0, 0)
+template <class T> constexpr inline Quat<T>::Quat() noexcept : r (1), v (0, 0, 0)
 {
     // empty
 }
 
 template <class T>
 template <class S>
-constexpr inline Quat<T>::Quat (const Quat<S>& q) : r (q.r), v (q.v)
+constexpr inline Quat<T>::Quat (const Quat<S>& q) noexcept : r (q.r), v (q.v)
 {
     // empty
 }
 
-template <class T> constexpr inline Quat<T>::Quat (T s, T i, T j, T k) : r (s), v (i, j, k)
+template <class T> constexpr inline Quat<T>::Quat (T s, T i, T j, T k) noexcept : r (s), v (i, j, k)
 {
     // empty
 }
 
-template <class T> constexpr inline Quat<T>::Quat (T s, Vec3<T> d) : r (s), v (d)
+template <class T> constexpr inline Quat<T>::Quat (T s, Vec3<T> d) noexcept : r (s), v (d)
 {
     // empty
 }
 
-template <class T> constexpr inline Quat<T>::Quat (const Quat<T>& q) : r (q.r), v (q.v)
+template <class T> constexpr inline Quat<T>::Quat (const Quat<T>& q) noexcept : r (q.r), v (q.v)
 {
     // empty
 }
 
 template <class T>
 constexpr inline Quat<T>
-Quat<T>::identity()
+Quat<T>::identity() noexcept
 {
     return Quat<T>();
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Quat<T>&
-Quat<T>::operator= (const Quat<T>& q)
+Quat<T>::operator= (const Quat<T>& q) noexcept
 {
     r = q.r;
     v = q.v;
@@ -254,7 +254,7 @@ Quat<T>::operator= (const Quat<T>& q)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Quat<T>&
-Quat<T>::operator*= (const Quat<T>& q)
+Quat<T>::operator*= (const Quat<T>& q) noexcept
 {
     T rtmp = r * q.r - (v ^ q.v);
     v      = r * q.v + v * q.r + v % q.v;
@@ -264,7 +264,7 @@ Quat<T>::operator*= (const Quat<T>& q)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Quat<T>&
-Quat<T>::operator*= (T t)
+Quat<T>::operator*= (T t) noexcept
 {
     r *= t;
     v *= t;
@@ -273,7 +273,7 @@ Quat<T>::operator*= (T t)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Quat<T>&
-Quat<T>::operator/= (const Quat<T>& q)
+Quat<T>::operator/= (const Quat<T>& q) noexcept
 {
     *this = *this * q.inverse();
     return *this;
@@ -281,7 +281,7 @@ Quat<T>::operator/= (const Quat<T>& q)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Quat<T>&
-Quat<T>::operator/= (T t)
+Quat<T>::operator/= (T t) noexcept
 {
     r /= t;
     v /= t;
@@ -290,7 +290,7 @@ Quat<T>::operator/= (T t)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Quat<T>&
-Quat<T>::operator+= (const Quat<T>& q)
+Quat<T>::operator+= (const Quat<T>& q) noexcept
 {
     r += q.r;
     v += q.v;
@@ -299,7 +299,7 @@ Quat<T>::operator+= (const Quat<T>& q)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Quat<T>&
-Quat<T>::operator-= (const Quat<T>& q)
+Quat<T>::operator-= (const Quat<T>& q) noexcept
 {
     r -= q.r;
     v -= q.v;
@@ -308,14 +308,14 @@ Quat<T>::operator-= (const Quat<T>& q)
 
 template <class T>
 IMATH_CONSTEXPR14 inline T&
-Quat<T>::operator[] (int index)
+Quat<T>::operator[] (int index) noexcept
 {
     return index ? v[index - 1] : r;
 }
 
 template <class T>
 constexpr inline T
-Quat<T>::operator[] (int index) const
+Quat<T>::operator[] (int index) const noexcept
 {
     return index ? v[index - 1] : r;
 }
@@ -323,7 +323,7 @@ Quat<T>::operator[] (int index) const
 template <class T>
 template <class S>
 constexpr inline bool
-Quat<T>::operator== (const Quat<S>& q) const
+Quat<T>::operator== (const Quat<S>& q) const noexcept
 {
     return r == q.r && v == q.v;
 }
@@ -331,28 +331,28 @@ Quat<T>::operator== (const Quat<S>& q) const
 template <class T>
 template <class S>
 constexpr inline bool
-Quat<T>::operator!= (const Quat<S>& q) const
+Quat<T>::operator!= (const Quat<S>& q) const noexcept
 {
     return r != q.r || v != q.v;
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline T
-operator^ (const Quat<T>& q1, const Quat<T>& q2)
+operator^ (const Quat<T>& q1, const Quat<T>& q2) noexcept
 {
     return q1.r * q2.r + (q1.v ^ q2.v);
 }
 
 template <class T>
 constexpr inline T
-Quat<T>::length() const
+Quat<T>::length() const noexcept
 {
     return std::sqrt (r * r + (v ^ v));
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>&
-Quat<T>::normalize()
+Quat<T>::normalize() noexcept
 {
     if (T l = length())
     {
@@ -370,7 +370,7 @@ Quat<T>::normalize()
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>
-Quat<T>::normalized() const
+Quat<T>::normalized() const noexcept
 {
     if (T l = length())
         return Quat (r / l, v / l);
@@ -380,7 +380,7 @@ Quat<T>::normalized() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>
-Quat<T>::inverse() const
+Quat<T>::inverse() const noexcept
 {
     //
     // 1    Q*
@@ -394,7 +394,7 @@ Quat<T>::inverse() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>&
-Quat<T>::invert()
+Quat<T>::invert() noexcept
 {
     T qdot = (*this) ^ (*this);
     r /= qdot;
@@ -404,7 +404,7 @@ Quat<T>::invert()
 
 template <class T>
 IMATH_CONSTEXPR14 inline Vec3<T>
-Quat<T>::rotateVector (const Vec3<T>& original) const
+Quat<T>::rotateVector (const Vec3<T>& original) const noexcept
 {
     //
     // Given a vector p and a quaternion q (aka this),
@@ -424,14 +424,14 @@ Quat<T>::rotateVector (const Vec3<T>& original) const
 
 template <class T>
 constexpr inline T
-Quat<T>::euclideanInnerProduct (const Quat<T>& q) const
+Quat<T>::euclideanInnerProduct (const Quat<T>& q) const noexcept
 {
     return r * q.r + v.x * q.v.x + v.y * q.v.y + v.z * q.v.z;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-angle4D (const Quat<T>& q1, const Quat<T>& q2)
+angle4D (const Quat<T>& q1, const Quat<T>& q2) noexcept
 {
     //
     // Compute the angle between two quaternions,
@@ -449,7 +449,7 @@ angle4D (const Quat<T>& q1, const Quat<T>& q2)
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>
-slerp (const Quat<T>& q1, const Quat<T>& q2, T t)
+slerp (const Quat<T>& q1, const Quat<T>& q2, T t) noexcept
 {
     //
     // Spherical linear interpolation.
@@ -481,7 +481,7 @@ slerp (const Quat<T>& q1, const Quat<T>& q2, T t)
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>
-slerpShortestArc (const Quat<T>& q1, const Quat<T>& q2, T t)
+slerpShortestArc (const Quat<T>& q1, const Quat<T>& q2, T t) noexcept
 {
     //
     // Spherical linear interpolation along the shortest
@@ -497,7 +497,7 @@ slerpShortestArc (const Quat<T>& q1, const Quat<T>& q2, T t)
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>
-spline (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2, const Quat<T>& q3, T t)
+spline (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2, const Quat<T>& q3, T t) noexcept
 {
     //
     // Spherical Cubic Spline Interpolation -
@@ -530,7 +530,7 @@ spline (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2, const Quat<T>& 
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>
-squad (const Quat<T>& q1, const Quat<T>& qa, const Quat<T>& qb, const Quat<T>& q2, T t)
+squad (const Quat<T>& q1, const Quat<T>& qa, const Quat<T>& qb, const Quat<T>& q2, T t) noexcept
 {
     //
     // Spherical Quadrangle Interpolation -
@@ -550,7 +550,7 @@ squad (const Quat<T>& q1, const Quat<T>& qa, const Quat<T>& qb, const Quat<T>& q
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>
-intermediate (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2)
+intermediate (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2) noexcept
 {
     //
     // From advanced Animation and Rendering
@@ -571,7 +571,7 @@ intermediate (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2)
 
 template <class T>
 inline Quat<T>
-Quat<T>::log() const
+Quat<T>::log() const noexcept
 {
     //
     // For unit quaternion, from Advanced Animation and
@@ -586,7 +586,7 @@ Quat<T>::log() const
     T sintheta = std::sin (theta);
 
     T k;
-    if (abs (sintheta) < 1 && abs (theta) >= limits<T>::max() * abs (sintheta))
+    if (std::abs(sintheta) < 1 && std::abs(theta) >= limits<T>::max() * std::abs(sintheta))
         k = 1;
     else
         k = theta / sintheta;
@@ -596,7 +596,7 @@ Quat<T>::log() const
 
 template <class T>
 inline Quat<T>
-Quat<T>::exp() const
+Quat<T>::exp() const noexcept
 {
     //
     // For pure quaternion (zero scalar part):
@@ -620,21 +620,21 @@ Quat<T>::exp() const
 
 template <class T>
 constexpr inline T
-Quat<T>::angle() const
+Quat<T>::angle() const noexcept
 {
     return 2 * std::atan2 (v.length(), r);
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Quat<T>::axis() const
+Quat<T>::axis() const noexcept
 {
     return v.normalized();
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>&
-Quat<T>::setAxisAngle (const Vec3<T>& axis, T radians)
+Quat<T>::setAxisAngle (const Vec3<T>& axis, T radians) noexcept
 {
     r = std::cos (radians / 2);
     v = axis.normalized() * std::sin (radians / 2);
@@ -643,7 +643,7 @@ Quat<T>::setAxisAngle (const Vec3<T>& axis, T radians)
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>&
-Quat<T>::setRotation (const Vec3<T>& from, const Vec3<T>& to)
+Quat<T>::setRotation (const Vec3<T>& from, const Vec3<T>& to) noexcept
 {
     //
     // Create a quaternion that rotates vector from into vector to,
@@ -717,7 +717,7 @@ Quat<T>::setRotation (const Vec3<T>& from, const Vec3<T>& to)
 
 template <class T>
 inline void
-Quat<T>::setRotationInternal (const Vec3<T>& f0, const Vec3<T>& t0, Quat<T>& q)
+Quat<T>::setRotationInternal (const Vec3<T>& f0, const Vec3<T>& t0, Quat<T>& q) noexcept
 {
     //
     // The following is equivalent to setAxisAngle(n,2*phi),
@@ -748,7 +748,7 @@ Quat<T>::setRotationInternal (const Vec3<T>& f0, const Vec3<T>& t0, Quat<T>& q)
 
 template <class T>
 constexpr inline Matrix33<T>
-Quat<T>::toMatrix33() const
+Quat<T>::toMatrix33() const noexcept
 {
     return Matrix33<T> (1 - 2 * (v.y * v.y + v.z * v.z),
                         2 * (v.x * v.y + v.z * r),
@@ -765,7 +765,7 @@ Quat<T>::toMatrix33() const
 
 template <class T>
 constexpr inline Matrix44<T>
-Quat<T>::toMatrix44() const
+Quat<T>::toMatrix44() const noexcept
 {
     return Matrix44<T> (1 - 2 * (v.y * v.y + v.z * v.z),
                         2 * (v.x * v.y + v.z * r),
@@ -787,14 +787,14 @@ Quat<T>::toMatrix44() const
 
 template <class T>
 constexpr inline Matrix33<T>
-operator* (const Matrix33<T>& M, const Quat<T>& q)
+operator* (const Matrix33<T>& M, const Quat<T>& q) noexcept
 {
     return M * q.toMatrix33();
 }
 
 template <class T>
 constexpr inline Matrix33<T>
-operator* (const Quat<T>& q, const Matrix33<T>& M)
+operator* (const Quat<T>& q, const Matrix33<T>& M) noexcept
 {
     return q.toMatrix33() * M;
 }
@@ -808,70 +808,70 @@ operator<< (std::ostream& o, const Quat<T>& q)
 
 template <class T>
 constexpr inline Quat<T>
-operator* (const Quat<T>& q1, const Quat<T>& q2)
+operator* (const Quat<T>& q1, const Quat<T>& q2) noexcept
 {
     return Quat<T> (q1.r * q2.r - (q1.v ^ q2.v), q1.r * q2.v + q1.v * q2.r + q1.v % q2.v);
 }
 
 template <class T>
 constexpr inline Quat<T>
-operator/ (const Quat<T>& q1, const Quat<T>& q2)
+operator/ (const Quat<T>& q1, const Quat<T>& q2) noexcept
 {
     return q1 * q2.inverse();
 }
 
 template <class T>
 constexpr inline Quat<T>
-operator/ (const Quat<T>& q, T t)
+operator/ (const Quat<T>& q, T t) noexcept
 {
     return Quat<T> (q.r / t, q.v / t);
 }
 
 template <class T>
 constexpr inline Quat<T>
-operator* (const Quat<T>& q, T t)
+operator* (const Quat<T>& q, T t) noexcept
 {
     return Quat<T> (q.r * t, q.v * t);
 }
 
 template <class T>
 constexpr inline Quat<T>
-operator* (T t, const Quat<T>& q)
+operator* (T t, const Quat<T>& q) noexcept
 {
     return Quat<T> (q.r * t, q.v * t);
 }
 
 template <class T>
 constexpr inline Quat<T>
-operator+ (const Quat<T>& q1, const Quat<T>& q2)
+operator+ (const Quat<T>& q1, const Quat<T>& q2) noexcept
 {
     return Quat<T> (q1.r + q2.r, q1.v + q2.v);
 }
 
 template <class T>
 constexpr inline Quat<T>
-operator- (const Quat<T>& q1, const Quat<T>& q2)
+operator- (const Quat<T>& q1, const Quat<T>& q2) noexcept
 {
     return Quat<T> (q1.r - q2.r, q1.v - q2.v);
 }
 
 template <class T>
 constexpr inline Quat<T>
-operator~ (const Quat<T>& q)
+operator~ (const Quat<T>& q) noexcept
 {
     return Quat<T> (q.r, -q.v);
 }
 
 template <class T>
 constexpr inline Quat<T>
-operator- (const Quat<T>& q)
+operator- (const Quat<T>& q) noexcept
 {
     return Quat<T> (-q.r, -q.v);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline Vec3<T>
-operator* (const Vec3<T>& v, const Quat<T>& q)
+operator* (const Vec3<T>& v, const Quat<T>& q) noexcept
 {
     Vec3<T> a = q.v % v;
     Vec3<T> b = q.v % a;

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -74,54 +74,54 @@ template <class T> class Vec2
 
     T x, y;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i);
-    IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i) noexcept;
+    IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const noexcept;
 
     //-------------
     // Constructors
     //-------------
 
-    IMATH_HOSTDEVICE Vec2();                                // no initialization
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Vec2 (T a); // (a a)
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2 (T a, T b);     // (a b)
+    IMATH_HOSTDEVICE Vec2() noexcept;                                // no initialization
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Vec2 (T a) noexcept; // (a a)
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2 (T a, T b) noexcept;     // (a b)
 
     //---------------------------------
     // Copy constructors and assignment
     //---------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2 (const Vec2& v);
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2 (const Vec2<S>& v);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2 (const Vec2& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2 (const Vec2<S>& v) noexcept;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator= (const Vec2& v);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator= (const Vec2& v) noexcept;
 
     //------------
     // Destructor
     //------------
 
-    ~Vec2() = default;
+    ~Vec2() noexcept = default;
 
     //----------------------
     // Compatibility with Sb
     //----------------------
 
-    template <class S> IMATH_HOSTDEVICE void setValue (S a, S b);
+    template <class S> IMATH_HOSTDEVICE void setValue (S a, S b) noexcept;
 
-    template <class S> IMATH_HOSTDEVICE void setValue (const Vec2<S>& v);
+    template <class S> IMATH_HOSTDEVICE void setValue (const Vec2<S>& v) noexcept;
 
-    template <class S> IMATH_HOSTDEVICE void getValue (S& a, S& b) const;
+    template <class S> IMATH_HOSTDEVICE void getValue (S& a, S& b) const noexcept;
 
-    template <class S> IMATH_HOSTDEVICE void getValue (Vec2<S>& v) const;
+    template <class S> IMATH_HOSTDEVICE void getValue (Vec2<S>& v) const noexcept;
 
-    IMATH_HOSTDEVICE T* getValue();
-    IMATH_HOSTDEVICE const T* getValue() const;
+    IMATH_HOSTDEVICE T* getValue() noexcept;
+    IMATH_HOSTDEVICE const T* getValue() const noexcept;
 
     //---------
     // Equality
     //---------
 
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Vec2<S>& v) const;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Vec2<S>& v) const noexcept;
 
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Vec2<S>& v) const;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Vec2<S>& v) const noexcept;
 
     //-----------------------------------------------------------------------
     // Compare two vectors and test if they are "approximately equal":
@@ -141,62 +141,62 @@ template <class T> class Vec2
     //      abs (this[i] - v[i]) <= e * abs (this[i])
     //-----------------------------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Vec2<T>& v, T e) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Vec2<T>& v, T e) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Vec2<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Vec2<T>& v, T e) const noexcept;
 
     //------------
     // Dot product
     //------------
 
-    IMATH_HOSTDEVICE constexpr T dot (const Vec2& v) const;
-    IMATH_HOSTDEVICE constexpr T operator^ (const Vec2& v) const;
+    IMATH_HOSTDEVICE constexpr T dot (const Vec2& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr T operator^ (const Vec2& v) const noexcept;
 
     //------------------------------------------------
     // Right-handed cross product, i.e. z component of
     // Vec3 (this->x, this->y, 0) % Vec3 (v.x, v.y, 0)
     //------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr T cross (const Vec2& v) const;
-    IMATH_HOSTDEVICE constexpr T operator% (const Vec2& v) const;
+    IMATH_HOSTDEVICE constexpr T cross (const Vec2& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr T operator% (const Vec2& v) const noexcept;
 
     //------------------------
     // Component-wise addition
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator+= (const Vec2& v);
-    IMATH_HOSTDEVICE constexpr Vec2 operator+ (const Vec2& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator+= (const Vec2& v) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 operator+ (const Vec2& v) const noexcept;
 
     //---------------------------
     // Component-wise subtraction
     //---------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator-= (const Vec2& v);
-    IMATH_HOSTDEVICE constexpr Vec2 operator- (const Vec2& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator-= (const Vec2& v) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 operator- (const Vec2& v) const noexcept;
 
     //------------------------------------
     // Component-wise multiplication by -1
     //------------------------------------
 
-    IMATH_HOSTDEVICE constexpr Vec2 operator-() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& negate();
+    IMATH_HOSTDEVICE constexpr Vec2 operator-() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& negate() noexcept;
 
     //------------------------------
     // Component-wise multiplication
     //------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator*= (const Vec2& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator*= (T a);
-    IMATH_HOSTDEVICE constexpr Vec2 operator* (const Vec2& v) const;
-    IMATH_HOSTDEVICE constexpr Vec2 operator* (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator*= (const Vec2& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator*= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 operator* (const Vec2& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 operator* (T a) const noexcept;
 
     //------------------------
     // Component-wise division
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator/= (const Vec2& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator/= (T a);
-    IMATH_HOSTDEVICE constexpr Vec2 operator/ (const Vec2& v) const;
-    IMATH_HOSTDEVICE constexpr Vec2 operator/ (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator/= (const Vec2& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator/= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 operator/ (const Vec2& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 operator/ (T a) const noexcept;
 
     //----------------------------------------------------------------
     // Length and normalization:  If v.length() is 0.0, v.normalize()
@@ -207,31 +207,31 @@ template <class T> class Vec2
     // is 0.0, the result is undefined.
     //----------------------------------------------------------------
 
-    IMATH_HOSTDEVICE T length() const;
-    IMATH_HOSTDEVICE constexpr T length2() const;
+    IMATH_HOSTDEVICE T length() const noexcept;
+    IMATH_HOSTDEVICE constexpr T length2() const noexcept;
 
-    IMATH_HOSTDEVICE const Vec2& normalize(); // modifies *this
+    IMATH_HOSTDEVICE const Vec2& normalize() noexcept; // modifies *this
     const Vec2& normalizeExc();
-    IMATH_HOSTDEVICE const Vec2& normalizeNonNull();
+    IMATH_HOSTDEVICE const Vec2& normalizeNonNull() noexcept;
 
-    IMATH_HOSTDEVICE Vec2<T> normalized() const; // does not modify *this
+    IMATH_HOSTDEVICE Vec2<T> normalized() const noexcept; // does not modify *this
     Vec2<T> normalizedExc() const;
-    IMATH_HOSTDEVICE Vec2<T> normalizedNonNull() const;
+    IMATH_HOSTDEVICE Vec2<T> normalizedNonNull() const noexcept;
 
     //--------------------------------------------------------
     // Number of dimensions, i.e. number of elements in a Vec2
     //--------------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() { return 2; }
+    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() noexcept { return 2; }
 
     //-------------------------------------------------
     // Limitations of type T (see also class limits<T>)
     //-------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static T baseTypeMin() { return limits<T>::min(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() { return limits<T>::max(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() { return limits<T>::smallest(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() { return limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMin() noexcept { return limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return limits<T>::smallest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return limits<T>::epsilon(); }
 
     //--------------------------------------------------------------
     // Base type -- in templates, which accept a parameter, V, which
@@ -242,7 +242,7 @@ template <class T> class Vec2
     typedef T BaseType;
 
   private:
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T lengthTiny() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T lengthTiny() const noexcept;
 };
 
 template <class T> class Vec3
@@ -254,31 +254,31 @@ template <class T> class Vec3
 
     T x, y, z;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i);
-    IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i) noexcept;
+    IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const noexcept;
 
     //-------------
     // Constructors
     //-------------
 
-    IMATH_HOSTDEVICE constexpr Vec3();                       // no initialization
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Vec3 (T a);  // (a a a)
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3 (T a, T b, T c); // (a b c)
+    IMATH_HOSTDEVICE constexpr Vec3() noexcept;                       // no initialization
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Vec3 (T a) noexcept;  // (a a a)
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3 (T a, T b, T c) noexcept; // (a b c)
 
     //---------------------------------
     // Copy constructors and assignment
     //---------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3 (const Vec3& v);
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3 (const Vec3<S>& v);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3 (const Vec3& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3 (const Vec3<S>& v) noexcept;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator= (const Vec3& v);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator= (const Vec3& v) noexcept;
 
     //-----------
     // Destructor
     //-----------
 
-    ~Vec3() = default;
+    ~Vec3() noexcept = default;
 
     //---------------------------------------------------------
     // Vec4 to Vec3 conversion, divides x, y and z by w:
@@ -291,7 +291,7 @@ template <class T> class Vec3
     // if w is zero or if division by w would overflow.
     //---------------------------------------------------------
 
-    template <class S> IMATH_HOSTDEVICE explicit IMATH_CONSTEXPR14 Vec3 (const Vec4<S>& v);
+    template <class S> IMATH_HOSTDEVICE explicit IMATH_CONSTEXPR14 Vec3 (const Vec4<S>& v) noexcept;
     template <class S>
     explicit IMATH_CONSTEXPR14 Vec3 (const Vec4<S>& v, InfException);
 
@@ -299,24 +299,24 @@ template <class T> class Vec3
     // Compatibility with Sb
     //----------------------
 
-    template <class S> IMATH_HOSTDEVICE void setValue (S a, S b, S c);
+    template <class S> IMATH_HOSTDEVICE void setValue (S a, S b, S c) noexcept;
 
-    template <class S> IMATH_HOSTDEVICE void setValue (const Vec3<S>& v);
+    template <class S> IMATH_HOSTDEVICE void setValue (const Vec3<S>& v) noexcept;
 
-    template <class S> IMATH_HOSTDEVICE void getValue (S& a, S& b, S& c) const;
+    template <class S> IMATH_HOSTDEVICE void getValue (S& a, S& b, S& c) const noexcept;
 
-    template <class S> IMATH_HOSTDEVICE void getValue (Vec3<S>& v) const;
+    template <class S> IMATH_HOSTDEVICE void getValue (Vec3<S>& v) const noexcept;
 
-    IMATH_HOSTDEVICE T* getValue();
-    IMATH_HOSTDEVICE const T* getValue() const;
+    IMATH_HOSTDEVICE T* getValue() noexcept;
+    IMATH_HOSTDEVICE const T* getValue() const noexcept;
 
     //---------
     // Equality
     //---------
 
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Vec3<S>& v) const;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Vec3<S>& v) const noexcept;
 
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Vec3<S>& v) const;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Vec3<S>& v) const noexcept;
 
     //-----------------------------------------------------------------------
     // Compare two vectors and test if they are "approximately equal":
@@ -336,62 +336,62 @@ template <class T> class Vec3
     //      abs (this[i] - v[i]) <= e * abs (this[i])
     //-----------------------------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Vec3<T>& v, T e) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Vec3<T>& v, T e) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Vec3<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Vec3<T>& v, T e) const noexcept;
 
     //------------
     // Dot product
     //------------
 
-    IMATH_HOSTDEVICE constexpr T dot (const Vec3& v) const;
-    IMATH_HOSTDEVICE constexpr T operator^ (const Vec3& v) const;
+    IMATH_HOSTDEVICE constexpr T dot (const Vec3& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr T operator^ (const Vec3& v) const noexcept;
 
     //---------------------------
     // Right-handed cross product
     //---------------------------
 
-    IMATH_HOSTDEVICE constexpr Vec3 cross (const Vec3& v) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator%= (const Vec3& v);
-    IMATH_HOSTDEVICE constexpr Vec3 operator% (const Vec3& v) const;
+    IMATH_HOSTDEVICE constexpr Vec3 cross (const Vec3& v) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator%= (const Vec3& v) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator% (const Vec3& v) const noexcept;
 
     //------------------------
     // Component-wise addition
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator+= (const Vec3& v);
-    IMATH_HOSTDEVICE constexpr Vec3 operator+ (const Vec3& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator+= (const Vec3& v) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator+ (const Vec3& v) const noexcept;
 
     //---------------------------
     // Component-wise subtraction
     //---------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator-= (const Vec3& v);
-    IMATH_HOSTDEVICE constexpr Vec3 operator- (const Vec3& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator-= (const Vec3& v) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator- (const Vec3& v) const noexcept;
 
     //------------------------------------
     // Component-wise multiplication by -1
     //------------------------------------
 
-    IMATH_HOSTDEVICE constexpr Vec3 operator-() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& negate();
+    IMATH_HOSTDEVICE constexpr Vec3 operator-() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& negate() noexcept;
 
     //------------------------------
     // Component-wise multiplication
     //------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator*= (const Vec3& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator*= (T a);
-    IMATH_HOSTDEVICE constexpr Vec3 operator* (const Vec3& v) const;
-    IMATH_HOSTDEVICE constexpr Vec3 operator* (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator*= (const Vec3& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator*= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator* (const Vec3& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator* (T a) const noexcept;
 
     //------------------------
     // Component-wise division
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator/= (const Vec3& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator/= (T a);
-    IMATH_HOSTDEVICE constexpr Vec3 operator/ (const Vec3& v) const;
-    IMATH_HOSTDEVICE constexpr Vec3 operator/ (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator/= (const Vec3& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator/= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator/ (const Vec3& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator/ (T a) const noexcept;
 
     //----------------------------------------------------------------
     // Length and normalization:  If v.length() is 0.0, v.normalize()
@@ -403,31 +403,31 @@ template <class T> class Vec3
     // is 0.0, the result is undefined.
     //----------------------------------------------------------------
 
-    IMATH_HOSTDEVICE T length() const;
-    IMATH_HOSTDEVICE constexpr T length2() const;
+    IMATH_HOSTDEVICE T length() const noexcept;
+    IMATH_HOSTDEVICE constexpr T length2() const noexcept;
 
-    IMATH_HOSTDEVICE const Vec3& normalize(); // modifies *this
+    IMATH_HOSTDEVICE const Vec3& normalize() noexcept; // modifies *this
     const Vec3& normalizeExc();
-    IMATH_HOSTDEVICE const Vec3& normalizeNonNull();
+    IMATH_HOSTDEVICE const Vec3& normalizeNonNull() noexcept;
 
-    IMATH_HOSTDEVICE Vec3<T> normalized() const; // does not modify *this
+    IMATH_HOSTDEVICE Vec3<T> normalized() const noexcept; // does not modify *this
     Vec3<T> normalizedExc() const;
-    IMATH_HOSTDEVICE Vec3<T> normalizedNonNull() const;
+    IMATH_HOSTDEVICE Vec3<T> normalizedNonNull() const noexcept;
 
     //--------------------------------------------------------
     // Number of dimensions, i.e. number of elements in a Vec3
     //--------------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() { return 3; }
+    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() noexcept { return 3; }
 
     //-------------------------------------------------
     // Limitations of type T (see also class limits<T>)
     //-------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static T baseTypeMin() { return limits<T>::min(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() { return limits<T>::max(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() { return limits<T>::smallest(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() { return limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMin() noexcept { return limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return limits<T>::smallest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return limits<T>::epsilon(); }
 
     //--------------------------------------------------------------
     // Base type -- in templates, which accept a parameter, V, which
@@ -438,7 +438,7 @@ template <class T> class Vec3
     typedef T BaseType;
 
   private:
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T lengthTiny() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T lengthTiny() const noexcept;
 };
 
 template <class T> class Vec4
@@ -450,45 +450,45 @@ template <class T> class Vec4
 
     T x, y, z, w;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i);
-    IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i) noexcept;
+    IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const noexcept;
 
     //-------------
     // Constructors
     //-------------
 
-    IMATH_HOSTDEVICE constexpr Vec4();                            // no initialization
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Vec4 (T a);       // (a a a a)
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec4 (T a, T b, T c, T d); // (a b c d)
+    IMATH_HOSTDEVICE constexpr Vec4() noexcept;                            // no initialization
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Vec4 (T a) noexcept;       // (a a a a)
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec4 (T a, T b, T c, T d) noexcept; // (a b c d)
 
     //---------------------------------
     // Copy constructors and assignment
     //---------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec4 (const Vec4& v);
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec4 (const Vec4<S>& v);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec4 (const Vec4& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec4 (const Vec4<S>& v) noexcept;
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator= (const Vec4& v);
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator= (const Vec4& v) noexcept;
 
     //-----------
     // Destructor
     //-----------
 
-    ~Vec4() = default;
+    ~Vec4() noexcept = default;
 
     //-------------------------------------
     // Vec3 to Vec4 conversion, sets w to 1
     //-------------------------------------
 
-    template <class S> IMATH_HOSTDEVICE explicit IMATH_CONSTEXPR14 Vec4 (const Vec3<S>& v);
+    template <class S> IMATH_HOSTDEVICE explicit IMATH_CONSTEXPR14 Vec4 (const Vec3<S>& v) noexcept;
 
     //---------
     // Equality
     //---------
 
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Vec4<S>& v) const;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Vec4<S>& v) const noexcept;
 
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Vec4<S>& v) const;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Vec4<S>& v) const noexcept;
 
     //-----------------------------------------------------------------------
     // Compare two vectors and test if they are "approximately equal":
@@ -508,15 +508,15 @@ template <class T> class Vec4
     //      abs (this[i] - v[i]) <= e * abs (this[i])
     //-----------------------------------------------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Vec4<T>& v, T e) const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Vec4<T>& v, T e) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Vec4<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Vec4<T>& v, T e) const noexcept;
 
     //------------
     // Dot product
     //------------
 
-    IMATH_HOSTDEVICE constexpr T dot (const Vec4& v) const;
-    IMATH_HOSTDEVICE constexpr T operator^ (const Vec4& v) const;
+    IMATH_HOSTDEVICE constexpr T dot (const Vec4& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr T operator^ (const Vec4& v) const noexcept;
 
     //-----------------------------------
     // Cross product is not defined in 4D
@@ -526,40 +526,40 @@ template <class T> class Vec4
     // Component-wise addition
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator+= (const Vec4& v);
-    IMATH_HOSTDEVICE constexpr Vec4 operator+ (const Vec4& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator+= (const Vec4& v) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 operator+ (const Vec4& v) const noexcept;
 
     //---------------------------
     // Component-wise subtraction
     //---------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator-= (const Vec4& v);
-    IMATH_HOSTDEVICE constexpr Vec4 operator- (const Vec4& v) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator-= (const Vec4& v) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 operator- (const Vec4& v) const noexcept;
 
     //------------------------------------
     // Component-wise multiplication by -1
     //------------------------------------
 
-    IMATH_HOSTDEVICE constexpr Vec4 operator-() const;
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& negate();
+    IMATH_HOSTDEVICE constexpr Vec4 operator-() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& negate() noexcept;
 
     //------------------------------
     // Component-wise multiplication
     //------------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator*= (const Vec4& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator*= (T a);
-    IMATH_HOSTDEVICE constexpr Vec4 operator* (const Vec4& v) const;
-    IMATH_HOSTDEVICE constexpr Vec4 operator* (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator*= (const Vec4& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator*= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 operator* (const Vec4& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 operator* (T a) const noexcept;
 
     //------------------------
     // Component-wise division
     //------------------------
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator/= (const Vec4& v);
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator/= (T a);
-    IMATH_HOSTDEVICE constexpr Vec4 operator/ (const Vec4& v) const;
-    IMATH_HOSTDEVICE constexpr Vec4 operator/ (T a) const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator/= (const Vec4& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator/= (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 operator/ (const Vec4& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 operator/ (T a) const noexcept;
 
     //----------------------------------------------------------------
     // Length and normalization:  If v.length() is 0.0, v.normalize()
@@ -570,31 +570,31 @@ template <class T> class Vec4
     // is 0.0, the result is undefined.
     //----------------------------------------------------------------
 
-    IMATH_HOSTDEVICE T length() const;
-    IMATH_HOSTDEVICE constexpr T length2() const;
+    IMATH_HOSTDEVICE T length() const noexcept;
+    IMATH_HOSTDEVICE constexpr T length2() const noexcept;
 
-    IMATH_HOSTDEVICE const Vec4& normalize(); // modifies *this
+    IMATH_HOSTDEVICE const Vec4& normalize() noexcept; // modifies *this
     const Vec4& normalizeExc();
-    IMATH_HOSTDEVICE const Vec4& normalizeNonNull();
+    IMATH_HOSTDEVICE const Vec4& normalizeNonNull() noexcept;
 
-    IMATH_HOSTDEVICE Vec4<T> normalized() const; // does not modify *this
+    IMATH_HOSTDEVICE Vec4<T> normalized() const noexcept; // does not modify *this
     Vec4<T> normalizedExc() const;
-    IMATH_HOSTDEVICE Vec4<T> normalizedNonNull() const;
+    IMATH_HOSTDEVICE Vec4<T> normalizedNonNull() const noexcept;
 
     //--------------------------------------------------------
     // Number of dimensions, i.e. number of elements in a Vec4
     //--------------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() { return 4; }
+    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() noexcept { return 4; }
 
     //-------------------------------------------------
     // Limitations of type T (see also class limits<T>)
     //-------------------------------------------------
 
-    IMATH_HOSTDEVICE constexpr static T baseTypeMin() { return limits<T>::min(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() { return limits<T>::max(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() { return limits<T>::smallest(); }
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() { return limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMin() noexcept { return limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return limits<T>::smallest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return limits<T>::epsilon(); }
 
     //--------------------------------------------------------------
     // Base type -- in templates, which accept a parameter, V, which
@@ -605,7 +605,7 @@ template <class T> class Vec4
     typedef T BaseType;
 
   private:
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T lengthTiny() const;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T lengthTiny() const noexcept;
 };
 
 //--------------
@@ -622,9 +622,9 @@ template <class T> std::ostream& operator<< (std::ostream& s, const Vec4<T>& v);
 // Reverse multiplication: S * Vec2<T> and S * Vec3<T>
 //----------------------------------------------------
 
-template <class T> IMATH_HOSTDEVICE constexpr Vec2<T> operator* (T a, const Vec2<T>& v);
-template <class T> IMATH_HOSTDEVICE constexpr Vec3<T> operator* (T a, const Vec3<T>& v);
-template <class T> IMATH_HOSTDEVICE constexpr Vec4<T> operator* (T a, const Vec4<T>& v);
+template <class T> IMATH_HOSTDEVICE constexpr Vec2<T> operator* (T a, const Vec2<T>& v) noexcept;
+template <class T> IMATH_HOSTDEVICE constexpr Vec3<T> operator* (T a, const Vec3<T>& v) noexcept;
+template <class T> IMATH_HOSTDEVICE constexpr Vec4<T> operator* (T a, const Vec4<T>& v) noexcept;
 
 //-------------------------
 // Typedefs for convenience
@@ -649,58 +649,58 @@ typedef Vec4<double> V4d;
 //-------------------------------------------
 
 // Vec2<short>
-template <> short Vec2<short>::length() const = delete;
-template <> const Vec2<short>& Vec2<short>::normalize() = delete;
+template <> short Vec2<short>::length() const noexcept = delete;
+template <> const Vec2<short>& Vec2<short>::normalize() noexcept = delete;
 template <> const Vec2<short>& Vec2<short>::normalizeExc() = delete;
-template <> const Vec2<short>& Vec2<short>::normalizeNonNull() = delete;
-template <> Vec2<short> Vec2<short>::normalized() const = delete;
+template <> const Vec2<short>& Vec2<short>::normalizeNonNull() noexcept = delete;
+template <> Vec2<short> Vec2<short>::normalized() const noexcept = delete;
 template <> Vec2<short> Vec2<short>::normalizedExc() const = delete;
-template <> Vec2<short> Vec2<short>::normalizedNonNull() const = delete;
+template <> Vec2<short> Vec2<short>::normalizedNonNull() const noexcept = delete;
 
 // Vec2<int>
-template <> int Vec2<int>::length() const = delete;
-template <> const Vec2<int>& Vec2<int>::normalize() = delete;
+template <> int Vec2<int>::length() const noexcept = delete;
+template <> const Vec2<int>& Vec2<int>::normalize() noexcept = delete;
 template <> const Vec2<int>& Vec2<int>::normalizeExc() = delete;
-template <> const Vec2<int>& Vec2<int>::normalizeNonNull() = delete;
-template <> Vec2<int> Vec2<int>::normalized() const = delete;
+template <> const Vec2<int>& Vec2<int>::normalizeNonNull() noexcept = delete;
+template <> Vec2<int> Vec2<int>::normalized() const noexcept = delete;
 template <> Vec2<int> Vec2<int>::normalizedExc() const = delete;
-template <> Vec2<int> Vec2<int>::normalizedNonNull() const = delete;
+template <> Vec2<int> Vec2<int>::normalizedNonNull() const noexcept = delete;
 
 // Vec3<short>
-template <> short Vec3<short>::length() const = delete;
-template <> const Vec3<short>& Vec3<short>::normalize() = delete;
+template <> short Vec3<short>::length() const noexcept = delete;
+template <> const Vec3<short>& Vec3<short>::normalize() noexcept = delete;
 template <> const Vec3<short>& Vec3<short>::normalizeExc() = delete;
-template <> const Vec3<short>& Vec3<short>::normalizeNonNull() = delete;
-template <> Vec3<short> Vec3<short>::normalized() const = delete;
+template <> const Vec3<short>& Vec3<short>::normalizeNonNull() noexcept = delete;
+template <> Vec3<short> Vec3<short>::normalized() const noexcept = delete;
 template <> Vec3<short> Vec3<short>::normalizedExc() const = delete;
-template <> Vec3<short> Vec3<short>::normalizedNonNull() const = delete;
+template <> Vec3<short> Vec3<short>::normalizedNonNull() const noexcept = delete;
 
 // Vec3<int>
-template <> int Vec3<int>::length() const = delete;
-template <> const Vec3<int>& Vec3<int>::normalize() = delete;
+template <> int Vec3<int>::length() const noexcept = delete;
+template <> const Vec3<int>& Vec3<int>::normalize() noexcept = delete;
 template <> const Vec3<int>& Vec3<int>::normalizeExc() = delete;
-template <> const Vec3<int>& Vec3<int>::normalizeNonNull() = delete;
-template <> Vec3<int> Vec3<int>::normalized() const = delete;
+template <> const Vec3<int>& Vec3<int>::normalizeNonNull() noexcept = delete;
+template <> Vec3<int> Vec3<int>::normalized() const noexcept = delete;
 template <> Vec3<int> Vec3<int>::normalizedExc() const = delete;
-template <> Vec3<int> Vec3<int>::normalizedNonNull() const = delete;
+template <> Vec3<int> Vec3<int>::normalizedNonNull() const noexcept = delete;
 
 // Vec4<short>
-template <> short Vec4<short>::length() const = delete;
-template <> const Vec4<short>& Vec4<short>::normalize() = delete;
+template <> short Vec4<short>::length() const noexcept = delete;
+template <> const Vec4<short>& Vec4<short>::normalize() noexcept = delete;
 template <> const Vec4<short>& Vec4<short>::normalizeExc() = delete;
-template <> const Vec4<short>& Vec4<short>::normalizeNonNull() = delete;
-template <> Vec4<short> Vec4<short>::normalized() const = delete;
+template <> const Vec4<short>& Vec4<short>::normalizeNonNull() noexcept = delete;
+template <> Vec4<short> Vec4<short>::normalized() const noexcept = delete;
 template <> Vec4<short> Vec4<short>::normalizedExc() const = delete;
-template <> Vec4<short> Vec4<short>::normalizedNonNull() const = delete;
+template <> Vec4<short> Vec4<short>::normalizedNonNull() const noexcept = delete;
 
 // Vec4<int>
-template <> int Vec4<int>::length() const = delete;
-template <> const Vec4<int>& Vec4<int>::normalize() = delete;
+template <> int Vec4<int>::length() const noexcept = delete;
+template <> const Vec4<int>& Vec4<int>::normalize() noexcept = delete;
 template <> const Vec4<int>& Vec4<int>::normalizeExc() = delete;
-template <> const Vec4<int>& Vec4<int>::normalizeNonNull() = delete;
-template <> Vec4<int> Vec4<int>::normalized() const = delete;
+template <> const Vec4<int>& Vec4<int>::normalizeNonNull() noexcept = delete;
+template <> Vec4<int> Vec4<int>::normalized() const noexcept = delete;
 template <> Vec4<int> Vec4<int>::normalizedExc() const = delete;
-template <> Vec4<int> Vec4<int>::normalizedNonNull() const = delete;
+template <> Vec4<int> Vec4<int>::normalizedNonNull() const noexcept = delete;
 
 //------------------------
 // Implementation of Vec2:
@@ -708,41 +708,41 @@ template <> Vec4<int> Vec4<int>::normalizedNonNull() const = delete;
 
 template <class T>
 IMATH_CONSTEXPR14 inline T&
-Vec2<T>::operator[] (int i)
+Vec2<T>::operator[] (int i) noexcept
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>
 constexpr inline const T&
-Vec2<T>::operator[] (int i) const
+Vec2<T>::operator[] (int i) const noexcept
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
-template <class T> inline Vec2<T>::Vec2()
+template <class T> inline Vec2<T>::Vec2() noexcept
 {
     // empty
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Vec2<T>::Vec2 (T a)
+template <class T> IMATH_CONSTEXPR14 inline Vec2<T>::Vec2 (T a) noexcept
 {
     x = y = a;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Vec2<T>::Vec2 (T a, T b)
+template <class T> IMATH_CONSTEXPR14 inline Vec2<T>::Vec2 (T a, T b) noexcept
 {
     x = a;
     y = b;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Vec2<T>::Vec2 (const Vec2& v)
+template <class T> IMATH_CONSTEXPR14 inline Vec2<T>::Vec2 (const Vec2& v) noexcept
 {
     x = v.x;
     y = v.y;
 }
 
-template <class T> template <class S> IMATH_CONSTEXPR14 inline Vec2<T>::Vec2 (const Vec2<S>& v)
+template <class T> template <class S> IMATH_CONSTEXPR14 inline Vec2<T>::Vec2 (const Vec2<S>& v) noexcept
 {
     x = T (v.x);
     y = T (v.y);
@@ -750,7 +750,7 @@ template <class T> template <class S> IMATH_CONSTEXPR14 inline Vec2<T>::Vec2 (co
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::operator= (const Vec2& v)
+Vec2<T>::operator= (const Vec2& v) noexcept
 {
     x = v.x;
     y = v.y;
@@ -760,7 +760,7 @@ Vec2<T>::operator= (const Vec2& v)
 template <class T>
 template <class S>
 inline void
-Vec2<T>::setValue (S a, S b)
+Vec2<T>::setValue (S a, S b) noexcept
 {
     x = T (a);
     y = T (b);
@@ -769,7 +769,7 @@ Vec2<T>::setValue (S a, S b)
 template <class T>
 template <class S>
 inline void
-Vec2<T>::setValue (const Vec2<S>& v)
+Vec2<T>::setValue (const Vec2<S>& v) noexcept
 {
     x = T (v.x);
     y = T (v.y);
@@ -778,7 +778,7 @@ Vec2<T>::setValue (const Vec2<S>& v)
 template <class T>
 template <class S>
 inline void
-Vec2<T>::getValue (S& a, S& b) const
+Vec2<T>::getValue (S& a, S& b) const noexcept
 {
     a = S (x);
     b = S (y);
@@ -787,7 +787,7 @@ Vec2<T>::getValue (S& a, S& b) const
 template <class T>
 template <class S>
 inline void
-Vec2<T>::getValue (Vec2<S>& v) const
+Vec2<T>::getValue (Vec2<S>& v) const noexcept
 {
     v.x = S (x);
     v.y = S (y);
@@ -795,14 +795,14 @@ Vec2<T>::getValue (Vec2<S>& v) const
 
 template <class T>
 inline T*
-Vec2<T>::getValue()
+Vec2<T>::getValue() noexcept
 {
     return (T*) &x;
 }
 
 template <class T>
 inline const T*
-Vec2<T>::getValue() const
+Vec2<T>::getValue() const noexcept
 {
     return (const T*) &x;
 }
@@ -810,7 +810,7 @@ Vec2<T>::getValue() const
 template <class T>
 template <class S>
 constexpr inline bool
-Vec2<T>::operator== (const Vec2<S>& v) const
+Vec2<T>::operator== (const Vec2<S>& v) const noexcept
 {
     return x == v.x && y == v.y;
 }
@@ -818,14 +818,14 @@ Vec2<T>::operator== (const Vec2<S>& v) const
 template <class T>
 template <class S>
 constexpr inline bool
-Vec2<T>::operator!= (const Vec2<S>& v) const
+Vec2<T>::operator!= (const Vec2<S>& v) const noexcept
 {
     return x != v.x || y != v.y;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Vec2<T>::equalWithAbsError (const Vec2<T>& v, T e) const
+Vec2<T>::equalWithAbsError (const Vec2<T>& v, T e) const noexcept
 {
     for (int i = 0; i < 2; i++)
         if (!IMATH_INTERNAL_NAMESPACE::equalWithAbsError ((*this)[i], v[i], e))
@@ -836,7 +836,7 @@ Vec2<T>::equalWithAbsError (const Vec2<T>& v, T e) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Vec2<T>::equalWithRelError (const Vec2<T>& v, T e) const
+Vec2<T>::equalWithRelError (const Vec2<T>& v, T e) const noexcept
 {
     for (int i = 0; i < 2; i++)
         if (!IMATH_INTERNAL_NAMESPACE::equalWithRelError ((*this)[i], v[i], e))
@@ -847,35 +847,35 @@ Vec2<T>::equalWithRelError (const Vec2<T>& v, T e) const
 
 template <class T>
 constexpr inline T
-Vec2<T>::dot (const Vec2& v) const
+Vec2<T>::dot (const Vec2& v) const noexcept
 {
     return x * v.x + y * v.y;
 }
 
 template <class T>
 constexpr inline T
-Vec2<T>::operator^ (const Vec2& v) const
+Vec2<T>::operator^ (const Vec2& v) const noexcept
 {
     return dot (v);
 }
 
 template <class T>
 constexpr inline T
-Vec2<T>::cross (const Vec2& v) const
+Vec2<T>::cross (const Vec2& v) const noexcept
 {
     return x * v.y - y * v.x;
 }
 
 template <class T>
 constexpr inline T
-Vec2<T>::operator% (const Vec2& v) const
+Vec2<T>::operator% (const Vec2& v) const noexcept
 {
     return x * v.y - y * v.x;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::operator+= (const Vec2& v)
+Vec2<T>::operator+= (const Vec2& v) noexcept
 {
     x += v.x;
     y += v.y;
@@ -884,14 +884,14 @@ Vec2<T>::operator+= (const Vec2& v)
 
 template <class T>
 constexpr inline Vec2<T>
-Vec2<T>::operator+ (const Vec2& v) const
+Vec2<T>::operator+ (const Vec2& v) const noexcept
 {
     return Vec2 (x + v.x, y + v.y);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::operator-= (const Vec2& v)
+Vec2<T>::operator-= (const Vec2& v) noexcept
 {
     x -= v.x;
     y -= v.y;
@@ -900,21 +900,21 @@ Vec2<T>::operator-= (const Vec2& v)
 
 template <class T>
 constexpr inline Vec2<T>
-Vec2<T>::operator- (const Vec2& v) const
+Vec2<T>::operator- (const Vec2& v) const noexcept
 {
     return Vec2 (x - v.x, y - v.y);
 }
 
 template <class T>
 constexpr inline Vec2<T>
-Vec2<T>::operator-() const
+Vec2<T>::operator-() const noexcept
 {
     return Vec2 (-x, -y);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::negate()
+Vec2<T>::negate() noexcept
 {
     x = -x;
     y = -y;
@@ -923,7 +923,7 @@ Vec2<T>::negate()
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::operator*= (const Vec2& v)
+Vec2<T>::operator*= (const Vec2& v) noexcept
 {
     x *= v.x;
     y *= v.y;
@@ -932,7 +932,7 @@ Vec2<T>::operator*= (const Vec2& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::operator*= (T a)
+Vec2<T>::operator*= (T a) noexcept
 {
     x *= a;
     y *= a;
@@ -941,21 +941,21 @@ Vec2<T>::operator*= (T a)
 
 template <class T>
 constexpr inline Vec2<T>
-Vec2<T>::operator* (const Vec2& v) const
+Vec2<T>::operator* (const Vec2& v) const noexcept
 {
     return Vec2 (x * v.x, y * v.y);
 }
 
 template <class T>
 constexpr inline Vec2<T>
-Vec2<T>::operator* (T a) const
+Vec2<T>::operator* (T a) const noexcept
 {
     return Vec2 (x * a, y * a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::operator/= (const Vec2& v)
+Vec2<T>::operator/= (const Vec2& v) noexcept
 {
     x /= v.x;
     y /= v.y;
@@ -964,7 +964,7 @@ Vec2<T>::operator/= (const Vec2& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::operator/= (T a)
+Vec2<T>::operator/= (T a) noexcept
 {
     x /= a;
     y /= a;
@@ -973,21 +973,21 @@ Vec2<T>::operator/= (T a)
 
 template <class T>
 constexpr inline Vec2<T>
-Vec2<T>::operator/ (const Vec2& v) const
+Vec2<T>::operator/ (const Vec2& v) const noexcept
 {
     return Vec2 (x / v.x, y / v.y);
 }
 
 template <class T>
 constexpr inline Vec2<T>
-Vec2<T>::operator/ (T a) const
+Vec2<T>::operator/ (T a) const noexcept
 {
     return Vec2 (x / a, y / a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Vec2<T>::lengthTiny() const
+Vec2<T>::lengthTiny() const noexcept
 {
     T absX = std::abs(x);
     T absY = std::abs(y);
@@ -1014,7 +1014,7 @@ Vec2<T>::lengthTiny() const
 
 template <class T>
 inline T
-Vec2<T>::length() const
+Vec2<T>::length() const noexcept
 {
     T length2 = dot (*this);
 
@@ -1026,14 +1026,14 @@ Vec2<T>::length() const
 
 template <class T>
 constexpr inline T
-Vec2<T>::length2() const
+Vec2<T>::length2() const noexcept
 {
     return dot (*this);
 }
 
 template <class T>
 inline const Vec2<T>&
-Vec2<T>::normalize()
+Vec2<T>::normalize() noexcept
 {
     T l = length();
 
@@ -1068,7 +1068,7 @@ Vec2<T>::normalizeExc()
 
 template <class T>
 inline const Vec2<T>&
-Vec2<T>::normalizeNonNull()
+Vec2<T>::normalizeNonNull() noexcept
 {
     T l = length();
     x /= l;
@@ -1078,7 +1078,7 @@ Vec2<T>::normalizeNonNull()
 
 template <class T>
 inline Vec2<T>
-Vec2<T>::normalized() const
+Vec2<T>::normalized() const noexcept
 {
     T l = length();
 
@@ -1102,7 +1102,7 @@ Vec2<T>::normalizedExc() const
 
 template <class T>
 inline Vec2<T>
-Vec2<T>::normalizedNonNull() const
+Vec2<T>::normalizedNonNull() const noexcept
 {
     T l = length();
     return Vec2 (x / l, y / l);
@@ -1114,43 +1114,43 @@ Vec2<T>::normalizedNonNull() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline T&
-Vec3<T>::operator[] (int i)
+Vec3<T>::operator[] (int i) noexcept
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>
 constexpr inline const T&
-Vec3<T>::operator[] (int i) const
+Vec3<T>::operator[] (int i) const noexcept
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
-template <class T> constexpr inline Vec3<T>::Vec3()
+template <class T> constexpr inline Vec3<T>::Vec3() noexcept
 {
     // empty
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (T a)
+template <class T> IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (T a) noexcept
 {
     x = y = z = a;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (T a, T b, T c)
+template <class T> IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (T a, T b, T c) noexcept
 {
     x = a;
     y = b;
     z = c;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (const Vec3& v)
+template <class T> IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (const Vec3& v) noexcept
 {
     x = v.x;
     y = v.y;
     z = v.z;
 }
 
-template <class T> template <class S> IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (const Vec3<S>& v)
+template <class T> template <class S> IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (const Vec3<S>& v) noexcept
 {
     x = T (v.x);
     y = T (v.y);
@@ -1159,7 +1159,7 @@ template <class T> template <class S> IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (co
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator= (const Vec3& v)
+Vec3<T>::operator= (const Vec3& v) noexcept
 {
     x = v.x;
     y = v.y;
@@ -1167,7 +1167,7 @@ Vec3<T>::operator= (const Vec3& v)
     return *this;
 }
 
-template <class T> template <class S> IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (const Vec4<S>& v)
+template <class T> template <class S> IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (const Vec4<S>& v) noexcept
 {
     x = T (v.x / v.w);
     y = T (v.y / v.w);
@@ -1201,7 +1201,7 @@ IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (const Vec4<S>& v, InfException)
 template <class T>
 template <class S>
 inline void
-Vec3<T>::setValue (S a, S b, S c)
+Vec3<T>::setValue (S a, S b, S c) noexcept
 {
     x = T (a);
     y = T (b);
@@ -1211,7 +1211,7 @@ Vec3<T>::setValue (S a, S b, S c)
 template <class T>
 template <class S>
 inline void
-Vec3<T>::setValue (const Vec3<S>& v)
+Vec3<T>::setValue (const Vec3<S>& v) noexcept
 {
     x = T (v.x);
     y = T (v.y);
@@ -1221,7 +1221,7 @@ Vec3<T>::setValue (const Vec3<S>& v)
 template <class T>
 template <class S>
 inline void
-Vec3<T>::getValue (S& a, S& b, S& c) const
+Vec3<T>::getValue (S& a, S& b, S& c) const noexcept
 {
     a = S (x);
     b = S (y);
@@ -1231,7 +1231,7 @@ Vec3<T>::getValue (S& a, S& b, S& c) const
 template <class T>
 template <class S>
 inline void
-Vec3<T>::getValue (Vec3<S>& v) const
+Vec3<T>::getValue (Vec3<S>& v) const noexcept
 {
     v.x = S (x);
     v.y = S (y);
@@ -1240,14 +1240,14 @@ Vec3<T>::getValue (Vec3<S>& v) const
 
 template <class T>
 inline T*
-Vec3<T>::getValue()
+Vec3<T>::getValue() noexcept
 {
     return (T*) &x;
 }
 
 template <class T>
 inline const T*
-Vec3<T>::getValue() const
+Vec3<T>::getValue() const noexcept
 {
     return (const T*) &x;
 }
@@ -1255,7 +1255,7 @@ Vec3<T>::getValue() const
 template <class T>
 template <class S>
 constexpr inline bool
-Vec3<T>::operator== (const Vec3<S>& v) const
+Vec3<T>::operator== (const Vec3<S>& v) const noexcept
 {
     return x == v.x && y == v.y && z == v.z;
 }
@@ -1263,14 +1263,14 @@ Vec3<T>::operator== (const Vec3<S>& v) const
 template <class T>
 template <class S>
 constexpr inline bool
-Vec3<T>::operator!= (const Vec3<S>& v) const
+Vec3<T>::operator!= (const Vec3<S>& v) const noexcept
 {
     return x != v.x || y != v.y || z != v.z;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Vec3<T>::equalWithAbsError (const Vec3<T>& v, T e) const
+Vec3<T>::equalWithAbsError (const Vec3<T>& v, T e) const noexcept
 {
     for (int i = 0; i < 3; i++)
         if (!IMATH_INTERNAL_NAMESPACE::equalWithAbsError ((*this)[i], v[i], e))
@@ -1281,7 +1281,7 @@ Vec3<T>::equalWithAbsError (const Vec3<T>& v, T e) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Vec3<T>::equalWithRelError (const Vec3<T>& v, T e) const
+Vec3<T>::equalWithRelError (const Vec3<T>& v, T e) const noexcept
 {
     for (int i = 0; i < 3; i++)
         if (!IMATH_INTERNAL_NAMESPACE::equalWithRelError ((*this)[i], v[i], e))
@@ -1292,28 +1292,28 @@ Vec3<T>::equalWithRelError (const Vec3<T>& v, T e) const
 
 template <class T>
 constexpr inline T
-Vec3<T>::dot (const Vec3& v) const
+Vec3<T>::dot (const Vec3& v) const noexcept
 {
     return x * v.x + y * v.y + z * v.z;
 }
 
 template <class T>
 constexpr inline T
-Vec3<T>::operator^ (const Vec3& v) const
+Vec3<T>::operator^ (const Vec3& v) const noexcept
 {
     return dot (v);
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::cross (const Vec3& v) const
+Vec3<T>::cross (const Vec3& v) const noexcept
 {
     return Vec3 (y * v.z - z * v.y, z * v.x - x * v.z, x * v.y - y * v.x);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator%= (const Vec3& v)
+Vec3<T>::operator%= (const Vec3& v) noexcept
 {
     T a = y * v.z - z * v.y;
     T b = z * v.x - x * v.z;
@@ -1326,14 +1326,14 @@ Vec3<T>::operator%= (const Vec3& v)
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator% (const Vec3& v) const
+Vec3<T>::operator% (const Vec3& v) const noexcept
 {
     return Vec3 (y * v.z - z * v.y, z * v.x - x * v.z, x * v.y - y * v.x);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator+= (const Vec3& v)
+Vec3<T>::operator+= (const Vec3& v) noexcept
 {
     x += v.x;
     y += v.y;
@@ -1343,14 +1343,14 @@ Vec3<T>::operator+= (const Vec3& v)
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator+ (const Vec3& v) const
+Vec3<T>::operator+ (const Vec3& v) const noexcept
 {
     return Vec3 (x + v.x, y + v.y, z + v.z);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator-= (const Vec3& v)
+Vec3<T>::operator-= (const Vec3& v) noexcept
 {
     x -= v.x;
     y -= v.y;
@@ -1360,21 +1360,21 @@ Vec3<T>::operator-= (const Vec3& v)
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator- (const Vec3& v) const
+Vec3<T>::operator- (const Vec3& v) const noexcept
 {
     return Vec3 (x - v.x, y - v.y, z - v.z);
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator-() const
+Vec3<T>::operator-() const noexcept
 {
     return Vec3 (-x, -y, -z);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::negate()
+Vec3<T>::negate() noexcept
 {
     x = -x;
     y = -y;
@@ -1384,7 +1384,7 @@ Vec3<T>::negate()
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator*= (const Vec3& v)
+Vec3<T>::operator*= (const Vec3& v) noexcept
 {
     x *= v.x;
     y *= v.y;
@@ -1394,7 +1394,7 @@ Vec3<T>::operator*= (const Vec3& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator*= (T a)
+Vec3<T>::operator*= (T a) noexcept
 {
     x *= a;
     y *= a;
@@ -1404,21 +1404,21 @@ Vec3<T>::operator*= (T a)
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator* (const Vec3& v) const
+Vec3<T>::operator* (const Vec3& v) const noexcept
 {
     return Vec3 (x * v.x, y * v.y, z * v.z);
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator* (T a) const
+Vec3<T>::operator* (T a) const noexcept
 {
     return Vec3 (x * a, y * a, z * a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator/= (const Vec3& v)
+Vec3<T>::operator/= (const Vec3& v) noexcept
 {
     x /= v.x;
     y /= v.y;
@@ -1428,7 +1428,7 @@ Vec3<T>::operator/= (const Vec3& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator/= (T a)
+Vec3<T>::operator/= (T a) noexcept
 {
     x /= a;
     y /= a;
@@ -1438,21 +1438,21 @@ Vec3<T>::operator/= (T a)
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator/ (const Vec3& v) const
+Vec3<T>::operator/ (const Vec3& v) const noexcept
 {
     return Vec3 (x / v.x, y / v.y, z / v.z);
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator/ (T a) const
+Vec3<T>::operator/ (T a) const noexcept
 {
     return Vec3 (x / a, y / a, z / a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Vec3<T>::lengthTiny() const
+Vec3<T>::lengthTiny() const noexcept
 {
     T absX = (x >= T (0)) ? x : -x;
     T absY = (y >= T (0)) ? y : -y;
@@ -1484,7 +1484,7 @@ Vec3<T>::lengthTiny() const
 
 template <class T>
 inline T
-Vec3<T>::length() const
+Vec3<T>::length() const noexcept
 {
     T length2 = dot (*this);
 
@@ -1496,14 +1496,14 @@ Vec3<T>::length() const
 
 template <class T>
 constexpr inline T
-Vec3<T>::length2() const
+Vec3<T>::length2() const noexcept
 {
     return dot (*this);
 }
 
 template <class T>
 inline const Vec3<T>&
-Vec3<T>::normalize()
+Vec3<T>::normalize() noexcept
 {
     T l = length();
 
@@ -1540,7 +1540,7 @@ Vec3<T>::normalizeExc()
 
 template <class T>
 inline const Vec3<T>&
-Vec3<T>::normalizeNonNull()
+Vec3<T>::normalizeNonNull() noexcept
 {
     T l = length();
     x /= l;
@@ -1551,7 +1551,7 @@ Vec3<T>::normalizeNonNull()
 
 template <class T>
 inline Vec3<T>
-Vec3<T>::normalized() const
+Vec3<T>::normalized() const noexcept
 {
     T l = length();
 
@@ -1575,7 +1575,7 @@ Vec3<T>::normalizedExc() const
 
 template <class T>
 inline Vec3<T>
-Vec3<T>::normalizedNonNull() const
+Vec3<T>::normalizedNonNull() const noexcept
 {
     T l = length();
     return Vec3 (x / l, y / l, z / l);
@@ -1587,29 +1587,29 @@ Vec3<T>::normalizedNonNull() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline T&
-Vec4<T>::operator[] (int i)
+Vec4<T>::operator[] (int i) noexcept
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>
 constexpr inline const T&
-Vec4<T>::operator[] (int i) const
+Vec4<T>::operator[] (int i) const noexcept
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
-template <class T> constexpr inline Vec4<T>::Vec4()
+template <class T> constexpr inline Vec4<T>::Vec4() noexcept
 {
     // empty
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Vec4<T>::Vec4 (T a)
+template <class T> IMATH_CONSTEXPR14 inline Vec4<T>::Vec4 (T a) noexcept
 {
     x = y = z = w = a;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Vec4<T>::Vec4 (T a, T b, T c, T d)
+template <class T> IMATH_CONSTEXPR14 inline Vec4<T>::Vec4 (T a, T b, T c, T d) noexcept
 {
     x = a;
     y = b;
@@ -1617,7 +1617,7 @@ template <class T> IMATH_CONSTEXPR14 inline Vec4<T>::Vec4 (T a, T b, T c, T d)
     w = d;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Vec4<T>::Vec4 (const Vec4& v)
+template <class T> IMATH_CONSTEXPR14 inline Vec4<T>::Vec4 (const Vec4& v) noexcept
 {
     x = v.x;
     y = v.y;
@@ -1625,7 +1625,7 @@ template <class T> IMATH_CONSTEXPR14 inline Vec4<T>::Vec4 (const Vec4& v)
     w = v.w;
 }
 
-template <class T> template <class S> IMATH_CONSTEXPR14 inline Vec4<T>::Vec4 (const Vec4<S>& v)
+template <class T> template <class S> IMATH_CONSTEXPR14 inline Vec4<T>::Vec4 (const Vec4<S>& v) noexcept
 {
     x = T (v.x);
     y = T (v.y);
@@ -1635,7 +1635,7 @@ template <class T> template <class S> IMATH_CONSTEXPR14 inline Vec4<T>::Vec4 (co
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::operator= (const Vec4& v)
+Vec4<T>::operator= (const Vec4& v) noexcept
 {
     x = v.x;
     y = v.y;
@@ -1644,7 +1644,7 @@ Vec4<T>::operator= (const Vec4& v)
     return *this;
 }
 
-template <class T> template <class S> IMATH_CONSTEXPR14 inline Vec4<T>::Vec4 (const Vec3<S>& v)
+template <class T> template <class S> IMATH_CONSTEXPR14 inline Vec4<T>::Vec4 (const Vec3<S>& v) noexcept
 {
     x = T (v.x);
     y = T (v.y);
@@ -1655,7 +1655,7 @@ template <class T> template <class S> IMATH_CONSTEXPR14 inline Vec4<T>::Vec4 (co
 template <class T>
 template <class S>
 constexpr inline bool
-Vec4<T>::operator== (const Vec4<S>& v) const
+Vec4<T>::operator== (const Vec4<S>& v) const noexcept
 {
     return x == v.x && y == v.y && z == v.z && w == v.w;
 }
@@ -1663,14 +1663,14 @@ Vec4<T>::operator== (const Vec4<S>& v) const
 template <class T>
 template <class S>
 constexpr inline bool
-Vec4<T>::operator!= (const Vec4<S>& v) const
+Vec4<T>::operator!= (const Vec4<S>& v) const noexcept
 {
     return x != v.x || y != v.y || z != v.z || w != v.w;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Vec4<T>::equalWithAbsError (const Vec4<T>& v, T e) const
+Vec4<T>::equalWithAbsError (const Vec4<T>& v, T e) const noexcept
 {
     for (int i = 0; i < 4; i++)
         if (!IMATH_INTERNAL_NAMESPACE::equalWithAbsError ((*this)[i], v[i], e))
@@ -1681,7 +1681,7 @@ Vec4<T>::equalWithAbsError (const Vec4<T>& v, T e) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Vec4<T>::equalWithRelError (const Vec4<T>& v, T e) const
+Vec4<T>::equalWithRelError (const Vec4<T>& v, T e) const noexcept
 {
     for (int i = 0; i < 4; i++)
         if (!IMATH_INTERNAL_NAMESPACE::equalWithRelError ((*this)[i], v[i], e))
@@ -1692,21 +1692,21 @@ Vec4<T>::equalWithRelError (const Vec4<T>& v, T e) const
 
 template <class T>
 constexpr inline T
-Vec4<T>::dot (const Vec4& v) const
+Vec4<T>::dot (const Vec4& v) const noexcept
 {
     return x * v.x + y * v.y + z * v.z + w * v.w;
 }
 
 template <class T>
 constexpr inline T
-Vec4<T>::operator^ (const Vec4& v) const
+Vec4<T>::operator^ (const Vec4& v) const noexcept
 {
     return dot (v);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::operator+= (const Vec4& v)
+Vec4<T>::operator+= (const Vec4& v) noexcept
 {
     x += v.x;
     y += v.y;
@@ -1717,14 +1717,14 @@ Vec4<T>::operator+= (const Vec4& v)
 
 template <class T>
 constexpr inline Vec4<T>
-Vec4<T>::operator+ (const Vec4& v) const
+Vec4<T>::operator+ (const Vec4& v) const noexcept
 {
     return Vec4 (x + v.x, y + v.y, z + v.z, w + v.w);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::operator-= (const Vec4& v)
+Vec4<T>::operator-= (const Vec4& v) noexcept
 {
     x -= v.x;
     y -= v.y;
@@ -1735,21 +1735,21 @@ Vec4<T>::operator-= (const Vec4& v)
 
 template <class T>
 constexpr inline Vec4<T>
-Vec4<T>::operator- (const Vec4& v) const
+Vec4<T>::operator- (const Vec4& v) const noexcept
 {
     return Vec4 (x - v.x, y - v.y, z - v.z, w - v.w);
 }
 
 template <class T>
 constexpr inline Vec4<T>
-Vec4<T>::operator-() const
+Vec4<T>::operator-() const noexcept
 {
     return Vec4 (-x, -y, -z, -w);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::negate()
+Vec4<T>::negate() noexcept
 {
     x = -x;
     y = -y;
@@ -1760,7 +1760,7 @@ Vec4<T>::negate()
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::operator*= (const Vec4& v)
+Vec4<T>::operator*= (const Vec4& v) noexcept
 {
     x *= v.x;
     y *= v.y;
@@ -1771,7 +1771,7 @@ Vec4<T>::operator*= (const Vec4& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::operator*= (T a)
+Vec4<T>::operator*= (T a) noexcept
 {
     x *= a;
     y *= a;
@@ -1782,21 +1782,21 @@ Vec4<T>::operator*= (T a)
 
 template <class T>
 constexpr inline Vec4<T>
-Vec4<T>::operator* (const Vec4& v) const
+Vec4<T>::operator* (const Vec4& v) const noexcept
 {
     return Vec4 (x * v.x, y * v.y, z * v.z, w * v.w);
 }
 
 template <class T>
 constexpr inline Vec4<T>
-Vec4<T>::operator* (T a) const
+Vec4<T>::operator* (T a) const noexcept
 {
     return Vec4 (x * a, y * a, z * a, w * a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::operator/= (const Vec4& v)
+Vec4<T>::operator/= (const Vec4& v) noexcept
 {
     x /= v.x;
     y /= v.y;
@@ -1807,7 +1807,7 @@ Vec4<T>::operator/= (const Vec4& v)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::operator/= (T a)
+Vec4<T>::operator/= (T a) noexcept
 {
     x /= a;
     y /= a;
@@ -1818,21 +1818,21 @@ Vec4<T>::operator/= (T a)
 
 template <class T>
 constexpr inline Vec4<T>
-Vec4<T>::operator/ (const Vec4& v) const
+Vec4<T>::operator/ (const Vec4& v) const noexcept
 {
     return Vec4 (x / v.x, y / v.y, z / v.z, w / v.w);
 }
 
 template <class T>
 constexpr inline Vec4<T>
-Vec4<T>::operator/ (T a) const
+Vec4<T>::operator/ (T a) const noexcept
 {
     return Vec4 (x / a, y / a, z / a, w / a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Vec4<T>::lengthTiny() const
+Vec4<T>::lengthTiny() const noexcept
 {
     T absX = (x >= T (0)) ? x : -x;
     T absY = (y >= T (0)) ? y : -y;
@@ -1869,7 +1869,7 @@ Vec4<T>::lengthTiny() const
 
 template <class T>
 inline T
-Vec4<T>::length() const
+Vec4<T>::length() const noexcept
 {
     T length2 = dot (*this);
 
@@ -1881,14 +1881,14 @@ Vec4<T>::length() const
 
 template <class T>
 constexpr inline T
-Vec4<T>::length2() const
+Vec4<T>::length2() const noexcept
 {
     return dot (*this);
 }
 
 template <class T>
 const inline Vec4<T>&
-Vec4<T>::normalize()
+Vec4<T>::normalize() noexcept
 {
     T l = length();
 
@@ -1927,7 +1927,7 @@ Vec4<T>::normalizeExc()
 
 template <class T>
 inline const Vec4<T>&
-Vec4<T>::normalizeNonNull()
+Vec4<T>::normalizeNonNull() noexcept
 {
     T l = length();
     x /= l;
@@ -1939,7 +1939,7 @@ Vec4<T>::normalizeNonNull()
 
 template <class T>
 inline Vec4<T>
-Vec4<T>::normalized() const
+Vec4<T>::normalized() const noexcept
 {
     T l = length();
 
@@ -1963,7 +1963,7 @@ Vec4<T>::normalizedExc() const
 
 template <class T>
 inline Vec4<T>
-Vec4<T>::normalizedNonNull() const
+Vec4<T>::normalizedNonNull() const noexcept
 {
     T l = length();
     return Vec4 (x / l, y / l, z / l, w / l);
@@ -2000,21 +2000,21 @@ operator<< (std::ostream& s, const Vec4<T>& v)
 
 template <class T>
 constexpr inline Vec2<T>
-operator* (T a, const Vec2<T>& v)
+operator* (T a, const Vec2<T>& v) noexcept
 {
     return Vec2<T> (a * v.x, a * v.y);
 }
 
 template <class T>
 constexpr inline Vec3<T>
-operator* (T a, const Vec3<T>& v)
+operator* (T a, const Vec3<T>& v) noexcept
 {
     return Vec3<T> (a * v.x, a * v.y, a * v.z);
 }
 
 template <class T>
 constexpr inline Vec4<T>
-operator* (T a, const Vec4<T>& v)
+operator* (T a, const Vec4<T>& v) noexcept
 {
     return Vec4<T> (a * v.x, a * v.y, a * v.z, a * v.w);
 }

--- a/src/Imath/ImathVecAlgo.h
+++ b/src/Imath/ImathVecAlgo.h
@@ -58,7 +58,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 template <class Vec,
           IMATH_ENABLE_IF(!std::is_integral<typename Vec::BaseType>::value)>
 IMATH_CONSTEXPR14 inline Vec
-project (const Vec& s, const Vec& t)
+project (const Vec& s, const Vec& t) noexcept
 {
     Vec sNormalized = s.normalized();
     return sNormalized * (sNormalized ^ t);
@@ -72,7 +72,7 @@ project (const Vec& s, const Vec& t)
 template <class Vec,
           IMATH_ENABLE_IF(!std::is_integral<typename Vec::BaseType>::value)>
 constexpr inline Vec
-orthogonal (const Vec& s, const Vec& t)
+orthogonal (const Vec& s, const Vec& t) noexcept
 {
     return t - project (s, t);
 }
@@ -85,7 +85,7 @@ orthogonal (const Vec& s, const Vec& t)
 template <class Vec,
           IMATH_ENABLE_IF(!std::is_integral<typename Vec::BaseType>::value)>
 constexpr inline Vec
-reflect (const Vec& s, const Vec& t)
+reflect (const Vec& s, const Vec& t) noexcept
 {
     return s - typename Vec::BaseType (2) * (s - project (t, s));
 }
@@ -97,7 +97,7 @@ reflect (const Vec& s, const Vec& t)
 //--------------------------------------------------------------------
 
 template <class Vec>
-IMATH_CONSTEXPR14 Vec closestVertex (const Vec& v0, const Vec& v1, const Vec& v2, const Vec& p);
+IMATH_CONSTEXPR14 Vec closestVertex (const Vec& v0, const Vec& v1, const Vec& v2, const Vec& p) noexcept;
 
 //---------------
 // Implementation
@@ -105,7 +105,7 @@ IMATH_CONSTEXPR14 Vec closestVertex (const Vec& v0, const Vec& v1, const Vec& v2
 
 template <class Vec>
 IMATH_CONSTEXPR14 Vec
-closestVertex (const Vec& v0, const Vec& v1, const Vec& v2, const Vec& p)
+closestVertex (const Vec& v0, const Vec& v1, const Vec& v2, const Vec& p) noexcept
 {
     Vec nearest                    = v0;
     typename Vec::BaseType neardot = (v0 - p).length2();

--- a/src/Imath/half.cpp
+++ b/src/Imath/half.cpp
@@ -72,7 +72,7 @@ EXPORT_CONST const unsigned short half::_eLut[1 << 9] =
 //-----------------------------------------------
 
 IMATH_EXPORT float
-half::overflow()
+half::overflow() noexcept
 {
     volatile float f = 1e10;
 
@@ -88,7 +88,7 @@ half::overflow()
 //-----------------------------------------------------
 
 IMATH_EXPORT short
-half::convert (int i)
+half::convert (int i) noexcept
 {
     //
     // Our floating point number, f, is represented by the bit

--- a/src/Imath/half.h
+++ b/src/Imath/half.h
@@ -98,44 +98,44 @@ class half
     // Constructors
     //-------------
 
-    half() = default; // no initialization
-    half (float f);
+    half() noexcept = default; // no initialization
+    half (float f) noexcept;
     // rule of 5
-    ~half()                = default;
-    half (const half&)     = default;
-    half (half&&) noexcept = default;
+    ~half() noexcept            = default;
+    half (const half&) noexcept = default;
+    half (half&&) noexcept      = default;
 
     //--------------------
     // Conversion to float
     //--------------------
 
-    operator float() const;
+    operator float() const noexcept;
 
     //------------
     // Unary minus
     //------------
 
-    half operator-() const;
+    half operator-() const noexcept;
 
     //-----------
     // Assignment
     //-----------
 
-    half& operator= (const half& h) = default;
-    half& operator= (half&& h) noexcept = default;
-    half& operator                      = (float f);
+    half& operator= (const half& h) noexcept = default;
+    half& operator= (half&& h) noexcept      = default;
+    half& operator= (float f) noexcept;
 
-    half& operator+= (half h);
-    half& operator+= (float f);
+    half& operator+= (half h) noexcept;
+    half& operator+= (float f) noexcept;
 
-    half& operator-= (half h);
-    half& operator-= (float f);
+    half& operator-= (half h) noexcept;
+    half& operator-= (float f) noexcept;
 
-    half& operator*= (half h);
-    half& operator*= (float f);
+    half& operator*= (half h) noexcept;
+    half& operator*= (float f) noexcept;
 
-    half& operator/= (half h);
-    half& operator/= (float f);
+    half& operator/= (half h) noexcept;
+    half& operator/= (float f) noexcept;
 
     //---------------------------------------------------------
     // Round to n-bit precision (n should be between 0 and 10).
@@ -143,7 +143,7 @@ class half
     // bits will be zero.
     //---------------------------------------------------------
 
-    half round (unsigned int n) const;
+    half round (unsigned int n) const noexcept;
 
     //--------------------------------------------------------------------
     // Classification:
@@ -166,13 +166,13 @@ class half
     //				is set (negative)
     //--------------------------------------------------------------------
 
-    bool isFinite() const;
-    bool isNormalized() const;
-    bool isDenormalized() const;
-    bool isZero() const;
-    bool isNan() const;
-    bool isInfinity() const;
-    bool isNegative() const;
+    bool isFinite() const noexcept;
+    bool isNormalized() const noexcept;
+    bool isDenormalized() const noexcept;
+    bool isZero() const noexcept;
+    bool isNan() const noexcept;
+    bool isInfinity() const noexcept;
+    bool isNegative() const noexcept;
 
     //--------------------------------------------
     // Special values
@@ -188,17 +188,17 @@ class half
     //			pattern 0111110111111111
     //--------------------------------------------
 
-    static half posInf();
-    static half negInf();
-    static half qNan();
-    static half sNan();
+    static half posInf() noexcept;
+    static half negInf() noexcept;
+    static half qNan() noexcept;
+    static half sNan() noexcept;
 
     //--------------------------------------
     // Access to the internal representation
     //--------------------------------------
 
-    IMATH_EXPORT unsigned short bits() const;
-    IMATH_EXPORT void setBits (unsigned short bits);
+    IMATH_EXPORT unsigned short bits() const noexcept;
+    IMATH_EXPORT void setBits (unsigned short bits) noexcept;
 
   public:
     union uif
@@ -208,8 +208,8 @@ class half
     };
 
   private:
-    IMATH_EXPORT static short convert (int i);
-    IMATH_EXPORT static float overflow();
+    IMATH_EXPORT static short convert (int i) noexcept;
+    IMATH_EXPORT static float overflow() noexcept;
 
     unsigned short _h;
 
@@ -395,7 +395,7 @@ class half
 // Half-from-float constructor
 //----------------------------
 
-inline half::half (float f)
+inline half::half (float f) noexcept
 {
     uif x;
 
@@ -457,7 +457,7 @@ inline half::half (float f)
 // Half-to-float conversion via table lookup
 //------------------------------------------
 
-inline half::operator float() const
+inline half::operator float() const noexcept
 {
     return _toFloat[_h].f;
 }
@@ -467,7 +467,7 @@ inline half::operator float() const
 //-------------------------
 
 inline half
-half::round (unsigned int n) const
+half::round (unsigned int n) const noexcept
 {
     //
     // Parameter check.
@@ -525,7 +525,7 @@ half::round (unsigned int n) const
 //-----------------------
 
 inline half
-half::operator-() const
+half::operator-() const noexcept
 {
     half h;
     h._h = _h ^ 0x8000;
@@ -533,84 +533,84 @@ half::operator-() const
 }
 
 inline half&
-half::operator= (float f)
+half::operator= (float f) noexcept
 {
     *this = half (f);
     return *this;
 }
 
 inline half&
-half::operator+= (half h)
+half::operator+= (half h) noexcept
 {
     *this = half (float (*this) + float (h));
     return *this;
 }
 
 inline half&
-half::operator+= (float f)
+half::operator+= (float f) noexcept
 {
     *this = half (float (*this) + f);
     return *this;
 }
 
 inline half&
-half::operator-= (half h)
+half::operator-= (half h) noexcept
 {
     *this = half (float (*this) - float (h));
     return *this;
 }
 
 inline half&
-half::operator-= (float f)
+half::operator-= (float f) noexcept
 {
     *this = half (float (*this) - f);
     return *this;
 }
 
 inline half&
-half::operator*= (half h)
+half::operator*= (half h) noexcept
 {
     *this = half (float (*this) * float (h));
     return *this;
 }
 
 inline half&
-half::operator*= (float f)
+half::operator*= (float f) noexcept
 {
     *this = half (float (*this) * f);
     return *this;
 }
 
 inline half&
-half::operator/= (half h)
+half::operator/= (half h) noexcept
 {
     *this = half (float (*this) / float (h));
     return *this;
 }
 
 inline half&
-half::operator/= (float f)
+half::operator/= (float f) noexcept
 {
     *this = half (float (*this) / f);
     return *this;
 }
 
 inline bool
-half::isFinite() const
+half::isFinite() const noexcept
 {
     unsigned short e = (_h >> 10) & 0x001f;
     return e < 31;
 }
 
 inline bool
-half::isNormalized() const
+half::isNormalized() const noexcept
 {
     unsigned short e = (_h >> 10) & 0x001f;
     return e > 0 && e < 31;
 }
 
 inline bool
-half::isDenormalized() const
+half::isDenormalized() const noexcept
 {
     unsigned short e = (_h >> 10) & 0x001f;
     unsigned short m = _h & 0x3ff;
@@ -618,13 +618,13 @@ half::isDenormalized() const
 }
 
 inline bool
-half::isZero() const
+half::isZero() const noexcept
 {
     return (_h & 0x7fff) == 0;
 }
 
 inline bool
-half::isNan() const
+half::isNan() const noexcept
 {
     unsigned short e = (_h >> 10) & 0x001f;
     unsigned short m = _h & 0x3ff;
@@ -632,7 +632,7 @@ half::isNan() const
 }
 
 inline bool
-half::isInfinity() const
+half::isInfinity() const noexcept
 {
     unsigned short e = (_h >> 10) & 0x001f;
     unsigned short m = _h & 0x3ff;
@@ -640,13 +640,13 @@ half::isInfinity() const
 }
 
 inline bool
-half::isNegative() const
+half::isNegative() const noexcept
 {
     return (_h & 0x8000) != 0;
 }
 
 inline half
-half::posInf()
+half::posInf() noexcept
 {
     half h;
     h._h = 0x7c00;
@@ -654,7 +654,7 @@ half::posInf()
 }
 
 inline half
-half::negInf()
+half::negInf() noexcept
 {
     half h;
     h._h = 0xfc00;
@@ -662,7 +662,7 @@ half::negInf()
 }
 
 inline half
-half::qNan()
+half::qNan() noexcept
 {
     half h;
     h._h = 0x7fff;
@@ -670,7 +670,7 @@ half::qNan()
 }
 
 inline half
-half::sNan()
+half::sNan() noexcept
 {
     half h;
     h._h = 0x7dff;
@@ -678,13 +678,13 @@ half::sNan()
 }
 
 inline unsigned short
-half::bits() const
+half::bits() const noexcept
 {
     return _h;
 }
 
 inline void
-half::setBits (unsigned short bits)
+half::setBits (unsigned short bits) noexcept
 {
     _h = bits;
 }

--- a/src/Imath/halfLimits.h
+++ b/src/Imath/halfLimits.h
@@ -56,48 +56,46 @@ template <> class numeric_limits<half>
   public:
     static const bool is_specialized = true;
 
-    static half min() throw() { return HALF_NRM_MIN; }
-    static half max() throw() { return HALF_MAX; }
+    static /*constexpr*/ half min() noexcept { return HALF_NRM_MIN; }
+    static /*constexpr*/ half max() noexcept { return HALF_MAX; }
+    static /*constexpr*/ half lowest() { return -HALF_MAX; }
 
-    static const int digits      = HALF_MANT_DIG;
-    static const int digits10    = HALF_DIG;
-    static const bool is_signed  = true;
-    static const bool is_integer = false;
-    static const bool is_exact   = false;
-    static const int radix       = HALF_RADIX;
-    static half epsilon() throw() { return HALF_EPSILON; }
-    static half round_error() throw() { return HALF_EPSILON / 2; }
-
-    static const int min_exponent   = HALF_MIN_EXP;
-    static const int min_exponent10 = HALF_MIN_10_EXP;
-    static const int max_exponent   = HALF_MAX_EXP;
-    static const int max_exponent10 = HALF_MAX_10_EXP;
-
-    static const bool has_infinity             = true;
-    static const bool has_quiet_NaN            = true;
-    static const bool has_signaling_NaN        = true;
-    static const float_denorm_style has_denorm = denorm_present;
-    static const bool has_denorm_loss          = false;
-    static half infinity() throw() { return half::posInf(); }
-    static half quiet_NaN() throw() { return half::qNan(); }
-    static half signaling_NaN() throw() { return half::sNan(); }
-    static half denorm_min() throw() { return HALF_MIN; }
-
-    static const bool is_iec559  = false;
-    static const bool is_bounded = false;
-    static const bool is_modulo  = false;
-
-    static const bool traps                    = true;
-    static const bool tinyness_before          = false;
-    static const float_round_style round_style = round_to_nearest;
-
-#if __cplusplus >= 201103L
-
-    // C++11 additions.
+    static constexpr int digits       = HALF_MANT_DIG;
+    static constexpr int digits10     = HALF_DIG;
     static constexpr int max_digits10 = HALF_DECIMAL_DIG;
-    static half lowest() { return -HALF_MAX; }
+    static constexpr bool is_signed   = true;
+    static constexpr bool is_integer  = false;
+    static constexpr bool is_exact    = false;
+    static constexpr int radix        = HALF_RADIX;
+    static /*constexpr*/ half epsilon() noexcept { return HALF_EPSILON; }
+    static /*constexpr*/ half round_error() noexcept { return HALF_EPSILON / 2; }
 
-#endif
+    static constexpr int min_exponent   = HALF_MIN_EXP;
+    static constexpr int min_exponent10 = HALF_MIN_10_EXP;
+    static constexpr int max_exponent   = HALF_MAX_EXP;
+    static constexpr int max_exponent10 = HALF_MAX_10_EXP;
+
+    static constexpr bool has_infinity             = true;
+    static constexpr bool has_quiet_NaN            = true;
+    static constexpr bool has_signaling_NaN        = true;
+    static constexpr float_denorm_style has_denorm = denorm_present;
+    static constexpr bool has_denorm_loss          = false;
+    static /*constexpr*/ half infinity() noexcept { return half::posInf(); }
+    static /*constexpr*/ half quiet_NaN() noexcept { return half::qNan(); }
+    static /*constexpr*/ half signaling_NaN() noexcept { return half::sNan(); }
+    static /*constexpr*/ half denorm_min() noexcept { return HALF_MIN; }
+
+    static constexpr bool is_iec559  = false;
+    static constexpr bool is_bounded = false;
+    static constexpr bool is_modulo  = false;
+
+    static constexpr bool traps                    = true;
+    static constexpr bool tinyness_before          = false;
+    static constexpr float_round_style round_style = round_to_nearest;
+
+    // FIXME: These methods should all be constexpr, but many of them are
+    // currently not able to be because half is not completedly plumbed for
+    // constexpr (and my not be able to be in C++11).
 };
 
 } // namespace std


### PR DESCRIPTION
This patch marks as noexcept absolutely everything that could be under
C++11 rules. Excluded are, obviously, anything that intentionally throws,
and those are very few after Owen's recent Imath overhaul and my changes
to eliminate the weird integer versions of normalize et al.

This patch also makes most of numeric_limits<half> constexpr, per
C++11 rules.  But a few are not constexpr yet because parts of half
still need to be fully constexpr-plumbed, and there are some tricky
parts (and maybe not 100% possible in C++11). I may revisit this in a
later patch.

Using `noexcept` is a promise that the caller to your function won't need
to handle exceptions. If your function calls something that turns out to
throw, it's on you to catch it, or else the application will crash with
an uncaught exception.

It's important that this get a thorough review. I really need a few
keen eyes to make sure that I haven't inadvertently marked anything
noexcept if it calls things (including outside Imath itself) that
might throw exceptions. (I mean, we can fix those bugs later, but I'd
prefer to find them now rather than in the heat of production.)

Closes #64 

Signed-off-by: Larry Gritz <lg@larrygritz.com>