### PR TITLE
Interoperability constructors

### DIFF
--- a/config/ImathConfig.h.in
+++ b/config/ImathConfig.h.in
@@ -57,7 +57,7 @@
 // templates from compiling correctly.
 //
 #ifndef IMATH_FOREIGN_VECTOR_INTEROP
-#  if defined(__GNUC__) && __GNUC__ == 4
+#  if defined(__GNUC__) && __GNUC__ == 4 && !defined(__clang__)
 #    define IMATH_FOREIGN_VECTOR_INTEROP 0
 #  else
 #    define IMATH_FOREIGN_VECTOR_INTEROP 1

--- a/config/ImathConfig.h.in
+++ b/config/ImathConfig.h.in
@@ -46,6 +46,25 @@
                              (uint32_t(IMATH_VERSION_MINOR) << 16) | \
                              (uint32_t(IMATH_VERSION_PATCH) <<  8))
 
+
+//
+// By default, opt into the interoparability constructors and assignments.
+// If this causes problems, it can be disabled by defining this symbol to
+// be 0 prior to including any Imath headers.
+//
+// If no such definition is found, we enable automatically unless we are
+// using gcc 4.x, which appears to have bugs that prevent the interop
+// templates from compiling correctly.
+//
+#ifndef IMATH_FOREIGN_VECTOR_INTEROP
+#  if defined(__GNUC__) && __GNUC__ == 4
+#    define IMATH_FOREIGN_VECTOR_INTEROP 0
+#  else
+#    define IMATH_FOREIGN_VECTOR_INTEROP 1
+#  endif
+#endif
+
+
 //
 // Decorator that makes a function available for both CPU and GPU, when
 // compiling for Cuda.

--- a/src/Imath/CMakeLists.txt
+++ b/src/Imath/CMakeLists.txt
@@ -41,6 +41,7 @@ imath_define_library(Imath
     ImathRoots.h
     ImathShear.h
     ImathSphere.h
+    ImathTypeTraits.h
     ImathVecAlgo.h
     ImathVec.h
     half.h

--- a/src/Imath/ImathMatrix.h
+++ b/src/Imath/ImathMatrix.h
@@ -121,7 +121,7 @@ template <class T> class Matrix22
     /// including any Imath header files.
     ///
     template<typename M, IMATH_ENABLE_IF(has_double_subscript<M,T,2,2>::value)>
-    IMATH_HOSTDEVICE Matrix22 (const M& m)
+    IMATH_HOSTDEVICE explicit Matrix22 (const M& m)
         : Matrix22(T(m[0][0]), T(m[0][1]), T(m[1][0]), T(m[1][1]))
     { }
 
@@ -394,7 +394,7 @@ template <class T> class Matrix33
     /// including any Imath header files.
     ///
     template<typename M, IMATH_ENABLE_IF(has_double_subscript<M,T,3,3>::value)>
-    IMATH_HOSTDEVICE Matrix33 (const M& m)
+    IMATH_HOSTDEVICE explicit Matrix33 (const M& m)
         : Matrix33(T(m[0][0]), T(m[0][1]), T(m[0][2]),
                    T(m[1][0]), T(m[1][1]), T(m[1][2]),
                    T(m[2][0]), T(m[2][1]), T(m[2][2]))
@@ -751,7 +751,7 @@ template <class T> class Matrix44
     /// including any Imath header files.
     ///
     template<typename M, IMATH_ENABLE_IF(has_double_subscript<M,T,4,4>::value)>
-    IMATH_HOSTDEVICE Matrix44 (const M& m)
+    IMATH_HOSTDEVICE explicit Matrix44 (const M& m)
         : Matrix44(T(m[0][0]), T(m[0][1]), T(m[0][2]), T(m[0][3]),
                    T(m[1][0]), T(m[1][1]), T(m[1][2]), T(m[1][3]),
                    T(m[2][0]), T(m[2][1]), T(m[2][2]), T(m[2][3]),

--- a/src/Imath/ImathMatrix.h
+++ b/src/Imath/ImathMatrix.h
@@ -94,11 +94,27 @@ template <class T> class Matrix22
     /// Construct from Matrix22 of another base type
     template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix22 (const Matrix22<S>& v) noexcept;
 
+    /// Interoperability constructor from another type that behaves as if it
+    /// were an equivalent matrix.
+    template<typename M, IMATH_ENABLE_IF(has_double_subscript<M,T,2,2>::value)>
+    IMATH_HOSTDEVICE Matrix22 (const M& m)
+        : Matrix22(T(m[0][0]), T(m[0][1]), T(m[1][0]), T(m[1][1]))
+    { }
+
     /// Assignment
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator= (const Matrix22& v) noexcept;
 
     /// Assignment from scalar
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator= (T a) noexcept;
+
+    /// Interoperability assignment from another type that behaves as if it
+    /// were an equivalent matrix.
+    template<typename M, IMATH_ENABLE_IF(has_double_subscript<M,T,2,2>::value)>
+    IMATH_HOSTDEVICE const Matrix22& operator= (const M& m)
+    {
+        *this = Matrix22(T(m[0][0]), T(m[0][1]), T(m[1][0]), T(m[1][1]));
+        return *this;
+    }
 
     /// Destructor
     ~Matrix22() noexcept = default;
@@ -278,23 +294,6 @@ template <class T> class Matrix22
 
     /// The base vector type
     typedef Vec2<T> BaseVecType;
-
-  private:
-    template <typename R, typename S> struct isSameType
-    {
-        enum
-        {
-            value = 0
-        };
-    };
-
-    template <typename R> struct isSameType<R, R>
-    {
-        enum
-        {
-            value = 1
-        };
-    };
 };
 
 ///
@@ -355,11 +354,31 @@ template <class T> class Matrix33
     /// Construct from Matrix33 of another base type
     template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix33 (const Matrix33<S>& v) noexcept;
 
+    /// Interoperability constructor from another type that behaves as if it
+    /// were an equivalent matrix.
+    template<typename M, IMATH_ENABLE_IF(has_double_subscript<M,T,3,3>::value)>
+    IMATH_HOSTDEVICE Matrix33 (const M& m)
+        : Matrix33(T(m[0][0]), T(m[0][1]), T(m[0][2]),
+                   T(m[1][0]), T(m[1][1]), T(m[1][2]),
+                   T(m[2][0]), T(m[2][1]), T(m[2][2]))
+    { }
+
     /// Assignment operator
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator= (const Matrix33& v) noexcept;
 
     /// Assignment from scalar
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator= (T a) noexcept;
+
+    /// Interoperability assignment from another type that behaves as if it
+    /// were an equivalent matrix.
+    template<typename M, IMATH_ENABLE_IF(has_double_subscript<M,T,3,3>::value)>
+    IMATH_HOSTDEVICE const Matrix33& operator= (const M& m)
+    {
+        *this = Matrix33(T(m[0][0]), T(m[0][1]), T(m[0][2]),
+                         T(m[1][0]), T(m[1][1]), T(m[1][2]),
+                         T(m[2][0]), T(m[2][1]), T(m[2][2]));
+        return *this;
+    }
 
     /// Destructor
     ~Matrix33() noexcept = default;
@@ -604,23 +623,6 @@ template <class T> class Matrix33
 
     /// The base vector type
     typedef Vec3<T> BaseVecType;
-
-  private:
-    template <typename R, typename S> struct isSameType
-    {
-        enum
-        {
-            value = 0
-        };
-    };
-
-    template <typename R> struct isSameType<R, R>
-    {
-        enum
-        {
-            value = 1
-        };
-    };
 };
 
 ///
@@ -694,11 +696,33 @@ template <class T> class Matrix44
     /// Construct from Matrix44 of another base type
     template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix44 (const Matrix44<S>& v) noexcept;
 
+    /// Interoperability constructor from another type that behaves as if it
+    /// were an equivalent matrix.
+    template<typename M, IMATH_ENABLE_IF(has_double_subscript<M,T,4,4>::value)>
+    IMATH_HOSTDEVICE Matrix44 (const M& m)
+        : Matrix44(T(m[0][0]), T(m[0][1]), T(m[0][2]), T(m[0][3]),
+                   T(m[1][0]), T(m[1][1]), T(m[1][2]), T(m[1][3]),
+                   T(m[2][0]), T(m[2][1]), T(m[2][2]), T(m[2][3]),
+                   T(m[3][0]), T(m[3][1]), T(m[3][2]), T(m[3][3]))
+    { }
+
     /// Assignment operator
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator= (const Matrix44& v) noexcept;
 
     /// Assignment from scalar
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator= (T a) noexcept;
+
+    /// Interoperability assignment from another type that behaves as if it
+    /// were an equivalent matrix.
+    template<typename M, IMATH_ENABLE_IF(has_double_subscript<M,T,4,4>::value)>
+    IMATH_HOSTDEVICE const Matrix44& operator= (const M& m)
+    {
+        *this = Matrix44(T(m[0][0]), T(m[0][1]), T(m[0][2]), T(m[0][3]),
+                         T(m[1][0]), T(m[1][1]), T(m[1][2]), T(m[1][3]),
+                         T(m[2][0]), T(m[2][1]), T(m[2][2]), T(m[2][3]),
+                         T(m[3][0]), T(m[3][1]), T(m[3][2]), T(m[3][3]));
+        return *this;
+    }
 
     /// Destructor
     ~Matrix44() noexcept = default;
@@ -979,23 +1003,6 @@ template <class T> class Matrix44
 
     /// The base vector type
     typedef Vec4<T> BaseVecType;
-
-  private:
-    template <typename R, typename S> struct isSameType
-    {
-        enum
-        {
-            value = 0
-        };
-    };
-
-    template <typename R> struct isSameType<R, R>
-    {
-        enum
-        {
-            value = 1
-        };
-    };
 };
 
 /// Stream output

--- a/src/Imath/ImathMatrix.h
+++ b/src/Imath/ImathMatrix.h
@@ -94,32 +94,45 @@ template <class T> class Matrix22
     /// Construct from Matrix22 of another base type
     template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix22 (const Matrix22<S>& v) noexcept;
 
-    /// Interoperability constructor from another type that behaves as if it
-    /// were an equivalent matrix.
-    template<typename M, IMATH_ENABLE_IF(has_double_subscript<M,T,2,2>::value)>
-    IMATH_HOSTDEVICE Matrix22 (const M& m)
-        : Matrix22(T(m[0][0]), T(m[0][1]), T(m[1][0]), T(m[1][1]))
-    { }
-
     /// Assignment
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator= (const Matrix22& v) noexcept;
 
     /// Assignment from scalar
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator= (T a) noexcept;
 
-    /// Interoperability assignment from another type that behaves as if it
-    /// were an equivalent matrix.
+    /// Destructor
+    ~Matrix22() noexcept = default;
+
+    /// @}
+
+#if IMATH_FOREIGN_VECTOR_INTEROP
+    /// @{
+    /// @name Interoperability with other matrix types
+    ///
+    /// Construction and assignment are allowed from other classes that
+    /// appear to be equivalent matrix types, provided that they support
+    /// double-subscript (i.e., `m[j][i]`) giving the same type as the
+    /// elements of this matrix, and their total size appears to be the
+    /// right number of matrix elements.
+    ///
+    /// This functionality is disabled for gcc 4.x, which seems to have a
+    /// compiler bug that results in spurious errors. It can also be
+    /// disabled by defining IMATH_FOREIGN_VECTOR_INTEROP to be 0 prior to
+    /// including any Imath header files.
+    ///
+    template<typename M, IMATH_ENABLE_IF(has_double_subscript<M,T,2,2>::value)>
+    IMATH_HOSTDEVICE Matrix22 (const M& m)
+        : Matrix22(T(m[0][0]), T(m[0][1]), T(m[1][0]), T(m[1][1]))
+    { }
+
     template<typename M, IMATH_ENABLE_IF(has_double_subscript<M,T,2,2>::value)>
     IMATH_HOSTDEVICE const Matrix22& operator= (const M& m)
     {
         *this = Matrix22(T(m[0][0]), T(m[0][1]), T(m[1][0]), T(m[1][1]));
         return *this;
     }
-
-    /// Destructor
-    ~Matrix22() noexcept = default;
-
     /// @}
+#endif
 
     /// @{
     /// @name Compatibility with Sb
@@ -354,20 +367,38 @@ template <class T> class Matrix33
     /// Construct from Matrix33 of another base type
     template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix33 (const Matrix33<S>& v) noexcept;
 
-    /// Interoperability constructor from another type that behaves as if it
-    /// were an equivalent matrix.
+    /// Assignment operator
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator= (const Matrix33& v) noexcept;
+
+    /// Assignment from scalar
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator= (T a) noexcept;
+
+    /// Destructor
+    ~Matrix33() noexcept = default;
+
+    /// @}
+
+#if IMATH_FOREIGN_VECTOR_INTEROP
+    /// @{
+    /// @name Interoperability with other matrix types
+    ///
+    /// Construction and assignment are allowed from other classes that
+    /// appear to be equivalent matrix types, provided that they support
+    /// double-subscript (i.e., `m[j][i]`) giving the same type as the
+    /// elements of this matrix, and their total size appears to be the
+    /// right number of matrix elements.
+    ///
+    /// This functionality is disabled for gcc 4.x, which seems to have a
+    /// compiler bug that results in spurious errors. It can also be
+    /// disabled by defining IMATH_FOREIGN_VECTOR_INTEROP to be 0 prior to
+    /// including any Imath header files.
+    ///
     template<typename M, IMATH_ENABLE_IF(has_double_subscript<M,T,3,3>::value)>
     IMATH_HOSTDEVICE Matrix33 (const M& m)
         : Matrix33(T(m[0][0]), T(m[0][1]), T(m[0][2]),
                    T(m[1][0]), T(m[1][1]), T(m[1][2]),
                    T(m[2][0]), T(m[2][1]), T(m[2][2]))
     { }
-
-    /// Assignment operator
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator= (const Matrix33& v) noexcept;
-
-    /// Assignment from scalar
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator= (T a) noexcept;
 
     /// Interoperability assignment from another type that behaves as if it
     /// were an equivalent matrix.
@@ -379,12 +410,9 @@ template <class T> class Matrix33
                          T(m[2][0]), T(m[2][1]), T(m[2][2]));
         return *this;
     }
-
-    /// Destructor
-    ~Matrix33() noexcept = default;
-
     /// @}
-    
+#endif
+
     /// @{
     /// @name Compatibility with Sb
 
@@ -696,8 +724,32 @@ template <class T> class Matrix44
     /// Construct from Matrix44 of another base type
     template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix44 (const Matrix44<S>& v) noexcept;
 
-    /// Interoperability constructor from another type that behaves as if it
-    /// were an equivalent matrix.
+    /// Assignment operator
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator= (const Matrix44& v) noexcept;
+
+    /// Assignment from scalar
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator= (T a) noexcept;
+
+    /// Destructor
+    ~Matrix44() noexcept = default;
+
+    /// @}
+
+#if IMATH_FOREIGN_VECTOR_INTEROP
+    /// @{
+    /// @name Interoperability with other matrix types
+    ///
+    /// Construction and assignment are allowed from other classes that
+    /// appear to be equivalent matrix types, provided that they support
+    /// double-subscript (i.e., `m[j][i]`) giving the same type as the
+    /// elements of this matrix, and their total size appears to be the
+    /// right number of matrix elements.
+    ///
+    /// This functionality is disabled for gcc 4.x, which seems to have a
+    /// compiler bug that results in spurious errors. It can also be
+    /// disabled by defining IMATH_FOREIGN_VECTOR_INTEROP to be 0 prior to
+    /// including any Imath header files.
+    ///
     template<typename M, IMATH_ENABLE_IF(has_double_subscript<M,T,4,4>::value)>
     IMATH_HOSTDEVICE Matrix44 (const M& m)
         : Matrix44(T(m[0][0]), T(m[0][1]), T(m[0][2]), T(m[0][3]),
@@ -705,12 +757,6 @@ template <class T> class Matrix44
                    T(m[2][0]), T(m[2][1]), T(m[2][2]), T(m[2][3]),
                    T(m[3][0]), T(m[3][1]), T(m[3][2]), T(m[3][3]))
     { }
-
-    /// Assignment operator
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator= (const Matrix44& v) noexcept;
-
-    /// Assignment from scalar
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator= (T a) noexcept;
 
     /// Interoperability assignment from another type that behaves as if it
     /// were an equivalent matrix.
@@ -723,12 +769,9 @@ template <class T> class Matrix44
                          T(m[3][0]), T(m[3][1]), T(m[3][2]), T(m[3][3]));
         return *this;
     }
-
-    /// Destructor
-    ~Matrix44() noexcept = default;
-
     /// @}
-    
+#endif
+
     /// @{
     /// @name Compatibility with Sb
 

--- a/src/Imath/ImathPlatform.h
+++ b/src/Imath/ImathPlatform.h
@@ -47,26 +47,6 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 #endif
 
 
-//
-// Define Imath::enable_if_t to be std for C++14, equivalent for C++11.
-//
-#if (IMATH_CPLUSPLUS_VERSION >= 14)
-    using std::enable_if_t;    // Use C++14 std::enable_if_t
-#else
-    // Define enable_if_t for C++11
-    template <bool B, class T = void>
-    using enable_if_t = typename std::enable_if<B, T>::type;
-#endif
-
-
-//
-// An enable_if helper to be used in template parameters which results in
-// much shorter symbols.
-//
-#define IMATH_ENABLE_IF(...) Imath::enable_if_t<(__VA_ARGS__), int> = 0
-
-
-
 #ifndef M_PI
 #    define M_PI 3.14159265358979323846
 #endif

--- a/src/Imath/ImathTypeTraits.h
+++ b/src/Imath/ImathTypeTraits.h
@@ -84,7 +84,7 @@ private:
     typedef char Yes[1];
     typedef char No[2];
 
-    // Valid only if .x, .y, .z exist and are the right type: return a Yes.
+    // Valid only if .x, .y exist and are the right type: return a Yes.
     template<typename C,
              IMATH_ENABLE_IF(std::is_same<decltype(C().x), Base>::value),
              IMATH_ENABLE_IF(std::is_same<decltype(C().y), Base>::value)>
@@ -133,7 +133,7 @@ private:
     typedef char Yes[1];
     typedef char No[2];
 
-    // Valid only if .x, .y, .z exist and are the right type: return a Yes.
+    // Valid only if .x, .y, .z, .w exist and are the right type: return a Yes.
     template<typename C,
              IMATH_ENABLE_IF(std::is_same<decltype(C().x), Base>::value),
              IMATH_ENABLE_IF(std::is_same<decltype(C().y), Base>::value),

--- a/src/Imath/ImathTypeTraits.h
+++ b/src/Imath/ImathTypeTraits.h
@@ -151,10 +151,10 @@ public:
 
 
 
-/// `has_subscript<T,Base,N>::value` will be true if type `T` has
+/// `has_subscript<T,Base,Nelem>::value` will be true if type `T` has
 /// subscripting syntax, a `T[int]` returns a `Base`, and the size of a `T`
-/// is exactly big enough to hold `N` `Base` values.
-template <typename T, typename Base, int N>
+/// is exactly big enough to hold `Nelem` `Base` values.
+template <typename T, typename Base, int Nelem>
 struct has_subscript {
 private:
     typedef char Yes[1];
@@ -169,14 +169,43 @@ private:
     template<typename C> static No& test(...);
 public:
     enum { value = (sizeof(test<T>(0)) == sizeof(Yes)
-                    && sizeof(T) == N*sizeof(Base))
+                    && sizeof(T) == Nelem*sizeof(Base))
       };
 };
 
 
 /// C arrays of just the right length also are qualified for has_subscript.
-template<typename Base, int N>
-struct has_subscript<Base[N], Base, N> : public std::true_type { };
+template<typename Base, int Nelem>
+struct has_subscript<Base[Nelem], Base, Nelem> : public std::true_type { };
+
+
+
+/// `has_double_subscript<T,Base,Rows,Cols>::value` will be true if type `T`
+/// has 2-level subscripting syntax, a `T[int][int]` returns a `Base`, and
+/// the size of a `T` is exactly big enough to hold `R*C` `Base` values.
+template <typename T, typename Base, int Rows, int Cols>
+struct has_double_subscript {
+private:
+    typedef char Yes[1];
+    typedef char No[2];
+
+    // Valid only if T[][] is possible and is the right type: return a Yes.
+    template<typename C,
+             IMATH_ENABLE_IF(std::is_same<typename std::decay<decltype(C()[0][0])>::type, Base>::value)>
+    static Yes& test(int);
+
+    // Fallback, default to returning a No.
+    template<typename C> static No& test(...);
+public:
+    enum { value = (sizeof(test<T>(0)) == sizeof(Yes)
+                    && sizeof(T) == (Rows*Cols)*sizeof(Base))
+      };
+};
+
+
+/// C arrays of just the right length also are qualified for has_double_subscript.
+template<typename Base, int Rows, int Cols>
+struct has_double_subscript<Base[Rows][Cols], Base, Rows, Cols> : public std::true_type { };
 
 /// @}
 

--- a/src/Imath/ImathTypeTraits.h
+++ b/src/Imath/ImathTypeTraits.h
@@ -1,0 +1,186 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+//
+// This file contains type traits related to or used by the Imath library.
+//
+
+#ifndef INCLUDED_IMATHTYPETRAITS_H
+#define INCLUDED_IMATHTYPETRAITS_H
+
+#include <type_traits>
+
+#include "ImathPlatform.h"
+
+IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
+
+
+/// Define Imath::enable_if_t to be std for C++14, equivalent for C++11.
+#if (IMATH_CPLUSPLUS_VERSION >= 14)
+    using std::enable_if_t;    // Use C++14 std::enable_if_t
+#else
+    // Define enable_if_t for C++11
+    template <bool B, class T = void>
+    using enable_if_t = typename std::enable_if<B, T>::type;
+#endif
+
+
+/// An enable_if helper to be used in template parameters which results in
+/// much shorter symbols.
+#define IMATH_ENABLE_IF(...) Imath::enable_if_t<(__VA_ARGS__), int> = 0
+
+
+
+/// @{
+/// @name Detecting interoperable types.
+///
+/// In order to construct or assign from external "compatible" types without
+/// prior knowledge of their definitions, we have a few helper type traits.
+/// The intent of these is to allow custom linear algebra types in an
+/// application that have seamless conversion to and from Imath types.
+///
+/// `has_xy<T,Base>`, `has_xyz<T,Base>`, `has_xyzw<T,Base>` detect if class
+/// `T` has elements `.x`, `.y`, and `.z` all of type `Base` and seems to be
+/// the right size to hold exactly those members and nothing more.
+///
+/// `has_subscript<T,Base,N>` detects if class `T` can perform `T[int]`
+/// to yield a `Base`, and that it seems to be exactly the right size to
+/// hold `N` of those elements.
+///
+/// This is not exact. It's possible that for a particular user-defined
+/// type, this may yield a false negative or false positive. For example:
+///   * A class for a 3-vector that contains an extra element of padding
+///     so that it will have the right size and alignment to use 4-wide
+///     SIMD math ops will appear to be the wrong size.
+///   * A `std::vector<T>` is subscriptable and might have N elements at
+///     runtime, but the size is dynamic and so would fail this test.
+///   * A foreign type may have .x, .y, .z that are not matching our base
+///     type but we still want it to work (with appropriate conversions).
+///
+/// In these cases, user code may declare an exception -- for example,
+/// stating that `mytype` should be considered implicitly convertible to
+/// an Imath::V3f by subscripting:
+///
+///     template<>
+///     struct Imath::has_subscript<mytype, float, 3> : public std::true_type { };
+///
+/// And similarly, user code may correct a potential false positive (that
+/// is, a `mytype` looks like it should be convertible to a V3f, but you
+/// don't want it to ever happen):
+///
+///     template<typename B, int N>
+///     struct Imath::has_subscript<mytype, B, N> : public std::false_type { };
+///
+
+
+/// `has_xy<T,Base>::value` will be true if type `T` has member variables
+/// `.x` and `.y`, all of type `Base`, and the size of a `T` is exactly big
+/// enough to hold 2 Base values.
+template <typename T, typename Base>
+struct has_xy {
+private:
+    typedef char Yes[1];
+    typedef char No[2];
+
+    // Valid only if .x, .y, .z exist and are the right type: return a Yes.
+    template<typename C,
+             IMATH_ENABLE_IF(std::is_same<decltype(C().x), Base>::value),
+             IMATH_ENABLE_IF(std::is_same<decltype(C().y), Base>::value)>
+    static Yes& test(int);
+
+    // Fallback, default to returning a No.
+    template<typename C> static No& test(...);
+public:
+    enum { value = (sizeof(test<T>(0)) == sizeof(Yes)
+                    && sizeof(T) == 2*sizeof(Base))
+      };
+};
+
+
+/// `has_xyz<T,Base>::value` will be true if type `T` has member variables
+/// `.x`, `.y`, and `.z`, all of type `Base`, and the size of a `T` is
+/// exactly big enough to hold 3 Base values.
+template <typename T, typename Base>
+struct has_xyz {
+private:
+    typedef char Yes[1];
+    typedef char No[2];
+
+    // Valid only if .x, .y, .z exist and are the right type: return a Yes.
+    template<typename C,
+             IMATH_ENABLE_IF(std::is_same<decltype(C().x), Base>::value),
+             IMATH_ENABLE_IF(std::is_same<decltype(C().y), Base>::value),
+             IMATH_ENABLE_IF(std::is_same<decltype(C().z), Base>::value)>
+    static Yes& test(int);
+
+    // Fallback, default to returning a No.
+    template<typename C> static No& test(...);
+public:
+    enum { value = (sizeof(test<T>(0)) == sizeof(Yes)
+                    && sizeof(T) == 3*sizeof(Base))
+      };
+};
+
+
+/// `has_xyzw<T,Base>::value` will be true if type `T` has member variables
+/// `.x`, `.y`, `.z`, and `.w`, all of type `Base`, and the size of a `T` is
+/// exactly big enough to hold 4 Base values.
+template <typename T, typename Base>
+struct has_xyzw {
+private:
+    typedef char Yes[1];
+    typedef char No[2];
+
+    // Valid only if .x, .y, .z exist and are the right type: return a Yes.
+    template<typename C,
+             IMATH_ENABLE_IF(std::is_same<decltype(C().x), Base>::value),
+             IMATH_ENABLE_IF(std::is_same<decltype(C().y), Base>::value),
+             IMATH_ENABLE_IF(std::is_same<decltype(C().z), Base>::value),
+             IMATH_ENABLE_IF(std::is_same<decltype(C().w), Base>::value)>
+    static Yes& test(int);
+
+    // Fallback, default to returning a No.
+    template<typename C> static No& test(...);
+public:
+    enum { value = (sizeof(test<T>(0)) == sizeof(Yes)
+                    && sizeof(T) == 4*sizeof(Base))
+      };
+};
+
+
+
+/// `has_subscript<T,Base,N>::value` will be true if type `T` has
+/// subscripting syntax, a `T[int]` returns a `Base`, and the size of a `T`
+/// is exactly big enough to hold `N` `Base` values.
+template <typename T, typename Base, int N>
+struct has_subscript {
+private:
+    typedef char Yes[1];
+    typedef char No[2];
+
+    // Valid only if T[] is possible and is the right type: return a Yes.
+    template<typename C,
+             IMATH_ENABLE_IF(std::is_same<typename std::decay<decltype(C()[0])>::type, Base>::value)>
+    static Yes& test(int);
+
+    // Fallback, default to returning a No.
+    template<typename C> static No& test(...);
+public:
+    enum { value = (sizeof(test<T>(0)) == sizeof(Yes)
+                    && sizeof(T) == N*sizeof(Base))
+      };
+};
+
+
+/// C arrays of just the right length also are qualified for has_subscript.
+template<typename Base, int N>
+struct has_subscript<Base[N], Base, N> : public std::true_type { };
+
+/// @}
+
+
+IMATH_INTERNAL_NAMESPACE_HEADER_EXIT
+
+#endif // INCLUDED_IMATHTYPETRAITS_H

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -101,12 +101,12 @@ template <class T> class Vec2
     ///
 
     template<typename V, IMATH_ENABLE_IF(has_xy<V,T>::value)>
-    IMATH_HOSTDEVICE constexpr Vec2 (const V& v) noexcept
+    IMATH_HOSTDEVICE explicit constexpr Vec2 (const V& v) noexcept
         : Vec2(T(v.x), T(v.y)) { }
 
     template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,2>::value
                                          && !has_xy<V,T>::value)>
-    IMATH_HOSTDEVICE Vec2 (const V& v) : Vec2(T(v[0]), T(v[1])) { }
+    IMATH_HOSTDEVICE explicit Vec2 (const V& v) : Vec2(T(v[0]), T(v[1])) { }
 
     template<typename V, IMATH_ENABLE_IF(has_xy<V,T>::value)>
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator= (const V& v) noexcept {
@@ -368,12 +368,12 @@ template <class T> class Vec3
     ///
 
     template<typename V, IMATH_ENABLE_IF(has_xyz<V,T>::value)>
-    IMATH_HOSTDEVICE constexpr Vec3 (const V& v) noexcept
+    IMATH_HOSTDEVICE explicit constexpr Vec3 (const V& v) noexcept
         : Vec3(T(v.x), T(v.y), T(v.z)) { }
 
     template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,3>::value
                                          && !has_xyz<V,T>::value)>
-    IMATH_HOSTDEVICE Vec3 (const V& v) : Vec3(T(v[0]), T(v[1]), T(v[2])) { }
+    IMATH_HOSTDEVICE explicit Vec3 (const V& v) : Vec3(T(v[0]), T(v[1]), T(v[2])) { }
 
     /// Interoperability assignment from another type that behaves as if it
     /// were an equivalent vector.
@@ -632,12 +632,12 @@ template <class T> class Vec4
     ///
 
     template<typename V, IMATH_ENABLE_IF(has_xyzw<V,T>::value)>
-    IMATH_HOSTDEVICE constexpr Vec4 (const V& v) noexcept
+    IMATH_HOSTDEVICE explicit constexpr Vec4 (const V& v) noexcept
         : Vec4(T(v.x), T(v.y), T(v.z), T(v.w)) { }
 
     template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,4>::value
                                          && !has_xyzw<V,T>::value)>
-    IMATH_HOSTDEVICE Vec4 (const V& v) : Vec4(T(v[0]), T(v[1]), T(v[2]), T(v[3])) { }
+    IMATH_HOSTDEVICE explicit Vec4 (const V& v) : Vec4(T(v[0]), T(v[1]), T(v[2]), T(v[3])) { }
 
     template<typename V, IMATH_ENABLE_IF(has_xyzw<V,T>::value)>
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator= (const V& v) noexcept {

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -25,6 +25,17 @@
 
 IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
+
+/// Does type V appear to be equivalent to an Imath::VecN<Base>? We assume
+/// that it is if it has a subscript operator that returns a Base, and its
+/// size is large enough to contain N elements of type Base.
+#define IMATH_VECTOR_EQUIVALENT(V,Base,N) \
+    (std::is_same<typename std::decay<decltype(V()[0])>::type, Base>::value \
+     && sizeof(V) >= N*sizeof(Base))
+
+
+
+
 template <class T> class Vec2;
 template <class T> class Vec3;
 template <class T> class Vec4;
@@ -291,6 +302,12 @@ template <class T> class Vec3
     /// Construct from Vec3 of another base type
     template <class S> IMATH_HOSTDEVICE constexpr Vec3 (const Vec3<S>& v) noexcept;
 
+    /// Interoperability constructor from another type that behaves as if it
+    /// were an equivalent vector.
+    template<typename V, IMATH_ENABLE_IF(IMATH_VECTOR_EQUIVALENT(V, T, 3))>
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3 (const V& v) noexcept
+        : Vec3(v[0], v[1], v[2]) { }
+
     /// Vec4 to Vec3 conversion: divide x, y and z by w, even if w is
     /// 0.  The result depends on how the environment handles
     /// floating-point exceptions.
@@ -303,6 +320,16 @@ template <class T> class Vec3
 
     /// Assignment
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator= (const Vec3& v) noexcept;
+
+    /// Interoperability assignment from another type that behaves as if it
+    /// were an equivalent vector.
+    template<typename V, IMATH_ENABLE_IF(IMATH_VECTOR_EQUIVALENT(V, T, 3))>
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator= (const V& v) noexcept {
+        x = v[0];
+        y = v[1];
+        z = v[2];
+        return *this;
+    }
 
     /// Destructor
     ~Vec3() noexcept = default;

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -75,8 +75,35 @@ template <class T> class Vec2
     /// Construct from Vec2 of another base type
     template <class S> IMATH_HOSTDEVICE constexpr Vec2 (const Vec2<S>& v) noexcept;
 
+    /// Interoperability constructor from another type that behaves as if it
+    /// were an equivalent vector.
+    template<typename V, IMATH_ENABLE_IF(has_xy<V,T>::value)>
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2 (const V& v) noexcept
+        : Vec2(T(v.x), T(v.y)) { }
+
+    template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,2>::value
+                                         && !has_xy<V,T>::value)>
+    IMATH_HOSTDEVICE Vec2 (const V& v) : Vec2(T(v[0]), T(v[1])) { }
+
     /// Assignment
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator= (const Vec2& v) noexcept;
+
+    /// Interoperability assignment from another type that behaves as if it
+    /// were an equivalent vector.
+    template<typename V, IMATH_ENABLE_IF(has_xy<V,T>::value)>
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator= (const V& v) noexcept {
+        x = T(v.x);
+        y = T(v.y);
+        return *this;
+    }
+
+    template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,2>::value
+                                         && !has_xy<V,T>::value)>
+    IMATH_HOSTDEVICE const Vec2& operator= (const V& v) {
+        x = T(v[0]);
+        y = T(v[1]);
+        return *this;
+    }
 
     /// Destructor
     ~Vec2() noexcept = default;
@@ -296,12 +323,11 @@ template <class T> class Vec3
     /// were an equivalent vector.
     template<typename V, IMATH_ENABLE_IF(has_xyz<V,T>::value)>
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3 (const V& v) noexcept
-        : Vec3(v.x, v.y, v.z) { }
+        : Vec3(T(v.x), T(v.y), T(v.z)) { }
 
     template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,3>::value
                                          && !has_xyz<V,T>::value)>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3 (const V& v) noexcept
-        : Vec3(v[0], v[1], v[2]) { }
+    IMATH_HOSTDEVICE Vec3 (const V& v) : Vec3(T(v[0]), T(v[1]), T(v[2])) { }
 
     /// Vec4 to Vec3 conversion: divide x, y and z by w, even if w is
     /// 0.  The result depends on how the environment handles
@@ -319,19 +345,19 @@ template <class T> class Vec3
     /// Interoperability assignment from another type that behaves as if it
     /// were an equivalent vector.
     template<typename V, IMATH_ENABLE_IF(has_xyz<V,T>::value)>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator= (const V& v) noexcept {
-        x = v.x;
-        y = v.y;
-        z = v.z;
+    IMATH_HOSTDEVICE const Vec3& operator= (const V& v) noexcept {
+        x = T(v.x);
+        y = T(v.y);
+        z = T(v.z);
         return *this;
     }
 
     template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,3>::value
                                          && !has_xyz<V,T>::value)>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator= (const V& v) noexcept {
-        x = v[0];
-        y = v[1];
-        z = v[2];
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator= (const V& v) {
+        x = T(v[0]);
+        y = T(v[1]);
+        z = T(v[2]);
         return *this;
     }
 
@@ -551,8 +577,39 @@ template <class T> class Vec4
     /// Vec3 to Vec4 conversion, sets w to 1.
     template <class S> IMATH_HOSTDEVICE explicit constexpr Vec4 (const Vec3<S>& v) noexcept;
 
+    /// Interoperability constructor from another type that behaves as if it
+    /// were an equivalent vector.
+    template<typename V, IMATH_ENABLE_IF(has_xyzw<V,T>::value)>
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec4 (const V& v) noexcept
+        : Vec4(T(v.x), T(v.y), T(v.z), T(v.w)) { }
+
+    template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,4>::value
+                                         && !has_xyzw<V,T>::value)>
+    IMATH_HOSTDEVICE Vec4 (const V& v) : Vec4(T(v[0]), T(v[1]), T(v[2]), T(v[3])) { }
+
     /// Assignment
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator= (const Vec4& v) noexcept;
+
+    /// Interoperability assignment from another type that behaves as if it
+    /// were an equivalent vector.
+    template<typename V, IMATH_ENABLE_IF(has_xyzw<V,T>::value)>
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator= (const V& v) noexcept {
+        x = T(v.x);
+        y = T(v.y);
+        z = T(v.z);
+        w = T(v.w);
+        return *this;
+    }
+
+    template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,4>::value
+                                         && !has_xyzw<V,T>::value)>
+    IMATH_HOSTDEVICE const Vec4& operator= (const V& v) {
+        x = T(v[0]);
+        y = T(v[1]);
+        z = T(v[2]);
+        w = T(v[3]);
+        return *this;
+    }
 
     /// Destructor
     ~Vec4() noexcept = default;

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -78,7 +78,7 @@ template <class T> class Vec2
     /// Interoperability constructor from another type that behaves as if it
     /// were an equivalent vector.
     template<typename V, IMATH_ENABLE_IF(has_xy<V,T>::value)>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2 (const V& v) noexcept
+    IMATH_HOSTDEVICE constexpr Vec2 (const V& v) noexcept
         : Vec2(T(v.x), T(v.y)) { }
 
     template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,2>::value
@@ -322,7 +322,7 @@ template <class T> class Vec3
     /// Interoperability constructor from another type that behaves as if it
     /// were an equivalent vector.
     template<typename V, IMATH_ENABLE_IF(has_xyz<V,T>::value)>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3 (const V& v) noexcept
+    IMATH_HOSTDEVICE constexpr Vec3 (const V& v) noexcept
         : Vec3(T(v.x), T(v.y), T(v.z)) { }
 
     template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,3>::value
@@ -580,7 +580,7 @@ template <class T> class Vec4
     /// Interoperability constructor from another type that behaves as if it
     /// were an equivalent vector.
     template<typename V, IMATH_ENABLE_IF(has_xyzw<V,T>::value)>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec4 (const V& v) noexcept
+    IMATH_HOSTDEVICE constexpr Vec4 (const V& v) noexcept
         : Vec4(T(v.x), T(v.y), T(v.z), T(v.w)) { }
 
     template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,4>::value

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -75,8 +75,31 @@ template <class T> class Vec2
     /// Construct from Vec2 of another base type
     template <class S> IMATH_HOSTDEVICE constexpr Vec2 (const Vec2<S>& v) noexcept;
 
-    /// Interoperability constructor from another type that behaves as if it
-    /// were an equivalent vector.
+
+    /// Assignment
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator= (const Vec2& v) noexcept;
+
+    /// Destructor
+    ~Vec2() noexcept = default;
+
+    /// @}
+
+#if IMATH_FOREIGN_VECTOR_INTEROP
+    /// @{
+    /// @name Interoperability with other vector types
+    ///
+    /// Construction and assignment are allowed from other classes that
+    /// appear to be equivalent vector types, provided that they have either
+    /// a subscripting operator, or data members .x and .y, that are of the
+    /// same type as the elements of this vector, and their size appears to
+    /// be the right number of elements.
+    ///
+    /// This functionality is disabled for gcc 4.x, which seems to have a
+    /// compiler bug that results in spurious errors. It can also be
+    /// disabled by defining IMATH_FOREIGN_VECTOR_INTEROP to be 0 prior to
+    /// including any Imath header files.
+    ///
+
     template<typename V, IMATH_ENABLE_IF(has_xy<V,T>::value)>
     IMATH_HOSTDEVICE constexpr Vec2 (const V& v) noexcept
         : Vec2(T(v.x), T(v.y)) { }
@@ -85,11 +108,6 @@ template <class T> class Vec2
                                          && !has_xy<V,T>::value)>
     IMATH_HOSTDEVICE Vec2 (const V& v) : Vec2(T(v[0]), T(v[1])) { }
 
-    /// Assignment
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator= (const Vec2& v) noexcept;
-
-    /// Interoperability assignment from another type that behaves as if it
-    /// were an equivalent vector.
     template<typename V, IMATH_ENABLE_IF(has_xy<V,T>::value)>
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator= (const V& v) noexcept {
         x = T(v.x);
@@ -104,12 +122,8 @@ template <class T> class Vec2
         y = T(v[1]);
         return *this;
     }
+#endif
 
-    /// Destructor
-    ~Vec2() noexcept = default;
-
-    /// @}
-    
     /// @{
     /// @name Compatibility with Sb
 
@@ -319,16 +333,6 @@ template <class T> class Vec3
     /// Construct from Vec3 of another base type
     template <class S> IMATH_HOSTDEVICE constexpr Vec3 (const Vec3<S>& v) noexcept;
 
-    /// Interoperability constructor from another type that behaves as if it
-    /// were an equivalent vector.
-    template<typename V, IMATH_ENABLE_IF(has_xyz<V,T>::value)>
-    IMATH_HOSTDEVICE constexpr Vec3 (const V& v) noexcept
-        : Vec3(T(v.x), T(v.y), T(v.z)) { }
-
-    template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,3>::value
-                                         && !has_xyz<V,T>::value)>
-    IMATH_HOSTDEVICE Vec3 (const V& v) : Vec3(T(v[0]), T(v[1]), T(v[2])) { }
-
     /// Vec4 to Vec3 conversion: divide x, y and z by w, even if w is
     /// 0.  The result depends on how the environment handles
     /// floating-point exceptions.
@@ -341,6 +345,35 @@ template <class T> class Vec3
 
     /// Assignment
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator= (const Vec3& v) noexcept;
+
+    /// Destructor
+    ~Vec3() noexcept = default;
+
+    /// @}
+
+#if IMATH_FOREIGN_VECTOR_INTEROP
+    /// @{
+    /// @name Interoperability with other vector types
+    ///
+    /// Construction and assignment are allowed from other classes that
+    /// appear to be equivalent vector types, provided that they have either
+    /// a subscripting operator, or data members .x, .y, .z, that are of the
+    /// same type as the elements of this vector, and their size appears to
+    /// be the right number of elements.
+    ///
+    /// This functionality is disabled for gcc 4.x, which seems to have a
+    /// compiler bug that results in spurious errors. It can also be
+    /// disabled by defining IMATH_FOREIGN_VECTOR_INTEROP to be 0 prior to
+    /// including any Imath header files.
+    ///
+
+    template<typename V, IMATH_ENABLE_IF(has_xyz<V,T>::value)>
+    IMATH_HOSTDEVICE constexpr Vec3 (const V& v) noexcept
+        : Vec3(T(v.x), T(v.y), T(v.z)) { }
+
+    template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,3>::value
+                                         && !has_xyz<V,T>::value)>
+    IMATH_HOSTDEVICE Vec3 (const V& v) : Vec3(T(v[0]), T(v[1]), T(v[2])) { }
 
     /// Interoperability assignment from another type that behaves as if it
     /// were an equivalent vector.
@@ -360,12 +393,9 @@ template <class T> class Vec3
         z = T(v[2]);
         return *this;
     }
-
-    /// Destructor
-    ~Vec3() noexcept = default;
-
     /// @}
-    
+#endif
+
     /// @{
     /// @name Compatibility with Sb
 
@@ -577,8 +607,30 @@ template <class T> class Vec4
     /// Vec3 to Vec4 conversion, sets w to 1.
     template <class S> IMATH_HOSTDEVICE explicit constexpr Vec4 (const Vec3<S>& v) noexcept;
 
-    /// Interoperability constructor from another type that behaves as if it
-    /// were an equivalent vector.
+    /// Assignment
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator= (const Vec4& v) noexcept;
+
+    /// Destructor
+    ~Vec4() noexcept = default;
+
+    /// @}
+
+#if IMATH_FOREIGN_VECTOR_INTEROP
+    /// @{
+    /// @name Interoperability with other vector types
+    ///
+    /// Construction and assignment are allowed from other classes that
+    /// appear to be equivalent vector types, provided that they have either
+    /// a subscripting operator, or data members .x, .y, .z, .w that are of
+    /// the same type as the elements of this vector, and their size appears
+    /// to be the right number of elements.
+    ///
+    /// This functionality is disabled for gcc 4.x, which seems to have a
+    /// compiler bug that results in spurious errors. It can also be
+    /// disabled by defining IMATH_FOREIGN_VECTOR_INTEROP to be 0 prior to
+    /// including any Imath header files.
+    ///
+
     template<typename V, IMATH_ENABLE_IF(has_xyzw<V,T>::value)>
     IMATH_HOSTDEVICE constexpr Vec4 (const V& v) noexcept
         : Vec4(T(v.x), T(v.y), T(v.z), T(v.w)) { }
@@ -587,11 +639,6 @@ template <class T> class Vec4
                                          && !has_xyzw<V,T>::value)>
     IMATH_HOSTDEVICE Vec4 (const V& v) : Vec4(T(v[0]), T(v[1]), T(v[2]), T(v[3])) { }
 
-    /// Assignment
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator= (const Vec4& v) noexcept;
-
-    /// Interoperability assignment from another type that behaves as if it
-    /// were an equivalent vector.
     template<typename V, IMATH_ENABLE_IF(has_xyzw<V,T>::value)>
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator= (const V& v) noexcept {
         x = T(v.x);
@@ -610,12 +657,9 @@ template <class T> class Vec4
         w = T(v[3]);
         return *this;
     }
-
-    /// Destructor
-    ~Vec4() noexcept = default;
-
     /// @}
-    
+#endif
+
     /// @{
     /// @name Arithmetic and Comparison
     

--- a/src/ImathTest/CMakeLists.txt
+++ b/src/ImathTest/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(ImathTest
   testLimits.cpp
   testSize.cpp
   testToFloat.cpp
+  testInterop.cpp
 )
 
 target_link_libraries(ImathTest Imath::Imath)

--- a/src/ImathTest/main.cpp
+++ b/src/ImathTest/main.cpp
@@ -23,6 +23,7 @@
 #include <testFrustum.h>
 #include <testFrustumTest.h>
 #include <testFun.h>
+#include <testInterop.h>
 #include <testInterval.h>
 #include <testInvert.h>
 #include <testJacobiEigenSolver.h>
@@ -85,6 +86,7 @@ main (int argc, char* argv[])
     TEST (testTinySVD);
     TEST (testJacobiEigenSolver);
     TEST (testFrustumTest);
+    TEST (testInterop);
     // NB: If you add a test here, make sure to enumerate it in the
     // CMakeLists.txt so it runs as part of the test suite
 

--- a/src/ImathTest/testInterop.cpp
+++ b/src/ImathTest/testInterop.cpp
@@ -242,7 +242,7 @@ testInteropVec2()
         s[1] = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42);
-        testVecVal2f(s, 1.0f, 42.0f);
+        testVecVal2f(V2f(s), 1.0f, 42.0f);
     }
     // Test construction/assignment/paramater pass of a vector type with
     // explicit .y, .y, .z components but no subscripting.
@@ -253,7 +253,7 @@ testInteropVec2()
         s.y = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42);
-        testVecVal2f(s, 1.0f, 42.0f);
+        testVecVal2f(V2f(s), 1.0f, 42.0f);
     }
     // Test construction/assignment/paramater pass of a std::vector of length 3
     {
@@ -263,7 +263,7 @@ testInteropVec2()
         s[1] = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42);
-        testVecVal2f(s, 1.0f, 42.0f);
+        testVecVal2f(V2f(s), 1.0f, 42.0f);
     }
     // Test construction/assignment/paramater pass of a std::array of length 3
     {
@@ -273,7 +273,7 @@ testInteropVec2()
         s[1] = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42);
-        testVecVal2f(s, 1.0f, 42.0f);
+        testVecVal2f(V2f(s), 1.0f, 42.0f);
     }
     // Test construction/assignment/paramater pass of initializer lists.
     {
@@ -291,7 +291,7 @@ testInteropVec2()
         s[1] = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42);
-        testVecVal2f(s, 1.0f, 42.0f);
+        testVecVal2f(V2f(s), 1.0f, 42.0f);
     }
 }
 
@@ -371,7 +371,7 @@ testInteropVec3()
         s[1] = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
-        testVecVal3f(s, 1.0f, 42.0f, 3.0f);
+        testVecVal3f(V3f(s), 1.0f, 42.0f, 3.0f);
     }
     // Test construction/assignment/paramater pass of a vector type with
     // explicit .y, .y, .z components but no subscripting.
@@ -382,7 +382,7 @@ testInteropVec3()
         s.y = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
-        testVecVal3f(s, 1.0f, 42.0f, 3.0f);
+        testVecVal3f(V3f(s), 1.0f, 42.0f, 3.0f);
     }
     // Test construction/assignment/paramater pass of a std::vector of length 3
     {
@@ -392,7 +392,7 @@ testInteropVec3()
         s[1] = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
-        testVecVal3f(s, 1.0f, 42.0f, 3.0f);
+        testVecVal3f(V3f(s), 1.0f, 42.0f, 3.0f);
     }
     // Test construction/assignment/paramater pass of a std::array of length 3
     {
@@ -402,7 +402,7 @@ testInteropVec3()
         s[1] = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
-        testVecVal3f(s, 1.0f, 42.0f, 3.0f);
+        testVecVal3f(V3f(s), 1.0f, 42.0f, 3.0f);
     }
     // Test construction/assignment/paramater pass of initializer lists.
     {
@@ -420,7 +420,7 @@ testInteropVec3()
         s[1] = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
-        testVecVal3f(s, 1.0f, 42.0f, 3.0f);
+        testVecVal3f(V3f(s), 1.0f, 42.0f, 3.0f);
     }
 }
 
@@ -501,7 +501,7 @@ testInteropVec4()
         s[1] = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42 && v[2] == 3 && v[3] == 4);
-        testVecVal4f(s, 1.0f, 42.0f, 3.0f, 4.0f);
+        testVecVal4f(V4f(s), 1.0f, 42.0f, 3.0f, 4.0f);
     }
     // Test construction/assignment/paramater pass of a vector type with
     // explicit .y, .y, .z components but no subscripting.
@@ -522,7 +522,7 @@ testInteropVec4()
         s[1] = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42 && v[2] == 3 && v[3] == 4);
-        testVecVal4f(s, 1.0f, 42.0f, 3.0f, 4.0f);
+        testVecVal4f(V4f(s), 1.0f, 42.0f, 3.0f, 4.0f);
     }
     // Test construction/assignment/paramater pass of a std::array of length 3
     {
@@ -532,7 +532,7 @@ testInteropVec4()
         s[1] = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42 && v[2] == 3 && v[3] == 4);
-        testVecVal4f(s, 1.0f, 42.0f, 3.0f, 4.0f);
+        testVecVal4f(V4f(s), 1.0f, 42.0f, 3.0f, 4.0f);
     }
     // Test construction/assignment/paramater pass of initializer lists.
     {
@@ -550,7 +550,7 @@ testInteropVec4()
         s[1] = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42 && v[2] == 3 && v[3] == 4);
-        testVecVal4f(s, 1.0f, 42.0f, 3.0f, 4.0f);
+        testVecVal4f(V4f(s), 1.0f, 42.0f, 3.0f, 4.0f);
     }
 }
 

--- a/src/ImathTest/testInterop.cpp
+++ b/src/ImathTest/testInterop.cpp
@@ -29,6 +29,7 @@ template<typename T, int N>
 struct has_subscript<std::vector<T>, T, N> : public std::true_type { };
 IMATH_INTERNAL_NAMESPACE_SOURCE_EXIT
 
+#if IMATH_FOREIGN_VECTOR_INTEROP
 
 
 namespace
@@ -511,7 +512,7 @@ testInteropVec4()
         s.y = 42;
         v = s;
         assert(v[0] == 1 && v[1] == 42 && v[2] == 3 && v[3] == 4);
-        testVecVal4f(s, 1.0f, 42.0f, 3.0f, 4.0f);
+        testVecVal4f(V4f(s), 1.0f, 42.0f, 3.0f, 4.0f);
     }
     // Test construction/assignment/paramater pass of a std::vector of length 3
     {
@@ -689,16 +690,16 @@ testInteropMx4()
     }
 }
 
-
-
-
 } // namespace
+#endif
+
 
 void
 testInterop()
 {
     cout << "Testing interoperability with foreign types" << endl;
 
+#if IMATH_FOREIGN_VECTOR_INTEROP
     testInteropVec2();
     testInteropVec3();
     testInteropVec4();
@@ -708,4 +709,7 @@ testInterop()
     testInteropMx4();
 
     cout << "ok\n" << endl;
+#else
+    cout << "Foreign vector type interopability is disabled.\n";
+#endif
 }

--- a/src/ImathTest/testInterop.cpp
+++ b/src/ImathTest/testInterop.cpp
@@ -1,0 +1,257 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+#ifdef NDEBUG
+#    undef NDEBUG
+#endif
+
+#include "ImathFun.h"
+#include "ImathVec.h"
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <vector>
+#include <testVec.h>
+
+using namespace std;
+using namespace IMATH_INTERNAL_NAMESPACE;
+
+
+// Imath::has_subscript fails for std::vector because its length does not
+// appear to be the length of N elements. Carve out an exception here that
+// allows this to work.
+IMATH_INTERNAL_NAMESPACE_SOURCE_ENTER
+template<typename T, int N>
+struct has_subscript<std::vector<T>, T, N> : public std::true_type { };
+IMATH_INTERNAL_NAMESPACE_SOURCE_EXIT
+
+
+
+namespace
+{
+
+// Extra simple vector that does nothing but allow element access, as an
+// example of a vector type that an app might use and want interop with
+// our vectors.
+template <typename T, int N>
+struct SimpleVec {
+    T elements[N];
+
+    SimpleVec(T val = T(0)) {
+        for (int i = 0; i < N; ++i)
+            elements[i] = val;
+    }
+    ~SimpleVec() = default;
+    constexpr T operator[](int i) const { return elements[i]; }
+    T& operator[](int i) { return elements[i]; }
+};
+
+
+
+// Small structs containing just x,y,z,w elements.
+template<typename T>
+struct xy {
+    T x, y;
+};
+
+
+template<typename T>
+struct xyz {
+    T x, y, z;
+};
+
+
+template<typename T>
+struct xyzw {
+    T x, y, z, w;
+};
+
+
+template<typename T>
+struct xyz_wrong {
+    T x() { return 0; }
+    T y() { return 1; }
+    T z() { return 2; }
+};
+
+
+
+// A class that has *both* subscripting and named members
+template<typename T>
+struct ComboVec3 {
+    union {
+        T elements[3];
+        struct { T x, y, z; };
+    };
+
+    ComboVec3(T val = T(0)) : x(val), y(val), z(val) { }
+    ~ComboVec3() = default;
+    constexpr T operator[](int i) const { return elements[i]; }
+    T& operator[](int i) { return elements[i]; }
+};
+
+
+
+// Test whether a Vec contains the given elements.
+void
+testVecVal2f(const V2f& v, float a, float b)
+{
+    assert(v[0] == a && v[1] == b);
+}
+
+void
+testVecVal3f(const V3f& v, float a, float b, float c)
+{
+    assert(v[0] == a && v[1] == b && v[2] == c);
+}
+
+void
+testVecVal4f(const V4f& v, float a, float b, float c, float d)
+{
+    assert(v[0] == a && v[1] == b && v[2] == c && v[3] == d);
+}
+
+
+
+
+void
+testInteropVec3()
+{
+    std::cout << "has_xyz<SimpleVec<float,3>, float>::value = "
+              << has_xyz<SimpleVec<float,3>, float>::value << "\n";
+    std::cout << "has_xyz<SimpleVec<int,3>, float>::value = "
+              << has_xyz<SimpleVec<int,3>, float>::value << "\n";
+    std::cout << "has_xyz<SimpleVec<float,4>, float>::value = "
+              << has_xyz<SimpleVec<float,4>, float>::value << "\n";
+    std::cout << "has_xyz<xyz<float>, float>::value = "
+              << has_xyz<xyz<float>, float>::value << "\n";
+    std::cout << "has_xyz<xyzw<float>, float>::value = "
+              << has_xyz<xyzw<float>, float>::value << "\n";
+    std::cout << "has_xyz<xy<float>, float>::value = "
+              << has_xyz<xy<float>, float>::value << "\n";
+    std::cout << "has_xyz<xyz<int>, float>::value = "
+              << has_xyz<xyz<int>, float>::value << "\n";
+    std::cout << "has_xyz<xyz_wrong<float>, float>::value = "
+              << has_xyz<xyz_wrong<float>, float>::value << "\n";
+    std::cout << "\n";
+    std::cout << "has_subscript<SimpleVec<float,3>, float, 3>::value = "
+              << has_subscript<SimpleVec<float,3>, float, 3>::value << "\n";
+    std::cout << "has_subscript<SimpleVec<int,3>, float, 3>::value = "
+              << has_subscript<SimpleVec<int,3>, float, 3>::value << "\n";
+    std::cout << "has_subscript<SimpleVec<float,4>, float, 3>::value = "
+              << has_subscript<SimpleVec<float,4>, float, 3>::value << "\n";
+    std::cout << "has_subscript<xyz<float>, float, 3>::value = "
+              << has_subscript<xyz<float>, float, 3>::value << "\n";
+    std::cout << "has_subscript<xyzw<float>, float, 3>::value = "
+              << has_subscript<xyzw<float>, float, 3>::value << "\n";
+    std::cout << "has_subscript<xy<float>, float, 3>::value = "
+              << has_subscript<xy<float>, float, 3>::value << "\n";
+    std::cout << "has_subscript<xyz<int>, float, 3>::value = "
+              << has_subscript<xyz<int>, float, 3>::value << "\n";
+    std::cout << "has_subscript<xyz_wrong<float>, float, 3>::value = "
+              << has_subscript<xyz_wrong<float>, float, 3>::value << "\n";
+    std::cout << "has_subscript<std::array<float, 3>, float, 3>::value = "
+              << has_subscript<std::array<float, 3>, float, 3>::value << "\n";
+    std::cout << "has_subscript<std::array<int, 3>, float, 3>::value = "
+              << has_subscript<std::array<int, 3>, float, 3>::value << "\n";
+    std::cout << "has_subscript<std::array<float, 4>, float, 3>::value = "
+              << has_subscript<std::array<float, 4>, float, 3>::value << "\n";
+    std::cout << "has_subscript<std::vector<float>, float, 3>::value = "
+              << has_subscript<std::vector<float>, float, 3>::value << "\n";
+    std::cout << "\n";
+    std::cout << "has_xyz<ComboVec3<float>, float, 3>::value = "
+              << has_xyz<ComboVec3<float>, float>::value << "\n";
+    std::cout << "has_subscript<ComboVec3<float>, float, 3>::value = "
+              << has_subscript<ComboVec3<float>, float, 3>::value << "\n";
+    std::cout << "\n";
+
+    assert((!has_xyz<SimpleVec<float,3>, float>::value));
+    assert((has_xyz<xyz<float>, float>::value));
+    assert((!has_xyz<xy<float>, float>::value));
+
+    assert((has_subscript<SimpleVec<float,3>, float, 3>::value));
+    assert((!has_subscript<SimpleVec<float,4>, float, 3>::value));
+    assert((!has_subscript<SimpleVec<float,3>, int, 3>::value));
+    assert((!has_subscript<xyz<float>, float, 3>::value));
+    assert((!has_subscript<xy<float>, float, 3>::value));
+
+    // Test construction/assignment/paramater pass of a vector type with
+    // subscripting to access components.
+    {
+        SimpleVec<float,3> s;
+        s[0] = 1;
+        s[1] = 2;
+        s[2] = 3;
+        Vec3<float> v(s);
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
+        testVecVal3f(s, 1.0f, 42.0f, 3.0f);
+    }
+    // Test construction/assignment/paramater pass of a vector type with
+    // explicit .y, .y, .z components but no subscripting.
+    {
+        xyz<float> s { 1, 2, 3 };
+        Vec3<float> v(s);
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
+        s.y = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
+        testVecVal3f(s, 1.0f, 42.0f, 3.0f);
+    }
+    // Test construction/assignment/paramater pass of a std::vector of length 3
+    {
+        std::vector<float> s { 1, 2, 3 };
+        Vec3<float> v(s);
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
+        testVecVal3f(s, 1.0f, 42.0f, 3.0f);
+    }
+    // Test construction/assignment/paramater pass of a std::array of length 3
+    {
+        std::array<float, 3> s { 1, 2, 3 };
+        Vec3<float> v(s);
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
+        testVecVal3f(s, 1.0f, 42.0f, 3.0f);
+    }
+    // Test construction/assignment/paramater pass of initializer lists.
+    {
+        Vec3<float> v({ 1.0f, 2.0f, 3.0f });
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
+        v = { 1.0f, 42.0f, 3.0f };
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
+        testVecVal3f({ 1.0f, 42.0f, 3.0f }, 1, 42, 3);
+    }
+    // Test construction/assignment/paramater pass of a C array
+    {
+        float s[3] = { 1, 2, 3 };
+        Vec3<float> v(s);
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
+        testVecVal3f(s, 1.0f, 42.0f, 3.0f);
+    }
+}
+
+
+} // namespace
+
+void
+testInterop()
+{
+    cout << "Testing interoperability with foreign types" << endl;
+
+    testInteropVec3();
+
+    cout << "ok\n" << endl;
+}

--- a/src/ImathTest/testInterop.cpp
+++ b/src/ImathTest/testInterop.cpp
@@ -9,6 +9,7 @@
 
 #include "ImathFun.h"
 #include "ImathVec.h"
+#include "ImathMatrix.h"
 #include <array>
 #include <cassert>
 #include <cmath>
@@ -51,6 +52,25 @@ struct SimpleVec {
 
 
 
+// Extra simple matrix that does nothing but allow element access, as an
+// example of a matrix type that an app might use and want interop with
+// our vectors.
+template <typename T, int N>
+struct SimpleMx {
+    T elements[N][N];
+
+    SimpleMx(T val = T(0)) {
+        for (int j = 0; j < N; ++j)
+            for (int i = 0; i < N; ++i)
+                elements[j][i] = val;
+    }
+    ~SimpleMx() = default;
+    const T* operator[](int i) const { return elements[i]; }
+    T* operator[](int i) { return elements[i]; }
+};
+
+
+
 // Small structs containing just x,y,z,w elements.
 template<typename T>
 struct xy {
@@ -81,6 +101,22 @@ struct xyz_wrong {
 
 // A class that has *both* subscripting and named members
 template<typename T>
+struct ComboVec2 {
+    union {
+        T elements[2];
+        struct { T x, y; };
+    };
+
+    ComboVec2(T val = T(0)) : x(val), y(val) { }
+    ~ComboVec2() = default;
+    constexpr T operator[](int i) const { return elements[i]; }
+    T& operator[](int i) { return elements[i]; }
+};
+
+
+
+// A class that has *both* subscripting and named members
+template<typename T>
 struct ComboVec3 {
     union {
         T elements[3];
@@ -89,6 +125,22 @@ struct ComboVec3 {
 
     ComboVec3(T val = T(0)) : x(val), y(val), z(val) { }
     ~ComboVec3() = default;
+    constexpr T operator[](int i) const { return elements[i]; }
+    T& operator[](int i) { return elements[i]; }
+};
+
+
+
+// A class that has *both* subscripting and named members
+template<typename T>
+struct ComboVec4 {
+    union {
+        T elements[4];
+        struct { T x, y, z, w; };
+    };
+
+    ComboVec4(T val = T(0)) : x(val), y(val), z(val), w(val) { }
+    ~ComboVec4() = default;
     constexpr T operator[](int i) const { return elements[i]; }
     T& operator[](int i) { return elements[i]; }
 };
@@ -116,6 +168,134 @@ testVecVal4f(const V4f& v, float a, float b, float c, float d)
 
 
 
+
+void
+testInteropVec2()
+{
+    std::cout << "has_xy<SimpleVec<float,2>, float>::value = "
+              << has_xy<SimpleVec<float,2>, float>::value << "\n";
+    std::cout << "has_xy<SimpleVec<int,2>, float>::value = "
+              << has_xy<SimpleVec<int,2>, float>::value << "\n";
+    std::cout << "has_xy<SimpleVec<float,4>, float>::value = "
+              << has_xy<SimpleVec<float,4>, float>::value << "\n";
+    std::cout << "has_xy<xyz<float>, float>::value = "
+              << has_xy<xyz<float>, float>::value << "\n";
+    std::cout << "has_xy<xyzw<float>, float>::value = "
+              << has_xy<xyzw<float>, float>::value << "\n";
+    std::cout << "has_xy<xy<float>, float>::value = "
+              << has_xy<xy<float>, float>::value << "\n";
+    std::cout << "has_xy<xyz<int>, float>::value = "
+              << has_xy<xyz<int>, float>::value << "\n";
+    std::cout << "has_xy<xyz_wrong<float>, float>::value = "
+              << has_xy<xyz_wrong<float>, float>::value << "\n";
+    std::cout << "\n";
+    std::cout << "has_subscript<SimpleVec<float,2>, float, 2>::value = "
+              << has_subscript<SimpleVec<float,2>, float, 2>::value << "\n";
+    std::cout << "has_subscript<SimpleVec<int,2>, float, 2>::value = "
+              << has_subscript<SimpleVec<int,2>, float, 2>::value << "\n";
+    std::cout << "has_subscript<SimpleVec<float,4>, float, 2>::value = "
+              << has_subscript<SimpleVec<float,4>, float, 2>::value << "\n";
+    std::cout << "has_subscript<xyz<float>, float, 2>::value = "
+              << has_subscript<xyz<float>, float, 2>::value << "\n";
+    std::cout << "has_subscript<xyzw<float>, float, 2>::value = "
+              << has_subscript<xyzw<float>, float, 2>::value << "\n";
+    std::cout << "has_subscript<xy<float>, float, 2>::value = "
+              << has_subscript<xy<float>, float, 2>::value << "\n";
+    std::cout << "has_subscript<xyz<int>, float, 2>::value = "
+              << has_subscript<xyz<int>, float, 2>::value << "\n";
+    std::cout << "has_subscript<xyz_wrong<float>, float, 2>::value = "
+              << has_subscript<xyz_wrong<float>, float, 2>::value << "\n";
+    std::cout << "has_subscript<std::array<float, 2>, float, 2>::value = "
+              << has_subscript<std::array<float, 2>, float, 2>::value << "\n";
+    std::cout << "has_subscript<std::array<int, 2>, float, 2>::value = "
+              << has_subscript<std::array<int, 2>, float, 2>::value << "\n";
+    std::cout << "has_subscript<std::array<float, 4>, float, 2>::value = "
+              << has_subscript<std::array<float, 4>, float, 2>::value << "\n";
+    std::cout << "has_subscript<std::vector<float>, float, 2>::value = "
+              << has_subscript<std::vector<float>, float, 2>::value << "\n";
+    std::cout << "\n";
+    std::cout << "has_xy<ComboVec3<float>, float, 2>::value = "
+              << has_xy<ComboVec3<float>, float>::value << "\n";
+    std::cout << "has_subscript<ComboVec3<float>, float, 2>::value = "
+              << has_subscript<ComboVec3<float>, float, 2>::value << "\n";
+    std::cout << "\n";
+
+    assert((!has_xy<SimpleVec<float,2>, float>::value));
+    assert((has_xy<xy<float>, float>::value));
+    assert((!has_xy<xyz<float>, float>::value));
+
+    assert((has_subscript<SimpleVec<float,2>, float, 2>::value));
+    assert((!has_subscript<SimpleVec<float,4>, float, 2>::value));
+    assert((!has_subscript<SimpleVec<float,2>, int, 2>::value));
+    assert((!has_subscript<xyz<float>, float, 2>::value));
+    assert((!has_subscript<xy<float>, float, 2>::value));
+
+    // Test construction/assignment/paramater pass of a vector type with
+    // subscripting to access components.
+    {
+        SimpleVec<float,2> s;
+        s[0] = 1;
+        s[1] = 2;
+        Vec2<float> v(s);
+        assert(v[0] == 1 && v[1] == 2);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42);
+        testVecVal2f(s, 1.0f, 42.0f);
+    }
+    // Test construction/assignment/paramater pass of a vector type with
+    // explicit .y, .y, .z components but no subscripting.
+    {
+        xy<float> s { 1, 2 };
+        Vec2<float> v(s);
+        assert(v[0] == 1 && v[1] == 2);
+        s.y = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42);
+        testVecVal2f(s, 1.0f, 42.0f);
+    }
+    // Test construction/assignment/paramater pass of a std::vector of length 3
+    {
+        std::vector<float> s { 1, 2 };
+        Vec2<float> v(s);
+        assert(v[0] == 1 && v[1] == 2);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42);
+        testVecVal2f(s, 1.0f, 42.0f);
+    }
+    // Test construction/assignment/paramater pass of a std::array of length 3
+    {
+        std::array<float, 2> s { 1, 2 };
+        Vec2<float> v(s);
+        assert(v[0] == 1 && v[1] == 2);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42);
+        testVecVal2f(s, 1.0f, 42.0f);
+    }
+    // Test construction/assignment/paramater pass of initializer lists.
+    {
+        Vec2<float> v({ 1.0f, 2.0f });
+        assert(v[0] == 1 && v[1] == 2);
+        v = { 1.0f, 42.0f };
+        assert(v[0] == 1 && v[1] == 42);
+        testVecVal2f({ 1.0f, 42.0f}, 1.0f, 42.0f);
+    }
+    // Test construction/assignment/paramater pass of a C array
+    {
+        float s[2] = { 1, 2 };
+        Vec2<float> v(s);
+        assert(v[0] == 1 && v[1] == 2);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42);
+        testVecVal2f(s, 1.0f, 42.0f);
+    }
+}
+
+
+//---------
 
 void
 testInteropVec3()
@@ -244,6 +424,274 @@ testInteropVec3()
 }
 
 
+//---------
+
+void
+testInteropVec4()
+{
+    std::cout << "has_xyzw<SimpleVec<float,4>, float>::value = "
+              << has_xyzw<SimpleVec<float,4>, float>::value << "\n";
+    std::cout << "has_xyzw<SimpleVec<int,4>, float>::value = "
+              << has_xyzw<SimpleVec<int,4>, float>::value << "\n";
+    std::cout << "has_xyzw<SimpleVec<float,4>, float>::value = "
+              << has_xyzw<SimpleVec<float,4>, float>::value << "\n";
+    std::cout << "has_xyzw<xyzw<float>, float>::value = "
+              << has_xyzw<xyzw<float>, float>::value << "\n";
+    std::cout << "has_xyzw<xyzw<float>, float>::value = "
+              << has_xyzw<xyzw<float>, float>::value << "\n";
+    std::cout << "has_xyzw<xy<float>, float>::value = "
+              << has_xyzw<xy<float>, float>::value << "\n";
+    std::cout << "has_xyzw<xyzw<int>, float>::value = "
+              << has_xyzw<xyzw<int>, float>::value << "\n";
+    std::cout << "has_xyzw<xyz_wrong<float>, float>::value = "
+              << has_xyzw<xyz_wrong<float>, float>::value << "\n";
+    std::cout << "\n";
+    std::cout << "has_subscript<SimpleVec<float,4>, float, 4>::value = "
+              << has_subscript<SimpleVec<float,4>, float, 4>::value << "\n";
+    std::cout << "has_subscript<SimpleVec<int,4>, float, 4>::value = "
+              << has_subscript<SimpleVec<int,4>, float, 4>::value << "\n";
+    std::cout << "has_subscript<SimpleVec<float,4>, float, 4>::value = "
+              << has_subscript<SimpleVec<float,4>, float, 4>::value << "\n";
+    std::cout << "has_subscript<xyzw<float>, float, 4>::value = "
+              << has_subscript<xyzw<float>, float, 4>::value << "\n";
+    std::cout << "has_subscript<xyzw<float>, float, 4>::value = "
+              << has_subscript<xyzw<float>, float, 4>::value << "\n";
+    std::cout << "has_subscript<xy<float>, float, 4>::value = "
+              << has_subscript<xy<float>, float, 4>::value << "\n";
+    std::cout << "has_subscript<xyzw<int>, float, 4>::value = "
+              << has_subscript<xyzw<int>, float, 4>::value << "\n";
+    std::cout << "has_subscript<xyz_wrong<float>, float, 4>::value = "
+              << has_subscript<xyz_wrong<float>, float, 4>::value << "\n";
+    std::cout << "has_subscript<std::array<float, 3>, float, 4>::value = "
+              << has_subscript<std::array<float, 3>, float, 4>::value << "\n";
+    std::cout << "has_subscript<std::array<int, 3>, float, 4>::value = "
+              << has_subscript<std::array<int, 3>, float, 4>::value << "\n";
+    std::cout << "has_subscript<std::array<float, 4>, float, 4>::value = "
+              << has_subscript<std::array<float, 4>, float, 4>::value << "\n";
+    std::cout << "has_subscript<std::vector<float>, float, 4>::value = "
+              << has_subscript<std::vector<float>, float, 4>::value << "\n";
+    std::cout << "\n";
+    std::cout << "has_xyzw<ComboVec4<float>, float, 4>::value = "
+              << has_xyzw<ComboVec4<float>, float>::value << "\n";
+    std::cout << "has_subscript<ComboVec4<float>, float, 4>::value = "
+              << has_subscript<ComboVec4<float>, float, 4>::value << "\n";
+    std::cout << "\n";
+
+    assert((!has_xyzw<SimpleVec<float,4>, float>::value));
+    assert((has_xyzw<xyzw<float>, float>::value));
+    assert((!has_xyzw<xyz<float>, float>::value));
+
+    assert((has_subscript<SimpleVec<float,4>, float, 4>::value));
+    assert((!has_subscript<SimpleVec<float,4>, float, 3>::value));
+    assert((!has_subscript<SimpleVec<float,4>, int, 4>::value));
+    assert((!has_subscript<xyzw<float>, float, 4>::value));
+    assert((!has_subscript<xy<float>, float, 4>::value));
+
+    // Test construction/assignment/paramater pass of a vector type with
+    // subscripting to access components.
+    {
+        SimpleVec<float,4> s;
+        s[0] = 1;
+        s[1] = 2;
+        s[2] = 3;
+        s[3] = 4;
+        Vec4<float> v(s);
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3 && v[3] == 4);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3 && v[3] == 4);
+        testVecVal4f(s, 1.0f, 42.0f, 3.0f, 4.0f);
+    }
+    // Test construction/assignment/paramater pass of a vector type with
+    // explicit .y, .y, .z components but no subscripting.
+    {
+        xyzw<float> s { 1, 2, 3, 4 };
+        Vec4<float> v(s);
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3 && v[3] == 4);
+        s.y = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3 && v[3] == 4);
+        testVecVal4f(s, 1.0f, 42.0f, 3.0f, 4.0f);
+    }
+    // Test construction/assignment/paramater pass of a std::vector of length 3
+    {
+        std::vector<float> s { 1, 2, 3, 4 };
+        Vec4<float> v(s);
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3 && v[3] == 4);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3 && v[3] == 4);
+        testVecVal4f(s, 1.0f, 42.0f, 3.0f, 4.0f);
+    }
+    // Test construction/assignment/paramater pass of a std::array of length 3
+    {
+        std::array<float, 4> s { 1, 2, 3, 4 };
+        Vec4<float> v(s);
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3 && v[3] == 4);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3 && v[3] == 4);
+        testVecVal4f(s, 1.0f, 42.0f, 3.0f, 4.0f);
+    }
+    // Test construction/assignment/paramater pass of initializer lists.
+    {
+        Vec4<float> v({ 1.0f, 2.0f, 3.0f, 4.0f });
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3 && v[3] == 4);
+        v = { 1.0f, 42.0f, 3.0f, 4.0f };
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3 && v[3] == 4);
+        testVecVal4f({ 1.0f, 42.0f, 3.0f, 4.0f }, 1, 42, 3, 4);
+    }
+    // Test construction/assignment/paramater pass of a C array
+    {
+        float s[4] = { 1, 2, 3, 4 };
+        Vec4<float> v(s);
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3 && v[3] == 4);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3 && v[3] == 4);
+        testVecVal4f(s, 1.0f, 42.0f, 3.0f, 4.0f);
+    }
+}
+
+
+//---------
+
+void
+testInteropMx2()
+{
+    std::cout << "has_double_subscript<SimpleMx<float,2>, float, 2, 2>::value = "
+              << has_double_subscript<SimpleMx<float,2>, float, 2, 2>::value << "\n";
+    std::cout << "has_double_subscript<SimpleMx<int,2>, float, 2, 2>::value = "
+              << has_double_subscript<SimpleMx<int,2>, float, 2, 2>::value << "\n";
+    std::cout << "has_double_subscript<SimpleMx<float,2>, float, 4, 4>::value = "
+              << has_double_subscript<SimpleMx<float,2>, float, 4, 4>::value << "\n";
+    std::cout << "has_double_subscript<xyzw<float>, float, 2, 2>::value = "
+              << has_double_subscript<xyzw<float>, float, 2, 2>::value << "\n";
+    std::cout << "has_double_subscript<xyz_wrong<float>, float, 2, 2>::value = "
+              << has_double_subscript<xyz_wrong<float>, float, 2, 2>::value << "\n";
+    std::cout << "\n";
+
+    assert((has_double_subscript<SimpleMx<float,2>, float, 2, 2>::value));
+    assert((!has_double_subscript<SimpleMx<float,2>, float, 4, 4>::value));
+    assert((!has_double_subscript<SimpleMx<float,2>, int, 2, 2>::value));
+    assert((!has_double_subscript<xyzw<float>, float, 2, 2>::value));
+    assert((!has_double_subscript<xy<float>, float, 2, 2>::value));
+
+    // Test construction/assignment/paramater pass of a vector type with
+    // subscripting to access components.
+    {
+        Matrix22<float> ref;
+        SimpleMx<float,2> s;
+        for (int j = 0; j < 2; ++j)
+            for (int i = 0; i < 2; ++i) {
+                s[j][i] = i + j * 2;
+                ref[j][i] = i + j * 2;
+            }
+        Matrix22<float> v(s);
+        assert(v[0][0] == 0 && v[0][1] == 1 &&
+               v[1][0] == 2 && v[1][1] == 3);
+        s[1][1] = 42;
+        v = s;
+        assert(v[0][0] == 0 && v[0][1] == 1 &&
+               v[1][0] == 2 && v[1][1] == 42);
+    }
+}
+
+
+
+void
+testInteropMx3()
+{
+    std::cout << "has_double_subscript<SimpleMx<float,3>, float, 3, 3>::value = "
+              << has_double_subscript<SimpleMx<float,3>, float, 3, 3>::value << "\n";
+    std::cout << "has_double_subscript<SimpleMx<int,3>, float, 3, 3>::value = "
+              << has_double_subscript<SimpleMx<int,3>, float, 3, 3>::value << "\n";
+    std::cout << "has_double_subscript<SimpleMx<float,3>, float, 4, 4>::value = "
+              << has_double_subscript<SimpleMx<float,3>, float, 4, 4>::value << "\n";
+    std::cout << "has_double_subscript<xyzw<float>, float, 3, 3>::value = "
+              << has_double_subscript<xyzw<float>, float, 3, 3>::value << "\n";
+    std::cout << "has_double_subscript<xyz_wrong<float>, float, 3, 3>::value = "
+              << has_double_subscript<xyz_wrong<float>, float, 3, 3>::value << "\n";
+    std::cout << "\n";
+
+    assert((has_double_subscript<SimpleMx<float,3>, float, 3, 3>::value));
+    assert((!has_double_subscript<SimpleMx<float,3>, float, 4, 4>::value));
+    assert((!has_double_subscript<SimpleMx<float,3>, int, 3, 3>::value));
+    assert((!has_double_subscript<xyzw<float>, float, 3, 3>::value));
+    assert((!has_double_subscript<xy<float>, float, 3, 3>::value));
+
+    // Test construction/assignment/paramater pass of a vector type with
+    // subscripting to access components.
+    {
+        Matrix33<float> ref;
+        SimpleMx<float,3> s;
+        for (int j = 0; j < 3; ++j)
+            for (int i = 0; i < 3; ++i) {
+                s[j][i] = i + j * 3;
+                ref[j][i] = i + j * 3;
+            }
+        Matrix33<float> v(s);
+        assert(v[0][0] == 0 && v[0][1] == 1 && v[0][2] == 2 &&
+               v[1][0] == 3 && v[1][1] == 4 && v[1][2] == 5 &&
+               v[2][0] == 6 && v[2][1] == 7 && v[2][2] == 8);
+        s[1][1] = 42;
+        v = s;
+        assert(v[0][0] == 0 && v[0][1] == 1 && v[0][2] == 2 &&
+               v[1][0] == 3 && v[1][1] == 42 && v[1][2] == 5 &&
+               v[2][0] == 6 && v[2][1] == 7 && v[2][2] == 8);
+    }
+}
+
+
+
+void
+testInteropMx4()
+{
+    std::cout << "has_double_subscript<SimpleMx<float,4>, float, 4, 4>::value = "
+              << has_double_subscript<SimpleMx<float,4>, float, 4, 4>::value << "\n";
+    std::cout << "has_double_subscript<SimpleMx<int,4>, float, 4, 4>::value = "
+              << has_double_subscript<SimpleMx<int,4>, float, 4, 4>::value << "\n";
+    std::cout << "has_double_subscript<SimpleMx<float,4>, float, 4, 4>::value = "
+              << has_double_subscript<SimpleMx<float,4>, float, 4, 4>::value << "\n";
+    std::cout << "has_double_subscript<xyzw<float>, float, 4, 4>::value = "
+              << has_double_subscript<xyzw<float>, float, 4, 4>::value << "\n";
+    std::cout << "has_double_subscript<xyz_wrong<float>, float, 4, 4>::value = "
+              << has_double_subscript<xyz_wrong<float>, float, 4, 4>::value << "\n";
+    std::cout << "\n";
+
+    assert((has_double_subscript<SimpleMx<float,4>, float, 4, 4>::value));
+    assert((!has_double_subscript<SimpleMx<float,4>, float, 3, 3>::value));
+    assert((!has_double_subscript<SimpleMx<float,4>, int, 4, 4>::value));
+    assert((!has_double_subscript<xyzw<float>, float, 4, 4>::value));
+    assert((!has_double_subscript<xy<float>, float, 4, 4>::value));
+
+    // Test construction/assignment/paramater pass of a vector type with
+    // subscripting to access components.
+    {
+        Matrix44<float> ref;
+        SimpleMx<float,4> s;
+        for (int j = 0; j < 4; ++j)
+            for (int i = 0; i < 4; ++i) {
+                s[j][i] = i + j * 4;
+                ref[j][i] = i + j * 4;
+            }
+        Matrix44<float> v(s);
+        assert(v[0][0] == 0 && v[0][1] == 1 && v[0][2] == 2 && v[0][3] == 3 &&
+               v[1][0] == 4 && v[1][1] == 5 && v[1][2] == 6 && v[1][3] == 7 &&
+               v[2][0] == 8 && v[2][1] == 9 && v[2][2] == 10 && v[2][3] == 11 &&
+               v[3][0] == 12 && v[3][1] == 13 && v[3][2] == 14 && v[3][3] == 15);
+        s[1][1] = 42;
+        v = s;
+        assert(v[0][0] == 0 && v[0][1] == 1 && v[0][2] == 2 && v[0][3] == 3 &&
+               v[1][0] == 4 && v[1][1] == 42 && v[1][2] == 6 && v[1][3] == 7 &&
+               v[2][0] == 8 && v[2][1] == 9 && v[2][2] == 10 && v[2][3] == 11 &&
+               v[3][0] == 12 && v[3][1] == 13 && v[3][2] == 14 && v[3][3] == 15);
+    }
+}
+
+
+
+
 } // namespace
 
 void
@@ -251,7 +699,13 @@ testInterop()
 {
     cout << "Testing interoperability with foreign types" << endl;
 
+    testInteropVec2();
     testInteropVec3();
+    testInteropVec4();
+
+    testInteropMx2();
+    testInteropMx3();
+    testInteropMx4();
 
     cout << "ok\n" << endl;
 }

--- a/src/ImathTest/testInterop.h
+++ b/src/ImathTest/testInterop.h
@@ -1,0 +1,6 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+void testInterop();

--- a/src/ImathTest/testVec.cpp
+++ b/src/ImathTest/testVec.cpp
@@ -9,11 +9,9 @@
 
 #include "ImathFun.h"
 #include "ImathVec.h"
-#include <array>
 #include <cassert>
 #include <cmath>
 #include <iostream>
-#include <vector>
 #include <testVec.h>
 
 using namespace std;
@@ -239,92 +237,6 @@ testLength4T()
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
 }
 
-
-
-// Extra simple vector that does nothing but allow element access, as an
-// example of a vector type that an app might use and want interop with
-// our vectors.
-template <typename T, int N>
-struct SimpleVec {
-    T elements[N];
-
-    SimpleVec(T val = T(0)) {
-        for (int i = 0; i < N; ++i)
-            elements[i] = val;
-    }
-    ~SimpleVec() = default;
-    constexpr T operator[](int i) const { return elements[i]; }
-    T& operator[](int i) { return elements[i]; }
-};
-
-
-
-void
-testInteropPass3(const Vec3<float>& v, float a, float b, float c)
-{
-    assert(v[0] == a && v[1] == b && v[2] == c);
-}
-
-void
-testInteropCtr3()
-{
-    // Test construction/assignment/paramater pass of a different vector type
-    {
-        SimpleVec<float,3> s;
-        s[0] = 1;
-        s[1] = 2;
-        s[2] = 3;
-        Vec3<float> v(s);
-        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
-        s[1] = 42;
-        v = s;
-        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
-
-        testInteropPass3(s, 1, 42, 3);
-    }
-    // Test construction/assignment/paramater pass of a std::vector of length 3
-    {
-        std::vector<float> s { 1, 2, 3 };
-        Vec3<float> v(s);
-        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
-        s[1] = 42;
-        v = s;
-        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
-        testInteropPass3(s, 1, 42, 3);
-    }
-    // Test construction/assignment/paramater pass of a std::array of length 3
-    {
-        std::array<float, 3> s { 1, 2, 3 };
-        Vec3<float> v(s);
-        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
-        s[1] = 42;
-        v = s;
-        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
-        testInteropPass3(s, 1, 42, 3);
-    }
-    // Test construction/assignment/paramater pass of initializer lists.
-    {
-        Vec3<float> v({ 1.0f, 2.0f, 3.0f });
-        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
-        v = { 1.0f, 42.0f, 3.0f };
-        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
-        testInteropPass3({ 1.0f, 42.0f, 3.0f }, 1, 42, 3);
-    }
-#if 0
-    // Test construction/assignment/paramater pass of a C array
-    {
-        float s[3] = { 1, 2, 3 };
-        Vec3<float> v(s);
-        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
-        s[1] = 42;
-        v = s;
-        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
-        testInteropPass3(s, 1, 42, 3);
-    }
-#endif
-}
-
-
 } // namespace
 
 void
@@ -338,8 +250,6 @@ testVec()
     testLength3T<double>();
     testLength4T<float>();
     testLength4T<double>();
-
-    testInteropCtr3();
 
     cout << "ok\n" << endl;
 }

--- a/src/ImathTest/testVec.cpp
+++ b/src/ImathTest/testVec.cpp
@@ -9,9 +9,11 @@
 
 #include "ImathFun.h"
 #include "ImathVec.h"
+#include <array>
 #include <cassert>
 #include <cmath>
 #include <iostream>
+#include <vector>
 #include <testVec.h>
 
 using namespace std;
@@ -237,6 +239,92 @@ testLength4T()
     assert (IMATH_INTERNAL_NAMESPACE::equal (v.normalized().length(), 1, e));
 }
 
+
+
+// Extra simple vector that does nothing but allow element access, as an
+// example of a vector type that an app might use and want interop with
+// our vectors.
+template <typename T, int N>
+struct SimpleVec {
+    T elements[N];
+
+    SimpleVec(T val = T(0)) {
+        for (int i = 0; i < N; ++i)
+            elements[i] = val;
+    }
+    ~SimpleVec() = default;
+    constexpr T operator[](int i) const { return elements[i]; }
+    T& operator[](int i) { return elements[i]; }
+};
+
+
+
+void
+testInteropPass3(const Vec3<float>& v, float a, float b, float c)
+{
+    assert(v[0] == a && v[1] == b && v[2] == c);
+}
+
+void
+testInteropCtr3()
+{
+    // Test construction/assignment/paramater pass of a different vector type
+    {
+        SimpleVec<float,3> s;
+        s[0] = 1;
+        s[1] = 2;
+        s[2] = 3;
+        Vec3<float> v(s);
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
+
+        testInteropPass3(s, 1, 42, 3);
+    }
+    // Test construction/assignment/paramater pass of a std::vector of length 3
+    {
+        std::vector<float> s { 1, 2, 3 };
+        Vec3<float> v(s);
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
+        testInteropPass3(s, 1, 42, 3);
+    }
+    // Test construction/assignment/paramater pass of a std::array of length 3
+    {
+        std::array<float, 3> s { 1, 2, 3 };
+        Vec3<float> v(s);
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
+        testInteropPass3(s, 1, 42, 3);
+    }
+    // Test construction/assignment/paramater pass of initializer lists.
+    {
+        Vec3<float> v({ 1.0f, 2.0f, 3.0f });
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
+        v = { 1.0f, 42.0f, 3.0f };
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
+        testInteropPass3({ 1.0f, 42.0f, 3.0f }, 1, 42, 3);
+    }
+#if 0
+    // Test construction/assignment/paramater pass of a C array
+    {
+        float s[3] = { 1, 2, 3 };
+        Vec3<float> v(s);
+        assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
+        s[1] = 42;
+        v = s;
+        assert(v[0] == 1 && v[1] == 42 && v[2] == 3);
+        testInteropPass3(s, 1, 42, 3);
+    }
+#endif
+}
+
+
 } // namespace
 
 void
@@ -250,6 +338,8 @@ testVec()
     testLength3T<double>();
     testLength4T<float>();
     testLength4T<double>();
+
+    testInteropCtr3();
 
     cout << "ok\n" << endl;
 }


### PR DESCRIPTION
This is a design review, feedback requested before I proceed further.

Trying out some use of enable_if to give `Vec3<T>` constructor and
assignment from unknown types that "look like" 3-vectors -- they have
a `operator[]` that returns a T, and their size is at least
3*sizeof(T).

The main idea is that if an app has rolled its own 3-vector class, it
can seamlessly construct a Vec3 from it, assign a Vec3 to it, or pass
their type as a parameter that expects a Vec3. And if the app's custom
3-vector class employs an equivalent idiom, all those operations will
work in the reverse direction.

It also works for std::vector, std::array, and even "initializer lists",
so all of this would work:

    // Your app's special snowflake custom 3-vector type.
    class YourCustomVec3 { ... };

    // My library has an API call where I use Imath::Vec3 as a parameter
    // passing convention, because I don't know about your vector.
    void myfunc (const Vec3<float>& v) { ... }

    // All sorts of things people may think of as "a vector"
    YourCustomVec3 myvec(1, 2, 3);
    std::array<float,3> arr { 1, 2, 3 };
    std::vector<float> stdvec { 1, 2, 3 };

    myfunc(yourvec);            // ok
    myfunc(arr);                // yep
    myfunc(stdvec);             // hunky-dory
    myfunc({ 1.0, 2.0, 3.0 });  // yeah, even that

This is only prototyped for Vec3 for now, but if you all like this
idea, then I will complete the work to do this for the other vector
and matrix classes.

Signed-off-by: Larry Gritz <lg@larrygritz.com>