### PR TITLE
Drop support for exception-handling in PyImath

### DIFF
--- a/src/python/PyImath/PyImathFixedArray.h
+++ b/src/python/PyImath/PyImathFixedArray.h
@@ -15,12 +15,17 @@
 #include <iostream>
 #include "PyImathUtil.h"
 
-#ifdef PYIMATH_ENABLE_EXCEPTIONS
-# define PY_IMATH_RETURN_PYTHON mathexcon.handleOutstandingExceptions()
-#else
-# define PY_IMATH_LEAVE_PYTHON PyImath::PyReleaseLock pyunlock;
-# define PY_IMATH_RETURN_PYTHON
-#endif
+//
+// Note: when PyImath from the v2 release of OpenEXR depended on Iex,
+// the PY_IMATH_LEAVE/RETURN_PYTHON macros bracketed calls that
+// enabled/disabled float-point exceptions via via the MathExcOn
+// class. This was a compile-time option based on the setting of
+// PYIMATH_ENABLE_EXCEPTIONS. This behavior is now deprecated, hence
+// the empty macros.
+//
+
+#define PY_IMATH_LEAVE_PYTHON PyImath::PyReleaseLock pyunlock;
+#define PY_IMATH_RETURN_PYTHON
 
 namespace PyImath {
 

--- a/src/python/PyImath/PyImathMathExc.h
+++ b/src/python/PyImath/PyImathMathExc.h
@@ -8,10 +8,14 @@
 #ifndef _PyImathMathExc_h_
 #define _PyImathMathExc_h_
 
-#ifdef PYIMATH_ENABLE_EXCEPTIONS
+//
+// Note: when PyImath from the v2 release of OpenEXR depended on Iex,
+// the MATH_EXC_ON macro enabled float-point exceptions via the
+// MathExcOn class. This was a compile-time option based on the
+// setting of PYIMATH_ENABLE_EXCEPTIONS. This behavior is now
+// deprecated, hence the empty macro.
+//
 
-#else
-# define MATH_EXC_ON
-#endif
+#define MATH_EXC_ON
 
 #endif

--- a/src/python/config/PyImathSetup.cmake
+++ b/src/python/config/PyImathSetup.cmake
@@ -10,10 +10,6 @@ include(GNUInstallDirs)
 set(PYIMATH_OVERRIDE_PYTHON2_INSTALL_DIR "" CACHE STRING "Override the install location for any python 2.x modules compiled")
 set(PYIMATH_OVERRIDE_PYTHON3_INSTALL_DIR "" CACHE STRING "Override the install location for any python 3.x modules compiled")
 
-# Enables tracking of floating point exceptions and throwing them
-# as the signals are received
-option(PYIMATH_ENABLE_EXCEPTIONS "Enable runtime floating point exceptions" OFF)
-
 # What C++ standard to compile for
 # VFX Platform 18 is c++14, so let's enable that by default
 set(tmp 14)


### PR DESCRIPTION
Remove the PY_IMATH_HANDLE_EXCEPTIONS option altogether.

With the removal of Iex from Imath and its wrapping of floating-point exceptions, there is no longer any need for the PY_IMATH_LEAVE/RETURN_PYTHON or MATH_EXC_ON macros.

Signed-off-by: Cary Phillips <cary@ilm.com>