### PR TITLE
Fix compiler errors from recent changes

### DIFF
--- a/src/Imath/ImathQuat.h
+++ b/src/Imath/ImathQuat.h
@@ -185,6 +185,10 @@ template <class T> class Quat
 
     /// @}
     
+    /// The base type: In templates that accept a parameter `V`, you
+    /// can refer to `T` as `V::BaseType`
+    typedef T BaseType;
+
   private:
     IMATH_HOSTDEVICE void setRotationInternal (const Vec3<T>& f0, const Vec3<T>& t0, Quat<T>& q) noexcept;
 };

--- a/src/Imath/ImathSphere.h
+++ b/src/Imath/ImathSphere.h
@@ -145,7 +145,7 @@ template <class T>
 IMATH_CONSTEXPR14 bool
 Sphere3<T>::intersect (const Line3<T>& line, Vec3<T>& intersection) const
 {
-    T t;
+    T t (0);
 
     if (intersectT (line, t))
     {


### PR DESCRIPTION
* Restore Quat::BaseType typedef, which got lost inadvertently

* Initialize t in Sphere::intersect (must be initialized because the
  function is now constexpr)

Signed-off-by: Cary Phillips <cary@ilm.com>