### PR TITLE
Fix regression in succf()/predf()

### DIFF
--- a/src/Imath/ImathFun.cpp
+++ b/src/Imath/ImathFun.cpp
@@ -27,7 +27,7 @@ succf (float f) noexcept
 
         u.i = 0x00000001;
     }
-    else if (u.i > 0)
+    else if (u.f > 0)
     {
         // Positive float, normalized or denormalized.
         // Incrementing the largest positive float
@@ -65,7 +65,7 @@ predf (float f) noexcept
 
         u.i = 0x80000001;
     }
-    else if (u.i > 0)
+    else if (u.f > 0)
     {
         // Positive float, normalized or denormalized.
 


### PR DESCRIPTION
And add more thorough test.

Should resolve https://github.com/AcademySoftwareFoundation/openexr/issues/999 for Imath v3.

Fix courtesy @christianaguilera-foundry.

Signed-off-by: Cary Phillips <cary@ilm.com>