### PR TITLE
Make symbols hidden by default

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -4,6 +4,11 @@
 if (IMATH_ENABLE_LARGE_STACK)
   set(IMATH_HAVE_LARGE_STACK ON)
 endif()
+if (IMATH_USE_DEFAULT_VISIBILITY)
+  set(IMATH_ENABLE_API_VISIBILITY OFF)
+else()
+  set(IMATH_ENABLE_API_VISIBILITY ON)
+endif()
 
 configure_file(ImathConfig.h.in ${CMAKE_CURRENT_BINARY_DIR}/ImathConfig.h)
 

--- a/config/ImathConfig.h.in
+++ b/config/ImathConfig.h.in
@@ -13,7 +13,7 @@
 /////////////////////
 
 //
-// Define and set to 1 if the target system has support for large
+// Define if the target system has support for large
 // stack sizes.
 //
 #cmakedefine IMATH_HAVE_LARGE_STACK
@@ -111,6 +111,22 @@
 # define IMATH_DEPRECATED(msg) __attribute__((deprecated(msg)))
 #else
 # define IMATH_DEPRECATED(msg) /* unsupported on this platform */
+#endif
+
+// Whether the user configured the library to have symbol visibility
+// tagged
+#cmakedefine IMATH_ENABLE_API_VISIBILITY
+
+// MSVC does not do the same visibility attributes, and when we are
+// compiling a static library we won't be in DLL mode, but just don't
+// define these and the export headers will work out
+#if ! defined(_MSC_VER) && defined(IMATH_ENABLE_API_VISIBILITY)
+#  define IMATH_PUBLIC_SYMBOL_ATTRIBUTE __attribute__ ((__visibility__ ("default")))
+#  define IMATH_PRIVATE_SYMBOL_ATTRIBUTE __attribute__ ((__visibility__ ("hidden")))
+// clang differs from gcc and has type visibility which is needed for enums and templates
+#  if __has_attribute(__type_visibility__)
+#    define IMATH_PUBLIC_TYPE_VISIBILITY_ATTRIBUTE __attribute__ ((__type_visibility__ ("default")))
+#  endif
 #endif
 
 #endif // INCLUDED_IMATH_CONFIG_H

--- a/config/ImathSetup.cmake
+++ b/config/ImathSetup.cmake
@@ -9,6 +9,8 @@ if(NOT "${CMAKE_PROJECT_NAME}" STREQUAL "${PROJECT_NAME}")
   message(STATUS "Imath is configuring as a cmake sub project")
 endif()
 
+option(IMATH_USE_DEFAULT_VISIBILITY "Makes the compile use default visibility (by default compiles tidy, hidden-by-default)"     OFF)
+
 # This is primarily for the halfFunction code that enables a stack
 # object (if you enable this) that contains a LUT of the function
 option(IMATH_ENABLE_LARGE_STACK "Enables code to take advantage of large stack support"     OFF)

--- a/config/LibraryDefine.cmake
+++ b/config/LibraryDefine.cmake
@@ -35,10 +35,16 @@ function(IMATH_DEFINE_LIBRARY libname)
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
     POSITION_INDEPENDENT_CODE ON
-    C_VISIBILITY_PRESET hidden
-    CXX_VISIBILITY_PRESET hidden
-    VISIBILITY_INLINES_HIDDEN ON
-  )
+    )
+  if (NOT IMATH_USE_DEFAULT_VISIBILITY)
+    set_target_properties(${objlib} PROPERTIES
+      C_VISIBILITY_PRESET hidden
+      CXX_VISIBILITY_PRESET hidden
+      VISIBILITY_INLINES_HIDDEN ON
+      )
+  else()
+      target_compile_definitions(${objlib} PUBLIC IMATH_USE_DEFAULT_VISIBILITY)
+  endif()
   if (_imath_extra_flags)
     target_compile_options(${objlib} PUBLIC ${_imath_extra_flags})
   endif()

--- a/config/LibraryDefine.cmake
+++ b/config/LibraryDefine.cmake
@@ -35,6 +35,9 @@ function(IMATH_DEFINE_LIBRARY libname)
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
     POSITION_INDEPENDENT_CODE ON
+    C_VISIBILITY_PRESET hidden
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
   )
   if (_imath_extra_flags)
     target_compile_options(${objlib} PUBLIC ${_imath_extra_flags})

--- a/src/Imath/ImathBox.h
+++ b/src/Imath/ImathBox.h
@@ -10,7 +10,9 @@
 #ifndef INCLUDED_IMATHBOX_H
 #define INCLUDED_IMATHBOX_H
 
+#include "ImathExport.h"
 #include "ImathNamespace.h"
+
 #include "ImathVec.h"
 
 IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -32,7 +34,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 /// preferably, this returns a constant expression, typically 2 or 3.
 ///
 
-template <class V> class Box
+template <class V> class IMATH_EXPORT_TEMPLATE_TYPE Box
 {
   public:
 
@@ -351,7 +353,7 @@ template <typename V> class Box;
 /// public.
 ///
 
-template <class T> class Box<Vec2<T>>
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Box<Vec2<T>>
 {
   public:
 
@@ -620,7 +622,7 @@ Box<Vec2<T>>::majorAxis() const noexcept
 /// The Box<Vec3> template represents a 3D bounding box defined by
 /// minimum and maximum values of type Vec3. 
 ///
-template <class T> class Box<Vec3<T>>
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Box<Vec3<T>>
 {
   public:
 

--- a/src/Imath/ImathBoxAlgo.h
+++ b/src/Imath/ImathBoxAlgo.h
@@ -10,10 +10,11 @@
 #ifndef INCLUDED_IMATHBOXALGO_H
 #define INCLUDED_IMATHBOXALGO_H
 
+#include "ImathNamespace.h"
+
 #include "ImathBox.h"
 #include "ImathLineAlgo.h"
 #include "ImathMatrix.h"
-#include "ImathNamespace.h"
 #include "ImathPlane.h"
 
 IMATH_INTERNAL_NAMESPACE_HEADER_ENTER

--- a/src/Imath/ImathColor.h
+++ b/src/Imath/ImathColor.h
@@ -10,7 +10,9 @@
 #ifndef INCLUDED_IMATHCOLOR_H
 #define INCLUDED_IMATHCOLOR_H
 
+#include "ImathExport.h"
 #include "ImathNamespace.h"
+
 #include "ImathVec.h"
 #include "half.h"
 
@@ -25,7 +27,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 /// Note: because Color3 inherits from Vec3, its member fields are
 /// called `x`, `y`, and `z`.
 
-template <class T> class Color3 : public Vec3<T>
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Color3 : public Vec3<T>
 {
   public:
 
@@ -111,7 +113,7 @@ template <class T> class Color3 : public Vec3<T>
 /// can represent either rgb or hsv color values.
 ///
 
-template <class T> class Color4
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Color4
 {
   public:
 

--- a/src/Imath/ImathColorAlgo.h
+++ b/src/Imath/ImathColorAlgo.h
@@ -10,10 +10,11 @@
 #ifndef INCLUDED_IMATHCOLORALGO_H
 #define INCLUDED_IMATHCOLORALGO_H
 
-#include "ImathColor.h"
-#include "ImathExport.h"
-#include "ImathMath.h"
 #include "ImathNamespace.h"
+#include "ImathExport.h"
+
+#include "ImathColor.h"
+#include "ImathMath.h"
 
 IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 

--- a/src/Imath/ImathEuler.h
+++ b/src/Imath/ImathEuler.h
@@ -10,9 +10,11 @@
 #ifndef INCLUDED_IMATHEULER_H
 #define INCLUDED_IMATHEULER_H
 
+#include "ImathExport.h"
+#include "ImathNamespace.h"
+
 #include "ImathMath.h"
 #include "ImathMatrix.h"
-#include "ImathNamespace.h"
 #include "ImathQuat.h"
 #include "ImathVec.h"
 
@@ -114,7 +116,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 /// The units of the rotation angles are assumed to be radians.
 ///
 
-template <class T> class Euler : public Vec3<T>
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Euler : public Vec3<T>
 {
   public:
     using Vec3<T>::x;
@@ -125,7 +127,7 @@ template <class T> class Euler : public Vec3<T>
     ///
     ///  All 24 possible orderings
     ///
-    enum Order
+    enum IMATH_EXPORT_ENUM Order
     {
         XYZ = 0x0101, // "usual" orderings
         XZY = 0x0001,
@@ -175,7 +177,7 @@ template <class T> class Euler : public Vec3<T>
     ///
     /// Axes
     ///
-    enum Axis
+    enum IMATH_EXPORT_ENUM Axis
     {
         X = 0,
         Y = 1,
@@ -186,7 +188,7 @@ template <class T> class Euler : public Vec3<T>
     /// Layout
     ///
     
-    enum InputLayout
+    enum IMATH_EXPORT_ENUM InputLayout
     {
         XYZLayout,
         IJKLayout

--- a/src/Imath/ImathExport.h
+++ b/src/Imath/ImathExport.h
@@ -6,6 +6,8 @@
 #ifndef INCLUDED_IMATHEXPORT_H
 #define INCLUDED_IMATHEXPORT_H
 
+#include "ImathConfig.h"
+
 /// \defgroup ExportMacros Macros to manage symbol visibility
 ///
 /// There is more information about the motivation for these macros
@@ -34,51 +36,32 @@
 #    define IMATH_EXPORT_CONST extern __declspec(dllimport)
 #  endif
 
+// DLLs don't support these types of visibility controls, just leave them as empty
+#  define IMATH_EXPORT_TYPE
+#  define IMATH_EXPORT_ENUM
+#  define IMATH_EXPORT_TEMPLATE_TYPE
+
 #else
 
-// Need to handle when we are building as a static library under
-// windows and with a compiler that doesn't understand visibility
-// attributes.
-#  ifndef _MSC_VER
-// Allow the user to override and not control visibility
-#    ifdef IMATH_USE_DEFAULT_VISIBILITY
-#      define IMATH_EXPORT
-#      define IMATH_EXPORT_CONST extern const
-// else We are using a compiler that knows about visibility, so works for both
-// shared and static libraries...
-#    else // IMATH_USE_DEFAULT_VISIBILITY
-#      define IMATH_EXPORT __attribute__ ((__visibility__ ("default")))
-#      define IMATH_EXPORT_TYPE __attribute__ ((__visibility__ ("default")))
-#      define IMATH_HIDDEN __attribute__ ((__visibility__ ("hidden")))
-// clang differs from gcc and has type visibility which is needed for enums and templates
-#      if __has_attribute(__type_visibility__)
-#        define IMATH_EXPORT_ENUM __attribute__ ((__type_visibility__ ("default")))
-#        define IMATH_EXPORT_TEMPLATE_TYPE __attribute__ ((__type_visibility__ ("default")))
-#      else
-#        define IMATH_EXPORT_TEMPLATE_TYPE __attribute__ ((__visibility__ ("default")))
-#      endif
-#      define IMATH_EXPORT_CONST extern const __attribute__ ((visibility ("default")))
-#    endif
-#  else // _MSC_VER
+#  ifdef IMATH_PUBLIC_SYMBOL_ATTRIBUTE
+#    define IMATH_EXPORT IMATH_PUBLIC_SYMBOL_ATTRIBUTE
+#    define IMATH_EXPORT_CONST extern const  IMATH_PUBLIC_SYMBOL_ATTRIBUTE
+#  else
 #    define IMATH_EXPORT
 #    define IMATH_EXPORT_CONST extern const
 #  endif
 
-#endif // IMATH_DLL
-
-// Provide defaults so we don't have to replicate lines as much
-#ifndef IMATH_EXPORT_TYPE
-#    define IMATH_EXPORT_TYPE
-#endif
-#ifndef IMATH_EXPORT_TEMPLATE_TYPE
-#    define IMATH_EXPORT_TEMPLATE_TYPE
-#endif
-#ifndef IMATH_EXPORT_ENUM
+#  ifdef IMATH_PUBLIC_TYPE_VISIBILITY_ATTRIBUTE
+#    define IMATH_EXPORT_ENUM IMATH_PUBLIC_TYPE_VISIBILITY_ATTRIBUTE
+#    define IMATH_EXPORT_TEMPLATE_TYPE IMATH_PUBLIC_TYPE_VISIBILITY_ATTRIBUTE
+#    define IMATH_EXPORT_TYPE IMATH_PUBLIC_TYPE_VISIBILITY_ATTRIBUTE
+#  else
 #    define IMATH_EXPORT_ENUM
-#endif
-#ifndef IMATH_HIDDEN
-#    define IMATH_HIDDEN
-#endif
+#    define IMATH_EXPORT_TEMPLATE_TYPE IMATH_EXPORT
+#    define IMATH_EXPORT_TYPE IMATH_EXPORT
+#  endif
+
+#endif // IMATH_DLL
 
 /// @}
 

--- a/src/Imath/ImathExport.h
+++ b/src/Imath/ImathExport.h
@@ -3,15 +3,58 @@
 // Copyright Contributors to the OpenEXR Project.
 //
 
+// See the document in OpenEXR docs/SymbolVisibility.md for background
+// on all these types
 #if defined(IMATH_DLL)
 #    if defined(IMATH_EXPORTS)
 #        define IMATH_EXPORT __declspec(dllexport)
 #        define IMATH_EXPORT_CONST extern __declspec(dllexport)
+//#        if defined(__MINGW32__)
+//#            define IMATH_EXPORT_EXTERN_TEMPLATE IMATH_EXPORT
+//#        else
+//#            define IMATH_EXPORT_TEMPLATE_INSTANCE IMATH_EXPORT
+//#        endif
 #    else
 #        define IMATH_EXPORT __declspec(dllimport)
 #        define IMATH_EXPORT_CONST extern __declspec(dllimport)
 #    endif
 #else
-#    define IMATH_EXPORT
-#    define IMATH_EXPORT_CONST extern const
+#    ifndef _MSC_VER
+#        define IMATH_EXPORT __attribute__ ((__visibility__ ("default")))
+#        define IMATH_EXPORT_TYPE __attribute__ ((__visibility__ ("default")))
+//#        define IMATH_EXPORT_TEMPLATE_DATA __attribute__ ((__visibility__ ("default")))
+#        define IMATH_HIDDEN __attribute__ ((__visibility__ ("hidden")))
+#        if __has_attribute(__type_visibility__)
+#            define IMATH_EXPORT_ENUM __attribute__ ((__type_visibility__ ("default")))
+#            define IMATH_EXPORT_TEMPLATE_TYPE __attribute__ ((__type_visibility__ ("default")))
+//#            define IMATH_EXPORT_EXTERN_TEMPLATE __attribute__ ((__visibility__ ("default")))
+#        else
+#            define IMATH_EXPORT_TEMPLATE_TYPE __attribute__ ((__visibility__ ("default")))
+#        endif
+#        define IMATH_EXPORT_CONST extern const __attribute__ ((visibility ("default")))
+#    else
+#	     define IMATH_EXPORT
+#        define IMATH_EXPORT_CONST extern const
+#    endif
+#endif
+#ifndef IMATH_EXPORT_TYPE
+#    define IMATH_EXPORT_TYPE
+#endif
+#ifndef IMATH_EXPORT_TEMPLATE_TYPE
+#    define IMATH_EXPORT_TEMPLATE_TYPE
+#endif
+//#ifndef IMATH_EXPORT_EXTERN_TEMPLATE
+//#    define IMATH_EXPORT_EXTERN_TEMPLATE
+//#endif
+//#ifndef IMATH_EXPORT_TEMPLATE_INSTANCE
+//#    define IMATH_EXPORT_TEMPLATE_INSTANCE
+//#endif
+//#ifndef IMATH_EXPORT_TEMPLATE_TYPE
+//#    define IMATH_EXPORT_TEMPLATE_TYPE
+//#endif
+#ifndef IMATH_EXPORT_ENUM
+#    define IMATH_EXPORT_ENUM
+#endif
+#ifndef IMATH_HIDDEN
+#    define IMATH_HIDDEN
 #endif

--- a/src/Imath/ImathExport.h
+++ b/src/Imath/ImathExport.h
@@ -3,58 +3,83 @@
 // Copyright Contributors to the OpenEXR Project.
 //
 
-// See the document in OpenEXR docs/SymbolVisibility.md for background
-// on all these types
+#ifndef INCLUDED_IMATHEXPORT_H
+#define INCLUDED_IMATHEXPORT_H
+
+/// \defgroup ExportMacros Macros to manage symbol visibility
+///
+/// There is more information about the motivation for these macros
+/// documented in the OpenEXR source tree
+/// (https://github.com/AcademySoftwareFoundation/openexr) under
+/// docs/SymbolVisibility.md
+///
+/// Imath only needs a couple of the possible macros outlined in the
+/// above document, and due to it largely being inline only, does not
+/// have much to do.
+/// 
+/// @{
 #if defined(IMATH_DLL)
-#    if defined(IMATH_EXPORTS)
-#        define IMATH_EXPORT __declspec(dllexport)
-#        define IMATH_EXPORT_CONST extern __declspec(dllexport)
-//#        if defined(__MINGW32__)
-//#            define IMATH_EXPORT_EXTERN_TEMPLATE IMATH_EXPORT
-//#        else
-//#            define IMATH_EXPORT_TEMPLATE_INSTANCE IMATH_EXPORT
-//#        endif
-#    else
-#        define IMATH_EXPORT __declspec(dllimport)
-#        define IMATH_EXPORT_CONST extern __declspec(dllimport)
-#    endif
+
+// when building Imath as a DLL for Windows, we have to control the
+// typical DLL export / import things. Luckily, the typeinfo is all
+// automatic there, so only have to deal with symbols, except Windows
+// has some weirdness with DLLs and extern const, so we have to
+// provide a macro to handle that.
+
+#  if defined(IMATH_EXPORTS)
+#    define IMATH_EXPORT __declspec(dllexport)
+#    define IMATH_EXPORT_CONST extern __declspec(dllexport)
+#  else
+#    define IMATH_EXPORT __declspec(dllimport)
+#    define IMATH_EXPORT_CONST extern __declspec(dllimport)
+#  endif
+
 #else
-#    ifndef _MSC_VER
-#        define IMATH_EXPORT __attribute__ ((__visibility__ ("default")))
-#        define IMATH_EXPORT_TYPE __attribute__ ((__visibility__ ("default")))
-//#        define IMATH_EXPORT_TEMPLATE_DATA __attribute__ ((__visibility__ ("default")))
-#        define IMATH_HIDDEN __attribute__ ((__visibility__ ("hidden")))
-#        if __has_attribute(__type_visibility__)
-#            define IMATH_EXPORT_ENUM __attribute__ ((__type_visibility__ ("default")))
-#            define IMATH_EXPORT_TEMPLATE_TYPE __attribute__ ((__type_visibility__ ("default")))
-//#            define IMATH_EXPORT_EXTERN_TEMPLATE __attribute__ ((__visibility__ ("default")))
-#        else
-#            define IMATH_EXPORT_TEMPLATE_TYPE __attribute__ ((__visibility__ ("default")))
-#        endif
-#        define IMATH_EXPORT_CONST extern const __attribute__ ((visibility ("default")))
-#    else
-#	     define IMATH_EXPORT
-#        define IMATH_EXPORT_CONST extern const
+
+// Need to handle when we are building as a static library under
+// windows and with a compiler that doesn't understand visibility
+// attributes.
+#  ifndef _MSC_VER
+// Allow the user to override and not control visibility
+#    ifdef IMATH_USE_DEFAULT_VISIBILITY
+#      define IMATH_EXPORT
+#      define IMATH_EXPORT_CONST extern const
+// else We are using a compiler that knows about visibility, so works for both
+// shared and static libraries...
+#    else // IMATH_USE_DEFAULT_VISIBILITY
+#      define IMATH_EXPORT __attribute__ ((__visibility__ ("default")))
+#      define IMATH_EXPORT_TYPE __attribute__ ((__visibility__ ("default")))
+#      define IMATH_HIDDEN __attribute__ ((__visibility__ ("hidden")))
+// clang differs from gcc and has type visibility which is needed for enums and templates
+#      if __has_attribute(__type_visibility__)
+#        define IMATH_EXPORT_ENUM __attribute__ ((__type_visibility__ ("default")))
+#        define IMATH_EXPORT_TEMPLATE_TYPE __attribute__ ((__type_visibility__ ("default")))
+#      else
+#        define IMATH_EXPORT_TEMPLATE_TYPE __attribute__ ((__visibility__ ("default")))
+#      endif
+#      define IMATH_EXPORT_CONST extern const __attribute__ ((visibility ("default")))
 #    endif
-#endif
+#  else // _MSC_VER
+#    define IMATH_EXPORT
+#    define IMATH_EXPORT_CONST extern const
+#  endif
+
+#endif // IMATH_DLL
+
+// Provide defaults so we don't have to replicate lines as much
 #ifndef IMATH_EXPORT_TYPE
 #    define IMATH_EXPORT_TYPE
 #endif
 #ifndef IMATH_EXPORT_TEMPLATE_TYPE
 #    define IMATH_EXPORT_TEMPLATE_TYPE
 #endif
-//#ifndef IMATH_EXPORT_EXTERN_TEMPLATE
-//#    define IMATH_EXPORT_EXTERN_TEMPLATE
-//#endif
-//#ifndef IMATH_EXPORT_TEMPLATE_INSTANCE
-//#    define IMATH_EXPORT_TEMPLATE_INSTANCE
-//#endif
-//#ifndef IMATH_EXPORT_TEMPLATE_TYPE
-//#    define IMATH_EXPORT_TEMPLATE_TYPE
-//#endif
 #ifndef IMATH_EXPORT_ENUM
 #    define IMATH_EXPORT_ENUM
 #endif
 #ifndef IMATH_HIDDEN
 #    define IMATH_HIDDEN
 #endif
+
+/// @}
+
+#endif // INCLUDED_IMATHEXPORT_H

--- a/src/Imath/ImathForward.h
+++ b/src/Imath/ImathForward.h
@@ -31,15 +31,12 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Plane3;
 template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Quat;
 template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Shear6;
 template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Sphere3;
-template <class T> class IMATH_EXPORT_TEMPLATE_TYPE TMatrix;
-template <class T> class IMATH_EXPORT_TEMPLATE_TYPE TMatrixBase;
-template <class T> class IMATH_EXPORT_TEMPLATE_TYPE TMatrixData;
 template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec2;
 template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec3;
 template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec4;
 
-class Rand32;
-class Rand48;
+class IMATH_EXPORT_TYPE Rand32;
+class IMATH_EXPORT_TYPE Rand48;
 
 /// @endcond
 

--- a/src/Imath/ImathForward.h
+++ b/src/Imath/ImathForward.h
@@ -7,6 +7,7 @@
 #define INCLUDED_IMATHFORWARD_H
 
 #include "ImathNamespace.h"
+#include "ImathExport.h"
 
 IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
@@ -16,26 +17,26 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 // Basic template type declarations.
 //
 
-template <class T> class Box;
-template <class T> class Color3;
-template <class T> class Color4;
-template <class T> class Euler;
-template <class T> class Frustum;
-template <class T> class FrustumTest;
-template <class T> class Interval;
-template <class T> class Line3;
-template <class T> class Matrix33;
-template <class T> class Matrix44;
-template <class T> class Plane3;
-template <class T> class Quat;
-template <class T> class Shear6;
-template <class T> class Sphere3;
-template <class T> class TMatrix;
-template <class T> class TMatrixBase;
-template <class T> class TMatrixData;
-template <class T> class Vec2;
-template <class T> class Vec3;
-template <class T> class Vec4;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Box;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Color3;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Color4;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Euler;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Frustum;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE FrustumTest;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Interval;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Line3;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix33;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Plane3;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Quat;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Shear6;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Sphere3;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE TMatrix;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE TMatrixBase;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE TMatrixData;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec2;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec3;
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec4;
 
 class Rand32;
 class Rand48;

--- a/src/Imath/ImathFrustum.h
+++ b/src/Imath/ImathFrustum.h
@@ -10,10 +10,12 @@
 #ifndef INCLUDED_IMATHFRUSTUM_H
 #define INCLUDED_IMATHFRUSTUM_H
 
+#include "ImathExport.h"
+#include "ImathNamespace.h"
+
 #include "ImathFun.h"
 #include "ImathLine.h"
 #include "ImathMatrix.h"
-#include "ImathNamespace.h"
 #include "ImathPlane.h"
 #include "ImathVec.h"
 
@@ -34,7 +36,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 /// compiler, so we use nearPlane/farPlane instead to avoid
 /// issues.
 
-template <class T> class Frustum
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Frustum
 {
   public:
 

--- a/src/Imath/ImathFrustumTest.h
+++ b/src/Imath/ImathFrustumTest.h
@@ -15,10 +15,12 @@
 #ifndef INCLUDED_IMATHFRUSTUMTEST_H
 #define INCLUDED_IMATHFRUSTUMTEST_H
 
+#include "ImathExport.h"
+#include "ImathNamespace.h"
+
 #include "ImathBox.h"
 #include "ImathFrustum.h"
 #include "ImathMatrix.h"
-#include "ImathNamespace.h"
 #include "ImathSphere.h"
 #include "ImathVec.h"
 
@@ -80,7 +82,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 ///     form, with the X components grouped into an X vector, etc.
 ///
 
-template <class T> class FrustumTest
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE FrustumTest
 {
   public:
     /// @{

--- a/src/Imath/ImathInterval.h
+++ b/src/Imath/ImathInterval.h
@@ -10,7 +10,9 @@
 #ifndef INCLUDED_IMATHINTERVAL_H
 #define INCLUDED_IMATHINTERVAL_H
 
+#include "ImathExport.h"
 #include "ImathNamespace.h"
+
 #include "ImathVec.h"
 
 IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -20,7 +22,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 /// functions. It is basically a Box<T> that allows T to be a scalar.
 ///
 
-template <class T> class Interval
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Interval
 {
   public:
 

--- a/src/Imath/ImathMatrix.h
+++ b/src/Imath/ImathMatrix.h
@@ -10,8 +10,10 @@
 #ifndef INCLUDED_IMATHMATRIX_H
 #define INCLUDED_IMATHMATRIX_H
 
-#include "ImathFun.h"
+#include "ImathExport.h"
 #include "ImathNamespace.h"
+
+#include "ImathFun.h"
 #include "ImathPlatform.h"
 #include "ImathShear.h"
 #include "ImathVec.h"
@@ -31,7 +33,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 /// Enum used to indicate uninitialized construction of Matrix22,
 /// Matrix33, Matrix44
-enum Uninitialized
+enum IMATH_EXPORT_ENUM Uninitialized
 {
     UNINITIALIZED
 };
@@ -40,7 +42,7 @@ enum Uninitialized
 /// 2x2 transformation matrix
 ///
 
-template <class T> class Matrix22
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix22
 {
   public:
 
@@ -313,7 +315,7 @@ template <class T> class Matrix22
 /// 3x3 transformation matrix
 ///
 
-template <class T> class Matrix33
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix33
 {
   public:
 
@@ -657,7 +659,7 @@ template <class T> class Matrix33
 /// 4x4 transformation matrix
 ///
 
-template <class T> class Matrix44
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
 {
   public:
 

--- a/src/Imath/ImathPlane.h
+++ b/src/Imath/ImathPlane.h
@@ -10,8 +10,10 @@
 #ifndef INCLUDED_IMATHPLANE_H
 #define INCLUDED_IMATHPLANE_H
 
-#include "ImathLine.h"
+#include "ImathExport.h"
 #include "ImathNamespace.h"
+
+#include "ImathLine.h"
 #include "ImathVec.h"
 
 IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -26,7 +28,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 /// in. Note that reflection, and intersection functions will operate
 /// as expected.
 
-template <class T> class Plane3
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Plane3
 {
   public:
 

--- a/src/Imath/ImathQuat.h
+++ b/src/Imath/ImathQuat.h
@@ -17,8 +17,10 @@
 #ifndef INCLUDED_IMATHQUAT_H
 #define INCLUDED_IMATHQUAT_H
 
-#include "ImathMatrix.h"
+#include "ImathExport.h"
 #include "ImathNamespace.h"
+
+#include "ImathMatrix.h"
 
 #include <iostream>
 
@@ -36,7 +38,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 /// should probably use Imath::Euler<> for that.
 ///
 
-template <class T> class Quat
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Quat
 {
   public:
 

--- a/src/Imath/ImathShear.h
+++ b/src/Imath/ImathShear.h
@@ -10,8 +10,10 @@
 #ifndef INCLUDED_IMATHSHEAR_H
 #define INCLUDED_IMATHSHEAR_H
 
-#include "ImathMath.h"
+#include "ImathExport.h"
 #include "ImathNamespace.h"
+
+#include "ImathMath.h"
 #include "ImathVec.h"
 #include <iostream>
 
@@ -110,7 +112,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 /// construction to ensure that.  
 /// 
 
-template <class T> class Shear6
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Shear6
 {
   public:
 

--- a/src/Imath/ImathSphere.h
+++ b/src/Imath/ImathSphere.h
@@ -10,9 +10,11 @@
 #ifndef INCLUDED_IMATHSPHERE_H
 #define INCLUDED_IMATHSPHERE_H
 
+#include "ImathExport.h"
+#include "ImathNamespace.h"
+
 #include "ImathBox.h"
 #include "ImathLine.h"
-#include "ImathNamespace.h"
 #include "ImathVec.h"
 
 IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -21,7 +23,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 /// A 3D sphere
 ///
 
-template <class T> class Sphere3
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Sphere3
 {
   public:
 

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -10,9 +10,11 @@
 #ifndef INCLUDED_IMATHVEC_H
 #define INCLUDED_IMATHVEC_H
 
-#include "ImathMath.h"
+#include "ImathExport.h"
 #include "ImathNamespace.h"
 #include "ImathTypeTraits.h"
+
+#include "ImathMath.h"
 
 #include <iostream>
 #include <limits>
@@ -31,7 +33,7 @@ template <class T> class Vec3;
 template <class T> class Vec4;
 
 /// Enum for the Vec4 to Vec3 conversion constructor
-enum InfException
+enum IMATH_EXPORT_ENUM InfException
 {
     INF_EXCEPTION
 };
@@ -40,7 +42,7 @@ enum InfException
 /// 2-element vector
 ///
 
-template <class T> class Vec2
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec2
 {
   public:
 
@@ -298,7 +300,7 @@ template <class T> class Vec2
 /// 3-element vector
 ///
 
-template <class T> class Vec3
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec3
 {
   public:
 
@@ -569,7 +571,7 @@ template <class T> class Vec3
 /// 4-element vector
 ///
 
-template <class T> class Vec4
+template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec4
 {
   public:
 

--- a/src/Imath/half.h
+++ b/src/Imath/half.h
@@ -12,8 +12,8 @@
 #ifndef _HALF_H_
 #define _HALF_H_
 
-#include "ImathNamespace.h"
 #include "ImathExport.h"
+#include "ImathNamespace.h"
 #include "ImathPlatform.h"
 #include <iostream>
 
@@ -64,12 +64,12 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 /// * sizeof (unsigned short) == 2
 ///
 
-class half
+class IMATH_EXPORT_TYPE half
 {
   public:
 
     /// A special tag that lets us initialize a half from the raw bits.
-    enum FromBitsTag
+    enum IMATH_EXPORT_ENUM FromBitsTag
     {
         FromBits
     };


### PR DESCRIPTION
This also exports public types for OS that need that for the typeinfo information.

NB: This does not change the python module yet, there is more work to do before that could work