### PR TITLE
Minimum cmake version: 3.10 for Ubuntu 18.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenEXR Project.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)


### PR DESCRIPTION
PR #123 advanced the minimum supported cmake version to 3.12.
However, it's not clear if this was intentional, or necessary.
Ubuntu 18.04 (bionic) provides cmake version 3.10.
So, roll back to what it was before PR #123.
For consideration.