### PR TITLE
Incorrect constexpr in Imath::limits<half>, and missing test.

### DIFF
--- a/src/Imath/ImathHalfLimits.h
+++ b/src/Imath/ImathHalfLimits.h
@@ -50,12 +50,12 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 template <> struct limits<half>
 {
-    constexpr static constexpr float min() noexcept { return -HALF_MAX; }
-    constexpr static constexpr float max() noexcept { return HALF_MAX; }
-    constexpr static constexpr float smallest() noexcept { return HALF_MIN; }
-    constexpr static constexpr float epsilon() noexcept { return HALF_EPSILON; }
-    constexpr static constexpr bool isIntegral() noexcept { return false; }
-    constexpr static constexpr bool isSigned() noexcept { return true; }
+    IMATH_HOSTDEVICE static constexpr float min() noexcept { return -HALF_MAX; }
+    IMATH_HOSTDEVICE static constexpr float max() noexcept { return HALF_MAX; }
+    IMATH_HOSTDEVICE static constexpr float smallest() noexcept { return HALF_MIN; }
+    IMATH_HOSTDEVICE static constexpr float epsilon() noexcept { return HALF_EPSILON; }
+    IMATH_HOSTDEVICE static constexpr bool isIntegral() noexcept { return false; }
+    IMATH_HOSTDEVICE static constexpr bool isSigned() noexcept { return true; }
 };
 
 IMATH_INTERNAL_NAMESPACE_HEADER_EXIT

--- a/src/ImathTest/testLimits.cpp
+++ b/src/ImathTest/testLimits.cpp
@@ -8,6 +8,7 @@
 #endif
 
 #include "halfLimits.h"
+#include "ImathHalfLimits.h"
 #include <assert.h>
 #include <cmath>
 #include <iostream>

--- a/src/ImathTest/testLimits.cpp
+++ b/src/ImathTest/testLimits.cpp
@@ -112,3 +112,18 @@ testLimits()
 
     cout << "ok\n\n" << flush;
 }
+
+void
+testHalfLimits()
+{
+    cout << "values in Imath::limits<half>\n";
+    
+    assert (Imath::limits<half>::min() == float (-HALF_MAX)); 
+    assert (Imath::limits<half>::max() == float (HALF_MAX));
+    assert (Imath::limits<half>::smallest() == float (HALF_MIN));
+    assert (Imath::limits<half>::epsilon() == float (HALF_EPSILON));
+    assert (Imath::limits<half>::isIntegral() == false);
+    assert (Imath::limits<half>::isSigned() == true);
+
+    cout << "ok\n\n" << flush;
+}


### PR DESCRIPTION
ImathHalfLimits.h was not included in any test or any other source file, so this typo hadn't gotten noticed.