### PR TITLE
Don't impose C++14 on downstream projects

### DIFF
--- a/config/LibraryDefine.cmake
+++ b/config/LibraryDefine.cmake
@@ -14,7 +14,16 @@ function(IMATH_DEFINE_LIBRARY libname)
     ${IMATH_CURLIB_HEADERS}
     ${IMATH_CURLIB_SOURCES})
 
-  target_compile_features(${objlib} PUBLIC cxx_std_${IMATH_CXX_STANDARD})
+  # Use ${IMATH_CXX_STANDARD} to determine the standard we use to compile
+  # Imath itself. But the headers only require C++11 features, so that's
+  # all we need to pass on as interface reqirements to downstream projects.
+  # For example, it's fine for an Imath built with C++14 to be called from
+  # an app that is compiled with C++11; Imath needn't force the app to
+  # also use C++14.
+  target_compile_features(${objlib}
+                          PRIVATE cxx_std_${IMATH_CXX_STANDARD}
+                          INTERFACE cxx_std_11 )
+
   if(IMATH_CURLIB_PRIV_EXPORT AND BUILD_SHARED_LIBS)
     target_compile_definitions(${objlib} PRIVATE ${IMATH_CURLIB_PRIV_EXPORT})
     if(WIN32)


### PR DESCRIPTION
We were setting

    target_compile_features(${objlib} PUBLIC cxx_std_${IMATH_CXX_STANDARD})

The PUBLIC forced downstream projects that consume the
ImathConfig*.cmake exports to use C++ standard at least as recent as
what Imath used to build (which defaults to 14).

But this is unnecessary. There's nothing in Imath's headers that
requires anything beyond C++11. So this patch uses a more fine-grained
setting of target properties to express this more correctly. Now it
will be fine for a C++11 project to consume Imath (via its exported
configs) even if that Imath happened to be built with C++14.

This change is exactly the same as
https://github.com/AcademySoftwareFoundation/openexr/pull/995

Signed-off-by: Larry Gritz lg@larrygritz.com