### PR TITLE
Release notes for 3.0.2. Bump version on master branch to 3.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,21 @@
 # Imath Release Notes
 
+* [Version 3.0.2](#version-302-may-16-2021) May 16, 2021
 * [Version 3.0.1](#version-301-april-1-2021) April 1, 2021
 * [Version 3.0.1-beta](#version-301-beta-march-28-2021) March 28, 2021
 * [Version 3.0.0-beta](#version-300-beta-march-15-2021) March 15, 2021
 * [Inherited History from OpenEXR](#inherited-history-from-openexr)
+
+## Version 3.0.2 (May 16, 2021)
+
+Patch release with miscellaneous bug/build fixes:
+
+* \[[#142](https://github.com/AcademySoftwareFoundation/Imath/pull/142)\] Fix order of ${IMATH_SOVERSION}.${IMATH_SOREVISION}.${IMATH_SOAGE}
+* \[[#140](https://github.com/AcademySoftwareFoundation/Imath/pull/140)\] Fix regression in succf()/predf()          
+* \[[#139](https://github.com/AcademySoftwareFoundation/Imath/pull/139)\] Clean up setting of Imath version          
+* \[[#137](https://github.com/AcademySoftwareFoundation/Imath/pull/137)\] Don't impose C++14 on downstream projects  
+* \[[#135](https://github.com/AcademySoftwareFoundation/Imath/pull/135)\] Add section on python bindings             
+* \[[#133](https://github.com/AcademySoftwareFoundation/Imath/pull/133)\] Lib version                                
 
 ## Version 3.0.1 (April 1, 2021)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,12 @@ endif()
 
 # Imath version
 
-project(Imath VERSION 3.0.2 LANGUAGES C CXX)
+project(Imath VERSION 3.0.3 LANGUAGES C CXX)
 
 set(IMATH_VERSION_EXTRA "dev" CACHE STRING "Extra version tag string for Imath build")
 
 # See https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
-set(IMATH_SOVERSION 28)
+set(IMATH_SOVERSION 29)
 set(IMATH_SOREVISION 0) 
 set(IMATH_SOAGE 0) 
 set(IMATH_LIB_VERSION "${IMATH_SOVERSION}.${IMATH_SOREVISION}.${IMATH_SOAGE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # Imath version
 
-project(Imath VERSION 3.0.3 LANGUAGES C CXX)
+project(Imath VERSION 3.1.0 LANGUAGES C CXX)
 
 set(IMATH_VERSION_EXTRA "dev" CACHE STRING "Extra version tag string for Imath build")
 


### PR DESCRIPTION
3.1.0 is the expected next release, so the best choice of version for the master branch? The version name will be "3.1.0-dev".

Also, update master branch release notes.