### PR TITLE
Appveyor Visual Studio builds for 2017 and 2019

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,50 @@
+# Windows CI build via the Appveyor service
+
+version: '{build}'
+
+# branches to build
+branches:
+  only:
+    - master
+
+environment:
+  matrix:
+
+    # C++11 not supported
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+    #   COMPILER: "Visual Studio 12 2013 Win64"
+
+    # constexpr not allowed for constructors that don't initialise
+    # See: https://github.com/AcademySoftwareFoundation/Imath/pull/95
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #   COMPILER: "Visual Studio 14 2015 Win64"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      COMPILER: "Visual Studio 15 2017 Win64"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      COMPILER: "Visual Studio 16 2019"
+
+# build platform, i.e. x86, x64, Any CPU.
+platform:
+  - x64
+
+configuration:
+  - Debug
+  - Release
+
+build_script:
+  - echo --------------------------------------------------------------------------------
+  - echo Appveyor environment info:
+  - echo COMPILER = %COMPILER%, CONFIGURATION = %CONFIGURATION%
+# - cmake -h
+  - rem --------------------------------------------------------------------------------
+  - mkdir build
+  - cd build
+  - cmake -G "%COMPILER%" ..
+  - cmake --build . --config "%CONFIGURATION%"
+  - cd ..
+
+test_script:
+  - cd build
+  - ctest --timeout 100 -C "%CONFIGURATION%"
+  - cd ..


### PR DESCRIPTION
Provided as a reproducer for PR #95 

Produced the following results:
https://ci.appveyor.com/project/nigels-com/imath/builds/37740812
https://ci.appveyor.com/project/nigels-com/imath/builds/37743094

Enabling either 2013 or 2015 would not succeed, but PR #95 aims to support 2015.