### PR TITLE
Fix problems with IMATH_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 project(Imath VERSION 3.1.0 LANGUAGES C CXX)
 
-set(IMATH_VERSION_EXTRA "dev" CACHE STRING "Extra version tag string for Imath build")
+set(IMATH_VERSION_SUFFIX "-dev" CACHE STRING "Extra version tag string for Imath build, such as -dev, -beta1, etc.")
 
 # See https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 set(IMATH_SOVERSION 29)
@@ -28,9 +28,6 @@ set(IMATH_VERSION_MAJOR ${CMAKE_PROJECT_VERSION_MAJOR})
 set(IMATH_VERSION_MINOR ${CMAKE_PROJECT_VERSION_MINOR})
 set(IMATH_VERSION_PATCH ${CMAKE_PROJECT_VERSION_PATCH})
 set(IMATH_VERSION ${CMAKE_PROJECT_VERSION})
-if (NOT IMATH_VERSION_EXTRA STREQUAL "")
-  set(IMATH_VERSION "${CMAKE_PROJECT_VERSION}-${IMATH_VERSION_EXTRA}")
-endif()
 set(IMATH_VERSION_API "${IMATH_VERSION_MAJOR}_${IMATH_VERSION_MINOR}")
 
 message(STATUS "Configure Imath Version: ${IMATH_VERSION} Lib API: ${IMATH_LIB_VERSION}")

--- a/config/ImathSetup.cmake
+++ b/config/ImathSetup.cmake
@@ -29,7 +29,7 @@ set(tmp)
 set(IMATH_NAMESPACE_CUSTOM "0" CACHE STRING "Whether the namespace has been customized (so external users know)")
 set(IMATH_INTERNAL_NAMESPACE "Imath_${IMATH_VERSION_API}" CACHE STRING "Real namespace for Imath that will end up in compiled symbols")
 set(IMATH_NAMESPACE "Imath" CACHE STRING "Public namespace alias for Imath")
-set(IMATH_PACKAGE_NAME "Imath ${IMATH_VERSION}" CACHE STRING "Public string / label for displaying package")
+set(IMATH_PACKAGE_NAME "Imath ${IMATH_VERSION}${IMATH_VERSION_SUFFIX}" CACHE STRING "Public string / label for displaying package")
 
 # Whether to generate and install a pkg-config file Imath.pc on
 if(WIN32)


### PR DESCRIPTION
The "IMATH_VERSION_EXTRA" cannot be incorporated into IMATH_VERSION
because CMake versions need to in the form be
major.minor[.patch[.tweak]] and IMATH_VERSION gets folded all the way
into ImathConfigVersion.cmake, and thus messes with downstream
projects.

I have now renamed "IMATH_VERSION_EXTRA" to "IMATH_VERSION_SUFFIX" for
clarity, and instead of appending it to IMATH_VERSION, I just
incorporate it into IMATH_PACKAGE_NAME, which can be an arbitrary
string. That will print the right designation when it's used, but without
polluting the numeric version.

Signed-off-by: Larry Gritz <lg@larrygritz.com>