### PR TITLE
Replace Int64/SInt64 with uint64_t/int64_t

### DIFF
--- a/src/Imath/ImathFun.cpp
+++ b/src/Imath/ImathFun.cpp
@@ -89,7 +89,7 @@ succd (double d) noexcept
     union
     {
         double d;
-        Int64 i;
+        uint64_t i;
     } u;
     u.d = d;
 
@@ -127,7 +127,7 @@ predd (double d) noexcept
     union
     {
         double d;
-        Int64 i;
+        uint64_t i;
     } u;
     u.d = d;
 

--- a/src/Imath/ImathFun.h
+++ b/src/Imath/ImathFun.h
@@ -13,9 +13,9 @@
 //-----------------------------------------------------------------------------
 
 #include <limits>
+#include <cstdint>
 
 #include "ImathExport.h"
-#include "ImathInt64.h"
 #include "ImathNamespace.h"
 #include "ImathPlatform.h"
 
@@ -219,7 +219,7 @@ finited (double d) noexcept
     union
     {
         double d;
-        Int64 i;
+        uint64_t i;
     } u;
     u.d = d;
 

--- a/src/Imath/ImathInt64.h
+++ b/src/Imath/ImathInt64.h
@@ -6,6 +6,8 @@
 //
 // 64-bit integer types
 //
+// Deprecated, use int64_t/uint64_t instead.
+//
 
 #ifndef INCLUDED_IMATH_INT64_H
 #define INCLUDED_IMATH_INT64_H
@@ -17,18 +19,24 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 #if (defined _WIN32 || defined _WIN64) && _MSC_VER >= 1300
 /// Int64 - unsigned 64-bit integer
+IMATH_DEPRECATED("use uint64_t")
 typedef unsigned __int64 Int64;
 /// SInt64 - signed 64-bit integer
+IMATH_DEPRECATED("use sint64_t")
 typedef __int64 SInt64;
 #elif ULONG_MAX == 18446744073709551615LU
 /// Int64 - unsigned 64-bit integer
+IMATH_DEPRECATED("use uint64_t")
 typedef long unsigned int Int64;
 /// SInt64 - signed 64-bit integer
+IMATH_DEPRECATED("use sint64_t")
 typedef long int SInt64;
 #else
 /// Int64 - unsigned 64-bit integer
+IMATH_DEPRECATED("use uint64_t")
 typedef long long unsigned int Int64;
 /// SInt64 - signed 64-bit integer
+IMATH_DEPRECATED("use sint64_t")
 typedef long long int SInt64;
 #endif
 

--- a/src/Imath/ImathRandom.cpp
+++ b/src/Imath/ImathRandom.cpp
@@ -11,7 +11,7 @@
 //-----------------------------------------------------------------------------
 
 #include "ImathRandom.h"
-#include "ImathInt64.h"
+#include <cstdint>
 
 IMATH_INTERNAL_NAMESPACE_SOURCE_ENTER
 namespace
@@ -35,8 +35,8 @@ rand48Next (unsigned short state[3])
     // where a and c are as specified below, and m == (1 << 48)
     //
 
-    static const Int64 a = Int64 (0x5deece66dLL);
-    static const Int64 c = Int64 (0xbLL);
+    static const uint64_t a = uint64_t (0x5deece66dLL);
+    static const uint64_t c = uint64_t (0xbLL);
 
     //
     // Assemble the 48-bit value x[n] from the
@@ -44,9 +44,9 @@ rand48Next (unsigned short state[3])
     //
 
     // clang-format off
-    Int64 x = (Int64 (state[2]) << 32) |
-	      (Int64 (state[1]) << 16) |
-	       Int64 (state[0]);
+    uint64_t x = (uint64_t (state[2]) << 32) |
+	      (uint64_t (state[1]) << 16) |
+	       uint64_t (state[0]);
     // clang-format on
 
     //
@@ -91,15 +91,15 @@ erand48 (unsigned short state[3])
     union
     {
         double d;
-        Int64 i;
+        uint64_t i;
     } u;
 
     // clang-format off
-    u.i = (Int64 (0x3ff)    << 52) |	// sign and exponent
-	  (Int64 (state[2]) << 36) |	// significand
-	  (Int64 (state[1]) << 20) |
-	  (Int64 (state[0]) <<  4) |
-	  (Int64 (state[2]) >> 12);
+    u.i = (uint64_t (0x3ff)    << 52) |	// sign and exponent
+	  (uint64_t (state[2]) << 36) |	// significand
+	  (uint64_t (state[1]) << 20) |
+	  (uint64_t (state[0]) <<  4) |
+	  (uint64_t (state[2]) >> 12);
     // clang-format on
 
     return u.d - 1;

--- a/src/ImathTest/testMatrix.cpp
+++ b/src/ImathTest/testMatrix.cpp
@@ -45,7 +45,7 @@ testMatrix()
     union
     {
         double d;
-        Int64 i;
+        uint64_t i;
     } nand;
     nand.i = 0x7ff0000000000001ULL; //  NAN
 


### PR DESCRIPTION
Leave the Int64/SInt64 types in place in ImathInt64.h with deprecation warnings, in case external code relies on them.

Signed-off-by: Cary Phillips <cary@ilm.com>