### PR TITLE
Replace Iex::OverflowExc with std::invalid_argument

### DIFF
--- a/src/Imath/ImathGL.h
+++ b/src/Imath/ImathGL.h
@@ -91,7 +91,7 @@ throwBadMatrix (const IMATH_INTERNAL_NAMESPACE::M44f& m)
         badFloat (m[1][0]) || badFloat (m[1][1]) || badFloat (m[1][2]) || badFloat (m[1][3]) ||
         badFloat (m[2][0]) || badFloat (m[2][1]) || badFloat (m[2][2]) || badFloat (m[2][3]) ||
         badFloat (m[3][0]) || badFloat (m[3][1]) || badFloat (m[3][2]) || badFloat (m[3][3]))
-        throw IEX_NAMESPACE::OverflowExc ("GL matrix overflow");
+        throw std::invalid_argument ("GL matrix overflow");
 }
 
 /// Call glMultmatrixf. Throw an exception if m is not a valid matrix for GL.


### PR DESCRIPTION
This file is not referenced by the unit tests so it got missed when removing references to Iex.

Signed-off-by: Cary Phillips <cary@ilm.com>