### PR TITLE
#if IMATH_FOREIGN_VECTOR_INTEROP around type detectors

### DIFF
--- a/src/Imath/ImathTypeTraits.h
+++ b/src/Imath/ImathTypeTraits.h
@@ -32,6 +32,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 #define IMATH_ENABLE_IF(...) Imath::enable_if_t<(__VA_ARGS__), int> = 0
 
 
+#if IMATH_FOREIGN_VECTOR_INTEROP
 
 /// @{
 /// @name Detecting interoperable types.
@@ -209,6 +210,7 @@ struct has_double_subscript<Base[Rows][Cols], Base, Rows, Cols> : public std::tr
 
 /// @}
 
+#endif
 
 IMATH_INTERNAL_NAMESPACE_HEADER_EXIT
 


### PR DESCRIPTION
The Vec/Matrix interoperability constructors are already #if'd out for
older compilers. This #if's out the detector template definitions themselves,
which can cause errors with older compilers aside from the constructors.

Signed-off-by: Cary Phillips <cary@ilm.com>