### PR TITLE
IMATH_NOEXCEPT macro to make noexcept a compile-time option

### DIFF
--- a/config/ImathConfig.h.in
+++ b/config/ImathConfig.h.in
@@ -55,6 +55,19 @@
 // IMATH_LIB_VERSION is the library API version: SOCURRENT.SOAGE.SOREVISION
 #define IMATH_LIB_VERSION_STRING "@IMATH_LIB_VERSION@"
 
+//
+// Code that depends on the v2 ExcMath mechanism of signal handlers
+// that throw exceptions is incompatible with noexcept, since
+// floating-point overflow and underflow can occur in a wide variety
+// of computations within Imath functions now marked with
+// noexcept. Code that needs to accomodate the exception-handling
+// behavior can disable the noexcept specifier by defining the
+// IMATH_NOEXCEPT macro to be empty.
+//
+
+#ifndef IMATH_NOEXCEPT
+#define IMATH_NOEXCEPT noexcept
+#endif
 
 //
 // By default, opt into the interoparability constructors and assignments.

--- a/config/ImathConfig.h.in
+++ b/config/ImathConfig.h.in
@@ -61,12 +61,14 @@
 // floating-point overflow and underflow can occur in a wide variety
 // of computations within Imath functions now marked with
 // noexcept. Code that needs to accomodate the exception-handling
-// behavior can disable the noexcept specifier by defining the
-// IMATH_NOEXCEPT macro to be empty.
+// behavior can build with the IMATH_USE_NOEXCEPT off.
 //
 
-#ifndef IMATH_NOEXCEPT
+#cmakedefine01 IMATH_USE_NOEXCEPT
+#if IMATH_USE_NOEXCEPT
 #define IMATH_NOEXCEPT noexcept
+#else
+#define IMATH_NOEXCEPT
 #endif
 
 //

--- a/config/ImathSetup.cmake
+++ b/config/ImathSetup.cmake
@@ -17,6 +17,9 @@ option(IMATH_USE_DEFAULT_VISIBILITY "Makes the compile use default visibility (b
 # object (if you enable this) that contains a LUT of the function
 option(IMATH_ENABLE_LARGE_STACK "Enables code to take advantage of large stack support"     OFF)
 
+# Option to make it possible to build without the noexcept specifier
+option(IMATH_USE_NOEXCEPT "Compile with noexcept specifier" ON)
+
 # What C++ standard to compile for.  VFX Platform 18 is c++14, so
 # that's the default.
 set(tmp 14)

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -20,5 +20,10 @@ PREDEFINED = IMATH_CONSTEXPR14=constexpr \
              IMATH_INTERNAL_NAMESPACE_SOURCE_EXIT="}" \
              IMATH_INTERNAL_NAMESPACE_HEADER_ENTER="namespace Imath {" \
              IMATH_INTERNAL_NAMESPACE_HEADER_EXIT="}" \
+             IMATH_EXPORT= \
+             IMATH_EXPORT_ENUM= \
+             IMATH_EXPORT_TYPE= \
+             IMATH_EXPORT_TEMPLATE_TYPE= \
+             __cplusplus=1 \
              IMATH_NOEXCEPT="noexcept"
              

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -20,10 +20,10 @@ PREDEFINED = IMATH_CONSTEXPR14=constexpr \
              IMATH_INTERNAL_NAMESPACE_SOURCE_EXIT="}" \
              IMATH_INTERNAL_NAMESPACE_HEADER_ENTER="namespace Imath {" \
              IMATH_INTERNAL_NAMESPACE_HEADER_EXIT="}" \
+             IMATH_NOEXCEPT="noexcept" \
              IMATH_EXPORT= \
              IMATH_EXPORT_ENUM= \
              IMATH_EXPORT_TYPE= \
              IMATH_EXPORT_TEMPLATE_TYPE= \
-             __cplusplus=1 \
-             IMATH_NOEXCEPT="noexcept"
+             __cplusplus=1
              

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -19,5 +19,6 @@ PREDEFINED = IMATH_CONSTEXPR14=constexpr \
              IMATH_INTERNAL_NAMESPACE_SOURCE_ENTER="namespace Imath {" \
              IMATH_INTERNAL_NAMESPACE_SOURCE_EXIT="}" \
              IMATH_INTERNAL_NAMESPACE_HEADER_ENTER="namespace Imath {" \
-             IMATH_INTERNAL_NAMESPACE_HEADER_EXIT="}" 
+             IMATH_INTERNAL_NAMESPACE_HEADER_EXIT="}" \
+             IMATH_NOEXCEPT="noexcept"
              

--- a/src/Imath/ImathBox.h
+++ b/src/Imath/ImathBox.h
@@ -55,13 +55,13 @@ template <class V> class IMATH_EXPORT_TEMPLATE_TYPE Box
     /// Construct an empty bounding box. This initializes the mimimum to
     /// `std::numeric_limits<V::baseType>::max()` and the maximum to
     /// `std::numeric_limits<V::baseType>::lowest()`.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box() IMATH_NOEXCEPT;
 
     /// Construct a bounding box that contains a single point.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const V& point) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const V& point) IMATH_NOEXCEPT;
 
     /// Construct a bounding box with the given minimum and maximum values.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const V& minV, const V& maxV) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const V& minV, const V& maxV) IMATH_NOEXCEPT;
 
     /// @}
 
@@ -69,10 +69,10 @@ template <class V> class IMATH_EXPORT_TEMPLATE_TYPE Box
     /// @name Comparison
     
     /// Equality
-    IMATH_HOSTDEVICE constexpr bool operator== (const Box<V>& src) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Box<V>& src) const IMATH_NOEXCEPT;
 
     /// Inequality
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Box<V>& src) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Box<V>& src) const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -82,16 +82,16 @@ template <class V> class IMATH_EXPORT_TEMPLATE_TYPE Box
     /// Set the box to be empty. A box is empty if the mimimum is greater
     /// than the maximum. makeEmpty() sets the mimimum to `V::baseTypeMax()`
     /// and the maximum to `V::baseTypeLowest()`.
-    IMATH_HOSTDEVICE void makeEmpty() noexcept;
+    IMATH_HOSTDEVICE void makeEmpty() IMATH_NOEXCEPT;
 
     /// Extend the box to include the given point.
-    IMATH_HOSTDEVICE void extendBy (const V& point) noexcept;
+    IMATH_HOSTDEVICE void extendBy (const V& point) IMATH_NOEXCEPT;
 
     /// Extend the box to include the given box.
-    IMATH_HOSTDEVICE void extendBy (const Box<V>& box) noexcept;
+    IMATH_HOSTDEVICE void extendBy (const Box<V>& box) IMATH_NOEXCEPT;
 
     /// Make the box include the entire range of `V`.
-    IMATH_HOSTDEVICE void makeInfinite() noexcept;
+    IMATH_HOSTDEVICE void makeInfinite() IMATH_NOEXCEPT;
 
     /// @}
 
@@ -101,33 +101,33 @@ template <class V> class IMATH_EXPORT_TEMPLATE_TYPE Box
     /// Return the size of the box. The size is of type `V`, defined
     /// as `(max-min)`. An empty box has a size of `V(0)`, i.e. 0 in
     /// each dimension.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 V size() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 V size() const IMATH_NOEXCEPT;
 
     /// Return the center of the box. The center is defined as
     /// `(max+min)/2`. The center of an empty box is undefined.
-    IMATH_HOSTDEVICE constexpr V center() const noexcept;
+    IMATH_HOSTDEVICE constexpr V center() const IMATH_NOEXCEPT;
 
     /// Return true if the given point is inside the box, false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const V& point) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const V& point) const IMATH_NOEXCEPT;
 
     /// Return true if the given box is inside the box, false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Box<V>& box) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Box<V>& box) const IMATH_NOEXCEPT;
 
     /// Return the major axis of the box. The major axis is the dimension with
     /// the greatest difference between maximum and minimum.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 unsigned int majorAxis() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 unsigned int majorAxis() const IMATH_NOEXCEPT;
 
     /// Return true if the box is empty, false otherwise. An empty box's
     /// minimum is greater than its maximum.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const IMATH_NOEXCEPT;
 
     /// Return true if the box is larger than a single point, false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const IMATH_NOEXCEPT;
 
     /// Return true if the box contains all points, false otherwise.
     /// An infinite box has a mimimum of`V::baseTypeLowest()`
     /// and a maximum of `V::baseTypeMax()`.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const IMATH_NOEXCEPT;
 
     /// @}
 };
@@ -166,18 +166,18 @@ typedef Box<V3f> Box3f;
 /// 3D box of base type `double`.
 typedef Box<V3d> Box3d;
 
-template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box() noexcept
+template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box() IMATH_NOEXCEPT
 {
     makeEmpty();
 }
 
-template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box (const V& point) noexcept
+template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box (const V& point) IMATH_NOEXCEPT
 {
     min = point;
     max = point;
 }
 
-template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box (const V& minV, const V& maxV) noexcept
+template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box (const V& minV, const V& maxV) IMATH_NOEXCEPT
 {
     min = minV;
     max = maxV;
@@ -185,21 +185,21 @@ template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box (const V& minV, const V&
 
 template <class V>
 constexpr inline bool
-Box<V>::operator== (const Box<V>& src) const noexcept
+Box<V>::operator== (const Box<V>& src) const IMATH_NOEXCEPT
 {
     return (min == src.min && max == src.max);
 }
 
 template <class V>
 constexpr inline bool
-Box<V>::operator!= (const Box<V>& src) const noexcept
+Box<V>::operator!= (const Box<V>& src) const IMATH_NOEXCEPT
 {
     return (min != src.min || max != src.max);
 }
 
 template <class V>
 inline void
-Box<V>::makeEmpty() noexcept
+Box<V>::makeEmpty() IMATH_NOEXCEPT
 {
     min = V (V::baseTypeMax());
     max = V (V::baseTypeLowest());
@@ -207,7 +207,7 @@ Box<V>::makeEmpty() noexcept
 
 template <class V>
 inline void
-Box<V>::makeInfinite() noexcept
+Box<V>::makeInfinite() IMATH_NOEXCEPT
 {
     min = V (V::baseTypeLowest());
     max = V (V::baseTypeMax());
@@ -215,7 +215,7 @@ Box<V>::makeInfinite() noexcept
 
 template <class V>
 inline void
-Box<V>::extendBy (const V& point) noexcept
+Box<V>::extendBy (const V& point) IMATH_NOEXCEPT
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
     {
@@ -229,7 +229,7 @@ Box<V>::extendBy (const V& point) noexcept
 
 template <class V>
 inline void
-Box<V>::extendBy (const Box<V>& box) noexcept
+Box<V>::extendBy (const Box<V>& box) IMATH_NOEXCEPT
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
     {
@@ -243,7 +243,7 @@ Box<V>::extendBy (const Box<V>& box) noexcept
 
 template <class V>
 IMATH_CONSTEXPR14 inline bool
-Box<V>::intersects (const V& point) const noexcept
+Box<V>::intersects (const V& point) const IMATH_NOEXCEPT
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
     {
@@ -256,7 +256,7 @@ Box<V>::intersects (const V& point) const noexcept
 
 template <class V>
 IMATH_CONSTEXPR14 inline bool
-Box<V>::intersects (const Box<V>& box) const noexcept
+Box<V>::intersects (const Box<V>& box) const IMATH_NOEXCEPT
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
     {
@@ -269,7 +269,7 @@ Box<V>::intersects (const Box<V>& box) const noexcept
 
 template <class V>
 IMATH_CONSTEXPR14 inline V
-Box<V>::size() const noexcept
+Box<V>::size() const IMATH_NOEXCEPT
 {
     if (isEmpty())
         return V (0);
@@ -279,14 +279,14 @@ Box<V>::size() const noexcept
 
 template <class V>
 constexpr inline V
-Box<V>::center() const noexcept
+Box<V>::center() const IMATH_NOEXCEPT
 {
     return (max + min) / 2;
 }
 
 template <class V>
 IMATH_CONSTEXPR14 inline bool
-Box<V>::isEmpty() const noexcept
+Box<V>::isEmpty() const IMATH_NOEXCEPT
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
     {
@@ -299,7 +299,7 @@ Box<V>::isEmpty() const noexcept
 
 template <class V>
 IMATH_CONSTEXPR14 inline bool
-Box<V>::isInfinite() const noexcept
+Box<V>::isInfinite() const IMATH_NOEXCEPT
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
     {
@@ -312,7 +312,7 @@ Box<V>::isInfinite() const noexcept
 
 template <class V>
 IMATH_CONSTEXPR14 inline bool
-Box<V>::hasVolume() const noexcept
+Box<V>::hasVolume() const IMATH_NOEXCEPT
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
     {
@@ -325,7 +325,7 @@ Box<V>::hasVolume() const noexcept
 
 template <class V>
 IMATH_CONSTEXPR14 inline unsigned int
-Box<V>::majorAxis() const noexcept
+Box<V>::majorAxis() const IMATH_NOEXCEPT
 {
     unsigned int major = 0;
     V s                = size();
@@ -372,13 +372,13 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Box<Vec2<T>>
     /// @name Constructors and Assignment
 
     /// Empty by default
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box() IMATH_NOEXCEPT;
 
     /// Construct a bounding box that contains a single point.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec2<T>& point) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec2<T>& point) IMATH_NOEXCEPT;
 
     /// Construct a bounding box with the given minimum and maximum points
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec2<T>& minT, const Vec2<T>& maxT) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec2<T>& minT, const Vec2<T>& maxT) IMATH_NOEXCEPT;
 
     /// @}
 
@@ -386,10 +386,10 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Box<Vec2<T>>
     /// @name Comparison
     
     /// Equality
-    IMATH_HOSTDEVICE constexpr bool operator== (const Box<Vec2<T>>& src) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Box<Vec2<T>>& src) const IMATH_NOEXCEPT;
 
     /// Inequality
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Box<Vec2<T>>& src) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Box<Vec2<T>>& src) const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -400,16 +400,16 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Box<Vec2<T>>
     /// greater than the maximum. makeEmpty() sets the mimimum to
     /// `numeric_limits<T>::max()' and the maximum to
     /// `numeric_limits<T>::lowest()`.
-    IMATH_HOSTDEVICE void makeEmpty() noexcept;
+    IMATH_HOSTDEVICE void makeEmpty() IMATH_NOEXCEPT;
 
     /// Extend the Box to include the given point.
-    IMATH_HOSTDEVICE void extendBy (const Vec2<T>& point) noexcept;
+    IMATH_HOSTDEVICE void extendBy (const Vec2<T>& point) IMATH_NOEXCEPT;
 
     /// Extend the Box to include the given box.
-    IMATH_HOSTDEVICE void extendBy (const Box<Vec2<T>>& box) noexcept;
+    IMATH_HOSTDEVICE void extendBy (const Box<Vec2<T>>& box) IMATH_NOEXCEPT;
 
     /// Make the box include the entire range of T.
-    IMATH_HOSTDEVICE void makeInfinite() noexcept;
+    IMATH_HOSTDEVICE void makeInfinite() IMATH_NOEXCEPT;
 
     /// @}
 
@@ -418,33 +418,33 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Box<Vec2<T>>
     
     /// Return the size of the box. The size is of type `V`, defined as
     /// `(max-min)`. An empty box has a size of `V(0)`, i.e. 0 in each dimension.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2<T> size() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2<T> size() const IMATH_NOEXCEPT;
 
     /// Return the center of the box. The center is defined as
     /// `(max+min)/2`. The center of an empty box is undefined.
-    IMATH_HOSTDEVICE constexpr Vec2<T> center() const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2<T> center() const IMATH_NOEXCEPT;
 
     /// Return true if the given point is inside the box, false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Vec2<T>& point) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Vec2<T>& point) const IMATH_NOEXCEPT;
 
     /// Return true if the given box is inside the box, false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Box<Vec2<T>>& box) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Box<Vec2<T>>& box) const IMATH_NOEXCEPT;
 
     /// Return the major axis of the box. The major axis is the dimension with
     /// the greatest difference between maximum and minimum.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 unsigned int majorAxis() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 unsigned int majorAxis() const IMATH_NOEXCEPT;
 
     /// Return true if the box is empty, false otherwise. An empty box's
     /// minimum is greater than its maximum.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const IMATH_NOEXCEPT;
 
     /// Return true if the box is larger than a single point, false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const IMATH_NOEXCEPT;
 
     /// Return true if the box contains all points, false otherwise.
     /// An infinite box has a mimimum of `V::baseTypeMin()`
     /// and a maximum of `V::baseTypeMax()`.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const IMATH_NOEXCEPT;
 
     /// @}
 };
@@ -453,19 +453,19 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Box<Vec2<T>>
 //  Implementation
 //----------------
 
-template <class T> IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box() noexcept
+template <class T> IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box() IMATH_NOEXCEPT
 {
     makeEmpty();
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box (const Vec2<T>& point) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box (const Vec2<T>& point) IMATH_NOEXCEPT
 {
     min = point;
     max = point;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box (const Vec2<T>& minT, const Vec2<T>& maxT) noexcept
+IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box (const Vec2<T>& minT, const Vec2<T>& maxT) IMATH_NOEXCEPT
 {
     min = minT;
     max = maxT;
@@ -473,21 +473,21 @@ IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box (const Vec2<T>& minT, const Vec2<T>& 
 
 template <class T>
 constexpr inline bool
-Box<Vec2<T>>::operator== (const Box<Vec2<T>>& src) const noexcept
+Box<Vec2<T>>::operator== (const Box<Vec2<T>>& src) const IMATH_NOEXCEPT
 {
     return (min == src.min && max == src.max);
 }
 
 template <class T>
 constexpr inline bool
-Box<Vec2<T>>::operator!= (const Box<Vec2<T>>& src) const noexcept
+Box<Vec2<T>>::operator!= (const Box<Vec2<T>>& src) const IMATH_NOEXCEPT
 {
     return (min != src.min || max != src.max);
 }
 
 template <class T>
 inline void
-Box<Vec2<T>>::makeEmpty() noexcept
+Box<Vec2<T>>::makeEmpty() IMATH_NOEXCEPT
 {
     min = Vec2<T> (Vec2<T>::baseTypeMax());
     max = Vec2<T> (Vec2<T>::baseTypeLowest());
@@ -495,7 +495,7 @@ Box<Vec2<T>>::makeEmpty() noexcept
 
 template <class T>
 inline void
-Box<Vec2<T>>::makeInfinite() noexcept
+Box<Vec2<T>>::makeInfinite() IMATH_NOEXCEPT
 {
     min = Vec2<T> (Vec2<T>::baseTypeLowest());
     max = Vec2<T> (Vec2<T>::baseTypeMax());
@@ -503,7 +503,7 @@ Box<Vec2<T>>::makeInfinite() noexcept
 
 template <class T>
 inline void
-Box<Vec2<T>>::extendBy (const Vec2<T>& point) noexcept
+Box<Vec2<T>>::extendBy (const Vec2<T>& point) IMATH_NOEXCEPT
 {
     if (point[0] < min[0])
         min[0] = point[0];
@@ -520,7 +520,7 @@ Box<Vec2<T>>::extendBy (const Vec2<T>& point) noexcept
 
 template <class T>
 inline void
-Box<Vec2<T>>::extendBy (const Box<Vec2<T>>& box) noexcept
+Box<Vec2<T>>::extendBy (const Box<Vec2<T>>& box) IMATH_NOEXCEPT
 {
     if (box.min[0] < min[0])
         min[0] = box.min[0];
@@ -537,7 +537,7 @@ Box<Vec2<T>>::extendBy (const Box<Vec2<T>>& box) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec2<T>>::intersects (const Vec2<T>& point) const noexcept
+Box<Vec2<T>>::intersects (const Vec2<T>& point) const IMATH_NOEXCEPT
 {
     if (point[0] < min[0] || point[0] > max[0] || point[1] < min[1] || point[1] > max[1])
         return false;
@@ -547,7 +547,7 @@ Box<Vec2<T>>::intersects (const Vec2<T>& point) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec2<T>>::intersects (const Box<Vec2<T>>& box) const noexcept
+Box<Vec2<T>>::intersects (const Box<Vec2<T>>& box) const IMATH_NOEXCEPT
 {
     if (box.max[0] < min[0] || box.min[0] > max[0] || box.max[1] < min[1] || box.min[1] > max[1])
         return false;
@@ -557,7 +557,7 @@ Box<Vec2<T>>::intersects (const Box<Vec2<T>>& box) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline Vec2<T>
-Box<Vec2<T>>::size() const noexcept
+Box<Vec2<T>>::size() const IMATH_NOEXCEPT
 {
     if (isEmpty())
         return Vec2<T> (0);
@@ -567,14 +567,14 @@ Box<Vec2<T>>::size() const noexcept
 
 template <class T>
 constexpr inline Vec2<T>
-Box<Vec2<T>>::center() const noexcept
+Box<Vec2<T>>::center() const IMATH_NOEXCEPT
 {
     return (max + min) / 2;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec2<T>>::isEmpty() const noexcept
+Box<Vec2<T>>::isEmpty() const IMATH_NOEXCEPT
 {
     if (max[0] < min[0] || max[1] < min[1])
         return true;
@@ -584,7 +584,7 @@ Box<Vec2<T>>::isEmpty() const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec2<T>>::isInfinite() const noexcept
+Box<Vec2<T>>::isInfinite() const IMATH_NOEXCEPT
 {
     if (min[0] != std::numeric_limits<T>::lowest() ||
         max[0] != std::numeric_limits<T>::max() ||
@@ -597,7 +597,7 @@ Box<Vec2<T>>::isInfinite() const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec2<T>>::hasVolume() const noexcept
+Box<Vec2<T>>::hasVolume() const IMATH_NOEXCEPT
 {
     if (max[0] <= min[0] || max[1] <= min[1])
         return false;
@@ -607,7 +607,7 @@ Box<Vec2<T>>::hasVolume() const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline unsigned int
-Box<Vec2<T>>::majorAxis() const noexcept
+Box<Vec2<T>>::majorAxis() const IMATH_NOEXCEPT
 {
     unsigned int major = 0;
     Vec2<T> s          = size();
@@ -641,85 +641,85 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Box<Vec3<T>>
     /// @name Constructors
 
     /// Empty by default
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box() IMATH_NOEXCEPT;
 
     /// Construct a bounding box that contains a single point.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec3<T>& point) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec3<T>& point) IMATH_NOEXCEPT;
 
     /// Construct a bounding box with the given minimum and maximum points
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec3<T>& minT, const Vec3<T>& maxT) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Box (const Vec3<T>& minT, const Vec3<T>& maxT) IMATH_NOEXCEPT;
 
     /// @}
 
     /// Equality
-    IMATH_HOSTDEVICE constexpr bool operator== (const Box<Vec3<T>>& src) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Box<Vec3<T>>& src) const IMATH_NOEXCEPT;
 
     /// Inequality
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Box<Vec3<T>>& src) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Box<Vec3<T>>& src) const IMATH_NOEXCEPT;
 
     /// Set the Box to be empty. A Box is empty if the mimimum is
     /// greater than the maximum. makeEmpty() sets the mimimum to
     /// `numeric_limits<T>::max()` and the maximum to
     /// `numeric_limits<T>::lowest()`.
-    IMATH_HOSTDEVICE void makeEmpty() noexcept;
+    IMATH_HOSTDEVICE void makeEmpty() IMATH_NOEXCEPT;
 
     /// Extend the Box to include the given point.
-    IMATH_HOSTDEVICE void extendBy (const Vec3<T>& point) noexcept;
+    IMATH_HOSTDEVICE void extendBy (const Vec3<T>& point) IMATH_NOEXCEPT;
     /// Extend the Box to include the given box.
 
-    IMATH_HOSTDEVICE void extendBy (const Box<Vec3<T>>& box) noexcept;
+    IMATH_HOSTDEVICE void extendBy (const Box<Vec3<T>>& box) IMATH_NOEXCEPT;
 
     /// Make the box include the entire range of T.
-    IMATH_HOSTDEVICE void makeInfinite() noexcept;
+    IMATH_HOSTDEVICE void makeInfinite() IMATH_NOEXCEPT;
 
     /// Return the size of the box. The size is of type `V`, defined as
     /// (max-min). An empty box has a size of V(0), i.e. 0 in each dimension.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T> size() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T> size() const IMATH_NOEXCEPT;
 
     /// Return the center of the box. The center is defined as
     /// (max+min)/2. The center of an empty box is undefined.
-    IMATH_HOSTDEVICE constexpr Vec3<T> center() const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3<T> center() const IMATH_NOEXCEPT;
 
     /// Return true if the given point is inside the box, false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Vec3<T>& point) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Vec3<T>& point) const IMATH_NOEXCEPT;
 
     /// Return true if the given box is inside the box, false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Box<Vec3<T>>& box) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Box<Vec3<T>>& box) const IMATH_NOEXCEPT;
 
     /// Return the major axis of the box. The major axis is the dimension with
     /// the greatest difference between maximum and minimum.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 unsigned int majorAxis() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 unsigned int majorAxis() const IMATH_NOEXCEPT;
 
     /// Return true if the box is empty, false otherwise. An empty box's
     /// minimum is greater than its maximum.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const IMATH_NOEXCEPT;
 
     /// Return true if the box is larger than a single point, false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const IMATH_NOEXCEPT;
 
     /// Return true if the box contains all points, false otherwise.
     /// An infinite box has a mimimum of`V::baseTypeMin()`
     /// and a maximum of `V::baseTypeMax()`.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const IMATH_NOEXCEPT;
 };
 
 //----------------
 //  Implementation
 //----------------
 
-template <class T> IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box() noexcept
+template <class T> IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box() IMATH_NOEXCEPT
 {
     makeEmpty();
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box (const Vec3<T>& point) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box (const Vec3<T>& point) IMATH_NOEXCEPT
 {
     min = point;
     max = point;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box (const Vec3<T>& minT, const Vec3<T>& maxT) noexcept
+IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box (const Vec3<T>& minT, const Vec3<T>& maxT) IMATH_NOEXCEPT
 {
     min = minT;
     max = maxT;
@@ -727,21 +727,21 @@ IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box (const Vec3<T>& minT, const Vec3<T>& 
 
 template <class T>
 constexpr inline bool
-Box<Vec3<T>>::operator== (const Box<Vec3<T>>& src) const noexcept
+Box<Vec3<T>>::operator== (const Box<Vec3<T>>& src) const IMATH_NOEXCEPT
 {
     return (min == src.min && max == src.max);
 }
 
 template <class T>
 constexpr inline bool
-Box<Vec3<T>>::operator!= (const Box<Vec3<T>>& src) const noexcept
+Box<Vec3<T>>::operator!= (const Box<Vec3<T>>& src) const IMATH_NOEXCEPT
 {
     return (min != src.min || max != src.max);
 }
 
 template <class T>
 inline void
-Box<Vec3<T>>::makeEmpty() noexcept
+Box<Vec3<T>>::makeEmpty() IMATH_NOEXCEPT
 {
     min = Vec3<T> (Vec3<T>::baseTypeMax());
     max = Vec3<T> (Vec3<T>::baseTypeLowest());
@@ -749,7 +749,7 @@ Box<Vec3<T>>::makeEmpty() noexcept
 
 template <class T>
 inline void
-Box<Vec3<T>>::makeInfinite() noexcept
+Box<Vec3<T>>::makeInfinite() IMATH_NOEXCEPT
 {
     min = Vec3<T> (Vec3<T>::baseTypeLowest());
     max = Vec3<T> (Vec3<T>::baseTypeMax());
@@ -757,7 +757,7 @@ Box<Vec3<T>>::makeInfinite() noexcept
 
 template <class T>
 inline void
-Box<Vec3<T>>::extendBy (const Vec3<T>& point) noexcept
+Box<Vec3<T>>::extendBy (const Vec3<T>& point) IMATH_NOEXCEPT
 {
     if (point[0] < min[0])
         min[0] = point[0];
@@ -780,7 +780,7 @@ Box<Vec3<T>>::extendBy (const Vec3<T>& point) noexcept
 
 template <class T>
 inline void
-Box<Vec3<T>>::extendBy (const Box<Vec3<T>>& box) noexcept
+Box<Vec3<T>>::extendBy (const Box<Vec3<T>>& box) IMATH_NOEXCEPT
 {
     if (box.min[0] < min[0])
         min[0] = box.min[0];
@@ -803,7 +803,7 @@ Box<Vec3<T>>::extendBy (const Box<Vec3<T>>& box) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec3<T>>::intersects (const Vec3<T>& point) const noexcept
+Box<Vec3<T>>::intersects (const Vec3<T>& point) const IMATH_NOEXCEPT
 {
     if (point[0] < min[0] || point[0] > max[0] || point[1] < min[1] || point[1] > max[1] ||
         point[2] < min[2] || point[2] > max[2])
@@ -814,7 +814,7 @@ Box<Vec3<T>>::intersects (const Vec3<T>& point) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec3<T>>::intersects (const Box<Vec3<T>>& box) const noexcept
+Box<Vec3<T>>::intersects (const Box<Vec3<T>>& box) const IMATH_NOEXCEPT
 {
     if (box.max[0] < min[0] || box.min[0] > max[0] || box.max[1] < min[1] || box.min[1] > max[1] ||
         box.max[2] < min[2] || box.min[2] > max[2])
@@ -825,7 +825,7 @@ Box<Vec3<T>>::intersects (const Box<Vec3<T>>& box) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline Vec3<T>
-Box<Vec3<T>>::size() const noexcept
+Box<Vec3<T>>::size() const IMATH_NOEXCEPT
 {
     if (isEmpty())
         return Vec3<T> (0);
@@ -835,14 +835,14 @@ Box<Vec3<T>>::size() const noexcept
 
 template <class T>
 constexpr inline Vec3<T>
-Box<Vec3<T>>::center() const noexcept
+Box<Vec3<T>>::center() const IMATH_NOEXCEPT
 {
     return (max + min) / 2;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec3<T>>::isEmpty() const noexcept
+Box<Vec3<T>>::isEmpty() const IMATH_NOEXCEPT
 {
     if (max[0] < min[0] || max[1] < min[1] || max[2] < min[2])
         return true;
@@ -852,7 +852,7 @@ Box<Vec3<T>>::isEmpty() const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec3<T>>::isInfinite() const noexcept
+Box<Vec3<T>>::isInfinite() const IMATH_NOEXCEPT
 {
     if (min[0] != std::numeric_limits<T>::lowest() ||
         max[0] != std::numeric_limits<T>::max() ||
@@ -867,7 +867,7 @@ Box<Vec3<T>>::isInfinite() const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Box<Vec3<T>>::hasVolume() const noexcept
+Box<Vec3<T>>::hasVolume() const IMATH_NOEXCEPT
 {
     if (max[0] <= min[0] || max[1] <= min[1] || max[2] <= min[2])
         return false;
@@ -877,7 +877,7 @@ Box<Vec3<T>>::hasVolume() const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline unsigned int
-Box<Vec3<T>>::majorAxis() const noexcept
+Box<Vec3<T>>::majorAxis() const IMATH_NOEXCEPT
 {
     unsigned int major = 0;
     Vec3<T> s          = size();

--- a/src/Imath/ImathBoxAlgo.h
+++ b/src/Imath/ImathBoxAlgo.h
@@ -26,7 +26,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T
-clip (const T& p, const Box<T>& box) noexcept
+clip (const T& p, const Box<T>& box) IMATH_NOEXCEPT
 {
     T q;
 
@@ -50,7 +50,7 @@ clip (const T& p, const Box<T>& box) noexcept
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline T
-closestPointInBox (const T& p, const Box<T>& box) noexcept
+closestPointInBox (const T& p, const Box<T>& box) IMATH_NOEXCEPT
 {
     return clip (p, box);
 }
@@ -64,7 +64,7 @@ closestPointInBox (const T& p, const Box<T>& box) noexcept
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T>
-closestPointOnBox (const Vec3<T>& p, const Box<Vec3<T>>& box) noexcept
+closestPointOnBox (const Vec3<T>& p, const Box<Vec3<T>>& box) IMATH_NOEXCEPT
 {
     if (box.isEmpty())
         return p;
@@ -111,7 +111,7 @@ closestPointOnBox (const Vec3<T>& p, const Box<Vec3<T>>& box) noexcept
 
 template <class S, class T>
 IMATH_HOSTDEVICE Box<Vec3<S>>
-transform (const Box<Vec3<S>>& box, const Matrix44<T>& m) noexcept
+transform (const Box<Vec3<S>>& box, const Matrix44<T>& m) IMATH_NOEXCEPT
 {
     if (box.isEmpty() || box.isInfinite())
         return box;
@@ -192,7 +192,7 @@ transform (const Box<Vec3<S>>& box, const Matrix44<T>& m) noexcept
 
 template <class S, class T>
 IMATH_HOSTDEVICE void
-transform (const Box<Vec3<S>>& box, const Matrix44<T>& m, Box<Vec3<S>>& result) noexcept
+transform (const Box<Vec3<S>>& box, const Matrix44<T>& m, Box<Vec3<S>>& result) IMATH_NOEXCEPT
 {
     if (box.isEmpty() || box.isInfinite())
     {
@@ -267,7 +267,7 @@ transform (const Box<Vec3<S>>& box, const Matrix44<T>& m, Box<Vec3<S>>& result) 
 
 template <class S, class T>
 IMATH_HOSTDEVICE Box<Vec3<S>>
-affineTransform (const Box<Vec3<S>>& box, const Matrix44<T>& m) noexcept
+affineTransform (const Box<Vec3<S>>& box, const Matrix44<T>& m) IMATH_NOEXCEPT
 {
     if (box.isEmpty() || box.isInfinite())
         return box;
@@ -315,7 +315,7 @@ affineTransform (const Box<Vec3<S>>& box, const Matrix44<T>& m) noexcept
 
 template <class S, class T>
 IMATH_HOSTDEVICE void
-affineTransform (const Box<Vec3<S>>& box, const Matrix44<T>& m, Box<Vec3<S>>& result) noexcept
+affineTransform (const Box<Vec3<S>>& box, const Matrix44<T>& m, Box<Vec3<S>>& result) IMATH_NOEXCEPT
 {
     if (box.isEmpty())
     {
@@ -369,7 +369,7 @@ affineTransform (const Box<Vec3<S>>& box, const Matrix44<T>& m, Box<Vec3<S>>& re
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool
-findEntryAndExitPoints (const Line3<T>& r, const Box<Vec3<T>>& b, Vec3<T>& entry, Vec3<T>& exit) noexcept
+findEntryAndExitPoints (const Line3<T>& r, const Box<Vec3<T>>& b, Vec3<T>& entry, Vec3<T>& exit) IMATH_NOEXCEPT
 {
     if (b.isEmpty())
     {
@@ -639,7 +639,7 @@ findEntryAndExitPoints (const Line3<T>& r, const Box<Vec3<T>>& b, Vec3<T>& entry
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool
-intersects (const Box<Vec3<T>>& b, const Line3<T>& r, Vec3<T>& ip) noexcept
+intersects (const Box<Vec3<T>>& b, const Line3<T>& r, Vec3<T>& ip) IMATH_NOEXCEPT
 {
     if (b.isEmpty())
     {
@@ -897,7 +897,7 @@ intersects (const Box<Vec3<T>>& b, const Line3<T>& r, Vec3<T>& ip) noexcept
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool
-intersects (const Box<Vec3<T>>& box, const Line3<T>& ray) noexcept
+intersects (const Box<Vec3<T>>& box, const Line3<T>& ray) IMATH_NOEXCEPT
 {
     Vec3<T> ignored;
     return intersects (box, ray, ignored);

--- a/src/Imath/ImathColor.h
+++ b/src/Imath/ImathColor.h
@@ -35,25 +35,25 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Color3 : public Vec3<T>
     /// @name Constructors and Assignemt
 
     /// No initialization by default
-    IMATH_HOSTDEVICE Color3() noexcept;                         
+    IMATH_HOSTDEVICE Color3() IMATH_NOEXCEPT;                         
 
     /// Initialize to (a a a)
-    IMATH_HOSTDEVICE constexpr explicit Color3 (T a) noexcept;  
+    IMATH_HOSTDEVICE constexpr explicit Color3 (T a) IMATH_NOEXCEPT;  
 
     /// Initialize to (a b c)
-    IMATH_HOSTDEVICE constexpr Color3 (T a, T b, T c) noexcept; 
+    IMATH_HOSTDEVICE constexpr Color3 (T a, T b, T c) IMATH_NOEXCEPT; 
 
     /// Construct from Color3
-    IMATH_HOSTDEVICE constexpr Color3 (const Color3& c) noexcept; 
+    IMATH_HOSTDEVICE constexpr Color3 (const Color3& c) IMATH_NOEXCEPT; 
 
     /// Construct from Vec3
-    template <class S> IMATH_HOSTDEVICE constexpr Color3 (const Vec3<S>& v) noexcept; 
+    template <class S> IMATH_HOSTDEVICE constexpr Color3 (const Vec3<S>& v) IMATH_NOEXCEPT; 
 
     /// Destructor
     ~Color3() = default;
 
     /// Component-wise assignment
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator= (const Color3& c) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator= (const Color3& c) IMATH_NOEXCEPT; 
 
     /// @}
     
@@ -61,46 +61,46 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Color3 : public Vec3<T>
     /// @name Arithmetic
     
     /// Component-wise addition
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator+= (const Color3& c) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator+= (const Color3& c) IMATH_NOEXCEPT; 
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE constexpr Color3 operator+ (const Color3& c) const noexcept;  
+    IMATH_HOSTDEVICE constexpr Color3 operator+ (const Color3& c) const IMATH_NOEXCEPT;  
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator-= (const Color3& c) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator-= (const Color3& c) IMATH_NOEXCEPT; 
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE constexpr Color3 operator- (const Color3& c) const noexcept; 
+    IMATH_HOSTDEVICE constexpr Color3 operator- (const Color3& c) const IMATH_NOEXCEPT; 
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE constexpr Color3 operator-() const noexcept; 
+    IMATH_HOSTDEVICE constexpr Color3 operator-() const IMATH_NOEXCEPT; 
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& negate() noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& negate() IMATH_NOEXCEPT; 
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator*= (const Color3& c) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator*= (const Color3& c) IMATH_NOEXCEPT; 
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator*= (T a) noexcept;  
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator*= (T a) IMATH_NOEXCEPT;  
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE constexpr Color3 operator* (const Color3& c) const noexcept;  
+    IMATH_HOSTDEVICE constexpr Color3 operator* (const Color3& c) const IMATH_NOEXCEPT;  
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE constexpr Color3 operator* (T a) const noexcept;  
+    IMATH_HOSTDEVICE constexpr Color3 operator* (T a) const IMATH_NOEXCEPT;  
 
     /// Component-wise division
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator/= (const Color3& c) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator/= (const Color3& c) IMATH_NOEXCEPT; 
 
     /// Component-wise division
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator/= (T a) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator/= (T a) IMATH_NOEXCEPT; 
 
     /// Component-wise division
-    IMATH_HOSTDEVICE constexpr Color3 operator/ (const Color3& c) const noexcept;  
+    IMATH_HOSTDEVICE constexpr Color3 operator/ (const Color3& c) const IMATH_NOEXCEPT;  
 
     /// Component-wise division
-    IMATH_HOSTDEVICE constexpr Color3 operator/ (T a) const noexcept;  
+    IMATH_HOSTDEVICE constexpr Color3 operator/ (T a) const IMATH_NOEXCEPT;  
 
     /// @}
 };
@@ -128,31 +128,31 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Color4
     /// @name Constructors and Assignment
 
     /// No initialization by default
-    IMATH_HOSTDEVICE Color4() noexcept;                                      
+    IMATH_HOSTDEVICE Color4() IMATH_NOEXCEPT;                                      
 
     /// Initialize to `(a a a a)`
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Color4 (T a) noexcept;       
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Color4 (T a) IMATH_NOEXCEPT;       
 
     /// Initialize to `(a b c d)`
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4 (T a, T b, T c, T d) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4 (T a, T b, T c, T d) IMATH_NOEXCEPT; 
 
     /// Construct from Color4
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4 (const Color4& v) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4 (const Color4& v) IMATH_NOEXCEPT; 
 
     /// Construct from Color4
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4 (const Color4<S>& v) noexcept; 
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4 (const Color4<S>& v) IMATH_NOEXCEPT; 
 
     /// Destructor
     ~Color4() = default;
 
     /// Assignment
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator= (const Color4& v) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator= (const Color4& v) IMATH_NOEXCEPT; 
 
     /// Component-wise value
-    IMATH_HOSTDEVICE T& operator[] (int i) noexcept; 
+    IMATH_HOSTDEVICE T& operator[] (int i) IMATH_NOEXCEPT; 
 
     /// Component-wise value
-    IMATH_HOSTDEVICE const T& operator[] (int i) const noexcept; 
+    IMATH_HOSTDEVICE const T& operator[] (int i) const IMATH_NOEXCEPT; 
 
     /// @}
     
@@ -160,52 +160,52 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Color4
     /// @name Arithmetic and Comparison
     
     /// Equality
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Color4<S>& v) const noexcept; 
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Color4<S>& v) const IMATH_NOEXCEPT; 
 
     /// Inequality
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Color4<S>& v) const noexcept; 
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Color4<S>& v) const IMATH_NOEXCEPT; 
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator+= (const Color4& v) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator+= (const Color4& v) IMATH_NOEXCEPT; 
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE constexpr Color4 operator+ (const Color4& v) const noexcept; 
+    IMATH_HOSTDEVICE constexpr Color4 operator+ (const Color4& v) const IMATH_NOEXCEPT; 
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator-= (const Color4& v) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator-= (const Color4& v) IMATH_NOEXCEPT; 
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE constexpr Color4 operator- (const Color4& v) const noexcept; 
+    IMATH_HOSTDEVICE constexpr Color4 operator- (const Color4& v) const IMATH_NOEXCEPT; 
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE constexpr Color4 operator-() const noexcept; 
+    IMATH_HOSTDEVICE constexpr Color4 operator-() const IMATH_NOEXCEPT; 
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& negate() noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& negate() IMATH_NOEXCEPT; 
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator*= (const Color4& v) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator*= (const Color4& v) IMATH_NOEXCEPT; 
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator*= (T a) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator*= (T a) IMATH_NOEXCEPT; 
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE constexpr Color4 operator* (const Color4& v) const noexcept; 
+    IMATH_HOSTDEVICE constexpr Color4 operator* (const Color4& v) const IMATH_NOEXCEPT; 
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE constexpr Color4 operator* (T a) const noexcept; 
+    IMATH_HOSTDEVICE constexpr Color4 operator* (T a) const IMATH_NOEXCEPT; 
 
     /// Component-wise division
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator/= (const Color4& v) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator/= (const Color4& v) IMATH_NOEXCEPT; 
 
     /// Component-wise division
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator/= (T a) noexcept; 
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator/= (T a) IMATH_NOEXCEPT; 
 
     /// Component-wise division
-    IMATH_HOSTDEVICE constexpr Color4 operator/ (const Color4& v) const noexcept; 
+    IMATH_HOSTDEVICE constexpr Color4 operator/ (const Color4& v) const IMATH_NOEXCEPT; 
 
     /// Component-wise division
-    IMATH_HOSTDEVICE constexpr Color4 operator/ (T a) const noexcept; 
+    IMATH_HOSTDEVICE constexpr Color4 operator/ (T a) const IMATH_NOEXCEPT; 
 
     /// @}
 
@@ -213,19 +213,19 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Color4
     /// @name Numeric Limits
     
     /// Number of dimensions (channels), i.e. 4 for a Color4
-    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() noexcept { return 4; }
+    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() IMATH_NOEXCEPT { return 4; }
 
     /// Largest possible negative value
-    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() noexcept { return std::numeric_limits<T>::lowest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() IMATH_NOEXCEPT { return std::numeric_limits<T>::lowest(); }
 
     /// Largest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return std::numeric_limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() IMATH_NOEXCEPT { return std::numeric_limits<T>::max(); }
 
     /// Smallest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return std::numeric_limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() IMATH_NOEXCEPT { return std::numeric_limits<T>::min(); }
 
     /// Smallest possible e for which 1+e != 1
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return std::numeric_limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() IMATH_NOEXCEPT { return std::numeric_limits<T>::epsilon(); }
 
     /// @}
     
@@ -237,22 +237,22 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Color4
     /// @name Compatibilty with Sb
 
     /// Set the value
-    template <class S> IMATH_HOSTDEVICE void setValue (S a, S b, S c, S d) noexcept; 
+    template <class S> IMATH_HOSTDEVICE void setValue (S a, S b, S c, S d) IMATH_NOEXCEPT; 
 
     /// Set the value
-    template <class S> IMATH_HOSTDEVICE void setValue (const Color4<S>& v) noexcept; 
+    template <class S> IMATH_HOSTDEVICE void setValue (const Color4<S>& v) IMATH_NOEXCEPT; 
 
     /// Return the value
-    template <class S> IMATH_HOSTDEVICE void getValue (S& a, S& b, S& c, S& d) const noexcept; 
+    template <class S> IMATH_HOSTDEVICE void getValue (S& a, S& b, S& c, S& d) const IMATH_NOEXCEPT; 
 
     /// Return the value
-    template <class S> IMATH_HOSTDEVICE void getValue (Color4<S>& v) const noexcept; 
+    template <class S> IMATH_HOSTDEVICE void getValue (Color4<S>& v) const IMATH_NOEXCEPT; 
 
     /// Return raw pointer to the value
-    IMATH_HOSTDEVICE T* getValue() noexcept; 
+    IMATH_HOSTDEVICE T* getValue() IMATH_NOEXCEPT; 
 
     /// Return raw pointer to the value
-    IMATH_HOSTDEVICE const T* getValue() const noexcept; 
+    IMATH_HOSTDEVICE const T* getValue() const IMATH_NOEXCEPT; 
 
     /// @}
 };
@@ -261,7 +261,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Color4
 template <class T> std::ostream& operator<< (std::ostream& s, const Color4<T>& v);
 
 /// Reverse multiplication: S * Color4
-template <class S, class T> constexpr Color4<T> operator* (S a, const Color4<T>& v) noexcept;
+template <class S, class T> constexpr Color4<T> operator* (S a, const Color4<T>& v) IMATH_NOEXCEPT;
 
 /// 3 float channels
 typedef Color3<float> Color3f;
@@ -306,36 +306,36 @@ typedef unsigned int PackedColor;
 // Implementation of Color3
 //
 
-template <class T> inline Color3<T>::Color3() noexcept : Vec3<T>()
+template <class T> inline Color3<T>::Color3() IMATH_NOEXCEPT : Vec3<T>()
 {
     // empty
 }
 
-template <class T> constexpr inline Color3<T>::Color3 (T a) noexcept : Vec3<T> (a)
+template <class T> constexpr inline Color3<T>::Color3 (T a) IMATH_NOEXCEPT : Vec3<T> (a)
 {
     // empty
 }
 
-template <class T> constexpr inline Color3<T>::Color3 (T a, T b, T c) noexcept : Vec3<T> (a, b, c)
+template <class T> constexpr inline Color3<T>::Color3 (T a, T b, T c) IMATH_NOEXCEPT : Vec3<T> (a, b, c)
 {
     // empty
 }
 
-template <class T> constexpr inline Color3<T>::Color3 (const Color3& c) noexcept : Vec3<T> (c)
+template <class T> constexpr inline Color3<T>::Color3 (const Color3& c) IMATH_NOEXCEPT : Vec3<T> (c)
 {
     // empty
 }
 
 template <class T>
 template <class S>
-constexpr inline Color3<T>::Color3 (const Vec3<S>& v) noexcept : Vec3<T> (v)
+constexpr inline Color3<T>::Color3 (const Vec3<S>& v) IMATH_NOEXCEPT : Vec3<T> (v)
 {
     //empty
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::operator= (const Color3& c) noexcept
+Color3<T>::operator= (const Color3& c) IMATH_NOEXCEPT
 {
     *((Vec3<T>*) this) = c;
     return *this;
@@ -343,7 +343,7 @@ Color3<T>::operator= (const Color3& c) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::operator+= (const Color3& c) noexcept
+Color3<T>::operator+= (const Color3& c) IMATH_NOEXCEPT
 {
     *((Vec3<T>*) this) += c;
     return *this;
@@ -351,14 +351,14 @@ Color3<T>::operator+= (const Color3& c) noexcept
 
 template <class T>
 constexpr inline Color3<T>
-Color3<T>::operator+ (const Color3& c) const noexcept
+Color3<T>::operator+ (const Color3& c) const IMATH_NOEXCEPT
 {
     return Color3 (*(Vec3<T>*) this + (const Vec3<T>&) c);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::operator-= (const Color3& c) noexcept
+Color3<T>::operator-= (const Color3& c) IMATH_NOEXCEPT
 {
     *((Vec3<T>*) this) -= c;
     return *this;
@@ -366,21 +366,21 @@ Color3<T>::operator-= (const Color3& c) noexcept
 
 template <class T>
 constexpr inline Color3<T>
-Color3<T>::operator- (const Color3& c) const noexcept
+Color3<T>::operator- (const Color3& c) const IMATH_NOEXCEPT
 {
     return Color3 (*(Vec3<T>*) this - (const Vec3<T>&) c);
 }
 
 template <class T>
 constexpr inline Color3<T>
-Color3<T>::operator-() const noexcept
+Color3<T>::operator-() const IMATH_NOEXCEPT
 {
     return Color3 (-(*(Vec3<T>*) this));
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::negate() noexcept
+Color3<T>::negate() IMATH_NOEXCEPT
 {
     ((Vec3<T>*) this)->negate();
     return *this;
@@ -388,7 +388,7 @@ Color3<T>::negate() noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::operator*= (const Color3& c) noexcept
+Color3<T>::operator*= (const Color3& c) IMATH_NOEXCEPT
 {
     *((Vec3<T>*) this) *= c;
     return *this;
@@ -396,7 +396,7 @@ Color3<T>::operator*= (const Color3& c) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::operator*= (T a) noexcept
+Color3<T>::operator*= (T a) IMATH_NOEXCEPT
 {
     *((Vec3<T>*) this) *= a;
     return *this;
@@ -404,21 +404,21 @@ Color3<T>::operator*= (T a) noexcept
 
 template <class T>
 constexpr inline Color3<T>
-Color3<T>::operator* (const Color3& c) const noexcept
+Color3<T>::operator* (const Color3& c) const IMATH_NOEXCEPT
 {
     return Color3 (*(Vec3<T>*) this * (const Vec3<T>&) c);
 }
 
 template <class T>
 constexpr inline Color3<T>
-Color3<T>::operator* (T a) const noexcept
+Color3<T>::operator* (T a) const IMATH_NOEXCEPT
 {
     return Color3 (*(Vec3<T>*) this * a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::operator/= (const Color3& c) noexcept
+Color3<T>::operator/= (const Color3& c) IMATH_NOEXCEPT
 {
     *((Vec3<T>*) this) /= c;
     return *this;
@@ -426,7 +426,7 @@ Color3<T>::operator/= (const Color3& c) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color3<T>&
-Color3<T>::operator/= (T a) noexcept
+Color3<T>::operator/= (T a) IMATH_NOEXCEPT
 {
     *((Vec3<T>*) this) /= a;
     return *this;
@@ -434,14 +434,14 @@ Color3<T>::operator/= (T a) noexcept
 
 template <class T>
 constexpr inline Color3<T>
-Color3<T>::operator/ (const Color3& c) const noexcept
+Color3<T>::operator/ (const Color3& c) const IMATH_NOEXCEPT
 {
     return Color3 (*(Vec3<T>*) this / (const Vec3<T>&) c);
 }
 
 template <class T>
 constexpr inline Color3<T>
-Color3<T>::operator/ (T a) const noexcept
+Color3<T>::operator/ (T a) const IMATH_NOEXCEPT
 {
     return Color3 (*(Vec3<T>*) this / a);
 }
@@ -452,29 +452,29 @@ Color3<T>::operator/ (T a) const noexcept
 
 template <class T>
 inline T&
-Color4<T>::operator[] (int i) noexcept
+Color4<T>::operator[] (int i) IMATH_NOEXCEPT
 {
     return (&r)[i];
 }
 
 template <class T>
 inline const T&
-Color4<T>::operator[] (int i) const noexcept
+Color4<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
     return (&r)[i];
 }
 
-template <class T> inline Color4<T>::Color4() noexcept
+template <class T> inline Color4<T>::Color4() IMATH_NOEXCEPT
 {
     // empty
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x) IMATH_NOEXCEPT
 {
     r = g = b = a = x;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x, T y, T z, T w) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x, T y, T z, T w) IMATH_NOEXCEPT
 {
     r = x;
     g = y;
@@ -482,7 +482,7 @@ template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x, T y, T z, T 
     a = w;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4& v) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4& v) IMATH_NOEXCEPT
 {
     r = v.r;
     g = v.g;
@@ -492,7 +492,7 @@ template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4& v) 
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4<S>& v) noexcept
+IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4<S>& v) IMATH_NOEXCEPT
 {
     r = T (v.r);
     g = T (v.g);
@@ -502,7 +502,7 @@ IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4<S>& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::operator= (const Color4& v) noexcept
+Color4<T>::operator= (const Color4& v) IMATH_NOEXCEPT
 {
     r = v.r;
     g = v.g;
@@ -514,7 +514,7 @@ Color4<T>::operator= (const Color4& v) noexcept
 template <class T>
 template <class S>
 inline void
-Color4<T>::setValue (S x, S y, S z, S w) noexcept
+Color4<T>::setValue (S x, S y, S z, S w) IMATH_NOEXCEPT
 {
     r = T (x);
     g = T (y);
@@ -525,7 +525,7 @@ Color4<T>::setValue (S x, S y, S z, S w) noexcept
 template <class T>
 template <class S>
 inline void
-Color4<T>::setValue (const Color4<S>& v) noexcept
+Color4<T>::setValue (const Color4<S>& v) IMATH_NOEXCEPT
 {
     r = T (v.r);
     g = T (v.g);
@@ -536,7 +536,7 @@ Color4<T>::setValue (const Color4<S>& v) noexcept
 template <class T>
 template <class S>
 inline void
-Color4<T>::getValue (S& x, S& y, S& z, S& w) const noexcept
+Color4<T>::getValue (S& x, S& y, S& z, S& w) const IMATH_NOEXCEPT
 {
     x = S (r);
     y = S (g);
@@ -547,7 +547,7 @@ Color4<T>::getValue (S& x, S& y, S& z, S& w) const noexcept
 template <class T>
 template <class S>
 inline void
-Color4<T>::getValue (Color4<S>& v) const noexcept
+Color4<T>::getValue (Color4<S>& v) const IMATH_NOEXCEPT
 {
     v.r = S (r);
     v.g = S (g);
@@ -557,14 +557,14 @@ Color4<T>::getValue (Color4<S>& v) const noexcept
 
 template <class T>
 inline T*
-Color4<T>::getValue() noexcept
+Color4<T>::getValue() IMATH_NOEXCEPT
 {
     return (T*) &r;
 }
 
 template <class T>
 inline const T*
-Color4<T>::getValue() const noexcept
+Color4<T>::getValue() const IMATH_NOEXCEPT
 {
     return (const T*) &r;
 }
@@ -572,7 +572,7 @@ Color4<T>::getValue() const noexcept
 template <class T>
 template <class S>
 constexpr inline bool
-Color4<T>::operator== (const Color4<S>& v) const noexcept
+Color4<T>::operator== (const Color4<S>& v) const IMATH_NOEXCEPT
 {
     return r == v.r && g == v.g && b == v.b && a == v.a;
 }
@@ -580,14 +580,14 @@ Color4<T>::operator== (const Color4<S>& v) const noexcept
 template <class T>
 template <class S>
 constexpr inline bool
-Color4<T>::operator!= (const Color4<S>& v) const noexcept
+Color4<T>::operator!= (const Color4<S>& v) const IMATH_NOEXCEPT
 {
     return r != v.r || g != v.g || b != v.b || a != v.a;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::operator+= (const Color4& v) noexcept
+Color4<T>::operator+= (const Color4& v) IMATH_NOEXCEPT
 {
     r += v.r;
     g += v.g;
@@ -598,14 +598,14 @@ Color4<T>::operator+= (const Color4& v) noexcept
 
 template <class T>
 constexpr inline Color4<T>
-Color4<T>::operator+ (const Color4& v) const noexcept
+Color4<T>::operator+ (const Color4& v) const IMATH_NOEXCEPT
 {
     return Color4 (r + v.r, g + v.g, b + v.b, a + v.a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::operator-= (const Color4& v) noexcept
+Color4<T>::operator-= (const Color4& v) IMATH_NOEXCEPT
 {
     r -= v.r;
     g -= v.g;
@@ -616,21 +616,21 @@ Color4<T>::operator-= (const Color4& v) noexcept
 
 template <class T>
 constexpr inline Color4<T>
-Color4<T>::operator- (const Color4& v) const noexcept
+Color4<T>::operator- (const Color4& v) const IMATH_NOEXCEPT
 {
     return Color4 (r - v.r, g - v.g, b - v.b, a - v.a);
 }
 
 template <class T>
 constexpr inline Color4<T>
-Color4<T>::operator-() const noexcept
+Color4<T>::operator-() const IMATH_NOEXCEPT
 {
     return Color4 (-r, -g, -b, -a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::negate() noexcept
+Color4<T>::negate() IMATH_NOEXCEPT
 {
     r = -r;
     g = -g;
@@ -641,7 +641,7 @@ Color4<T>::negate() noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::operator*= (const Color4& v) noexcept
+Color4<T>::operator*= (const Color4& v) IMATH_NOEXCEPT
 {
     r *= v.r;
     g *= v.g;
@@ -652,7 +652,7 @@ Color4<T>::operator*= (const Color4& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::operator*= (T x) noexcept
+Color4<T>::operator*= (T x) IMATH_NOEXCEPT
 {
     r *= x;
     g *= x;
@@ -663,21 +663,21 @@ Color4<T>::operator*= (T x) noexcept
 
 template <class T>
 constexpr inline Color4<T>
-Color4<T>::operator* (const Color4& v) const noexcept
+Color4<T>::operator* (const Color4& v) const IMATH_NOEXCEPT
 {
     return Color4 (r * v.r, g * v.g, b * v.b, a * v.a);
 }
 
 template <class T>
 constexpr inline Color4<T>
-Color4<T>::operator* (T x) const noexcept
+Color4<T>::operator* (T x) const IMATH_NOEXCEPT
 {
     return Color4 (r * x, g * x, b * x, a * x);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::operator/= (const Color4& v) noexcept
+Color4<T>::operator/= (const Color4& v) IMATH_NOEXCEPT
 {
     r /= v.r;
     g /= v.g;
@@ -688,7 +688,7 @@ Color4<T>::operator/= (const Color4& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Color4<T>&
-Color4<T>::operator/= (T x) noexcept
+Color4<T>::operator/= (T x) IMATH_NOEXCEPT
 {
     r /= x;
     g /= x;
@@ -699,14 +699,14 @@ Color4<T>::operator/= (T x) noexcept
 
 template <class T>
 constexpr inline Color4<T>
-Color4<T>::operator/ (const Color4& v) const noexcept
+Color4<T>::operator/ (const Color4& v) const IMATH_NOEXCEPT
 {
     return Color4 (r / v.r, g / v.g, b / v.b, a / v.a);
 }
 
 template <class T>
 constexpr inline Color4<T>
-Color4<T>::operator/ (T x) const noexcept
+Color4<T>::operator/ (T x) const IMATH_NOEXCEPT
 {
     return Color4 (r / x, g / x, b / x, a / x);
 }
@@ -724,7 +724,7 @@ operator<< (std::ostream& s, const Color4<T>& v)
 
 template <class S, class T>
 constexpr inline Color4<T>
-operator* (S x, const Color4<T>& v) noexcept
+operator* (S x, const Color4<T>& v) IMATH_NOEXCEPT
 {
     return Color4<T> (x * v.r, x * v.g, x * v.b, x * v.a);
 }

--- a/src/Imath/ImathColorAlgo.cpp
+++ b/src/Imath/ImathColorAlgo.cpp
@@ -14,7 +14,7 @@
 IMATH_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 Vec3<double>
-hsv2rgb_d (const Vec3<double>& hsv) noexcept
+hsv2rgb_d (const Vec3<double>& hsv) IMATH_NOEXCEPT
 {
     double hue = hsv.x;
     double sat = hsv.y;
@@ -71,7 +71,7 @@ hsv2rgb_d (const Vec3<double>& hsv) noexcept
 }
 
 Color4<double>
-hsv2rgb_d (const Color4<double>& hsv) noexcept
+hsv2rgb_d (const Color4<double>& hsv) IMATH_NOEXCEPT
 {
     double hue = hsv.r;
     double sat = hsv.g;
@@ -128,7 +128,7 @@ hsv2rgb_d (const Color4<double>& hsv) noexcept
 }
 
 Vec3<double>
-rgb2hsv_d (const Vec3<double>& c) noexcept
+rgb2hsv_d (const Vec3<double>& c) IMATH_NOEXCEPT
 {
     const double& x = c.x;
     const double& y = c.y;
@@ -164,7 +164,7 @@ rgb2hsv_d (const Vec3<double>& c) noexcept
 }
 
 Color4<double>
-rgb2hsv_d (const Color4<double>& c) noexcept
+rgb2hsv_d (const Color4<double>& c) IMATH_NOEXCEPT
 {
     const double& r = c.r;
     const double& g = c.g;

--- a/src/Imath/ImathColorAlgo.h
+++ b/src/Imath/ImathColorAlgo.h
@@ -25,19 +25,19 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 ///
 /// Convert 3-channel hsv to rgb. Non-templated helper routine.
-IMATH_EXPORT Vec3<double> hsv2rgb_d (const Vec3<double>& hsv) noexcept;
+IMATH_EXPORT Vec3<double> hsv2rgb_d (const Vec3<double>& hsv) IMATH_NOEXCEPT;
 
 ///
 /// Convert 4-channel hsv to rgb (with alpha). Non-templated helper routine.
-IMATH_EXPORT Color4<double> hsv2rgb_d (const Color4<double>& hsv) noexcept;
+IMATH_EXPORT Color4<double> hsv2rgb_d (const Color4<double>& hsv) IMATH_NOEXCEPT;
 
 ///
 /// Convert 3-channel rgb to hsv. Non-templated helper routine.
-IMATH_EXPORT Vec3<double> rgb2hsv_d (const Vec3<double>& rgb) noexcept;
+IMATH_EXPORT Vec3<double> rgb2hsv_d (const Vec3<double>& rgb) IMATH_NOEXCEPT;
 
 ///
 /// Convert 4-channel rgb to hsv. Non-templated helper routine.
-IMATH_EXPORT Color4<double> rgb2hsv_d (const Color4<double>& rgb) noexcept;
+IMATH_EXPORT Color4<double> rgb2hsv_d (const Color4<double>& rgb) IMATH_NOEXCEPT;
 
 ///
 /// Convert 3-channel hsv to rgb.
@@ -45,7 +45,7 @@ IMATH_EXPORT Color4<double> rgb2hsv_d (const Color4<double>& rgb) noexcept;
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T>
-hsv2rgb (const Vec3<T>& hsv) noexcept
+hsv2rgb (const Vec3<T>& hsv) IMATH_NOEXCEPT
 {
     if (std::numeric_limits<T>::is_integer)
     {
@@ -71,7 +71,7 @@ hsv2rgb (const Vec3<T>& hsv) noexcept
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4<T>
-hsv2rgb (const Color4<T>& hsv) noexcept
+hsv2rgb (const Color4<T>& hsv) IMATH_NOEXCEPT
 {
     if (std::numeric_limits<T>::is_integer)
     {
@@ -99,7 +99,7 @@ hsv2rgb (const Color4<T>& hsv) noexcept
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T>
-rgb2hsv (const Vec3<T>& rgb) noexcept
+rgb2hsv (const Vec3<T>& rgb) IMATH_NOEXCEPT
 {
     if (std::numeric_limits<T>::is_integer)
     {
@@ -125,7 +125,7 @@ rgb2hsv (const Vec3<T>& rgb) noexcept
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4<T>
-rgb2hsv (const Color4<T>& rgb) noexcept
+rgb2hsv (const Color4<T>& rgb) IMATH_NOEXCEPT
 {
     if (std::numeric_limits<T>::is_integer)
     {
@@ -153,7 +153,7 @@ rgb2hsv (const Color4<T>& rgb) noexcept
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 PackedColor
-rgb2packed (const Vec3<T>& c) noexcept
+rgb2packed (const Vec3<T>& c) IMATH_NOEXCEPT
 {
     if (std::numeric_limits<T>::is_integer)
     {
@@ -178,7 +178,7 @@ rgb2packed (const Vec3<T>& c) noexcept
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 PackedColor
-rgb2packed (const Color4<T>& c) noexcept
+rgb2packed (const Color4<T>& c) IMATH_NOEXCEPT
 {
     if (std::numeric_limits<T>::is_integer)
     {
@@ -206,7 +206,7 @@ rgb2packed (const Color4<T>& c) noexcept
 
 template <class T>
 IMATH_HOSTDEVICE void
-packed2rgb (PackedColor packed, Vec3<T>& out) noexcept
+packed2rgb (PackedColor packed, Vec3<T>& out) IMATH_NOEXCEPT
 {
     if (std::numeric_limits<T>::is_integer)
     {
@@ -231,7 +231,7 @@ packed2rgb (PackedColor packed, Vec3<T>& out) noexcept
 
 template <class T>
 IMATH_HOSTDEVICE void
-packed2rgb (PackedColor packed, Color4<T>& out) noexcept
+packed2rgb (PackedColor packed, Color4<T>& out) IMATH_NOEXCEPT
 {
     if (std::numeric_limits<T>::is_integer)
     {

--- a/src/Imath/ImathEuler.h
+++ b/src/Imath/ImathEuler.h
@@ -207,30 +207,30 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Euler : public Vec3<T>
     /// function, defined in ImathMatrixAlgo.h.
 
     /// No initialization by default
-    IMATH_HOSTDEVICE constexpr Euler() noexcept;
+    IMATH_HOSTDEVICE constexpr Euler() IMATH_NOEXCEPT;
 
     /// Copy constructor
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Euler&) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Euler&) IMATH_NOEXCEPT;
 
     /// Construct from given Order
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (Order p) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (Order p) IMATH_NOEXCEPT;
 
     /// Construct from vector, order, layout
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Vec3<T>& v,
                                               Order o       = Default,
-                                              InputLayout l = IJKLayout) noexcept;
+                                              InputLayout l = IJKLayout) IMATH_NOEXCEPT;
     /// Construct from explicit axes, order, layout
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14
-    Euler (T i, T j, T k, Order o = Default, InputLayout l = IJKLayout) noexcept;
+    Euler (T i, T j, T k, Order o = Default, InputLayout l = IJKLayout) IMATH_NOEXCEPT;
 
     /// Copy constructor with new Order
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Euler<T>& euler, Order newp) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Euler<T>& euler, Order newp) IMATH_NOEXCEPT;
 
     /// Construct from Matrix33
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Matrix33<T>&, Order o = Default) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Matrix33<T>&, Order o = Default) IMATH_NOEXCEPT;
 
     /// Construct from Matrix44
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Matrix44<T>&, Order o = Default) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Matrix44<T>&, Order o = Default) IMATH_NOEXCEPT;
 
     /// Destructor
     ~Euler() = default;
@@ -241,10 +241,10 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Euler : public Vec3<T>
     /// @name Query
     
     /// Return whether the given value is a legal Order
-    IMATH_HOSTDEVICE constexpr static bool legal (Order) noexcept;
+    IMATH_HOSTDEVICE constexpr static bool legal (Order) IMATH_NOEXCEPT;
 
     /// Return the order
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Order order() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Order order() const IMATH_NOEXCEPT;
 
     /// Return frameStatic
     IMATH_HOSTDEVICE constexpr bool frameStatic() const { return _frameStatic; }
@@ -259,10 +259,10 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Euler : public Vec3<T>
     IMATH_HOSTDEVICE constexpr Axis initialAxis() const { return _initialAxis; }
 
     /// Unpack angles from ijk form
-    IMATH_HOSTDEVICE void angleOrder (int& i, int& j, int& k) const noexcept;
+    IMATH_HOSTDEVICE void angleOrder (int& i, int& j, int& k) const IMATH_NOEXCEPT;
 
     /// Determine mapping from xyz to ijk (reshuffle the xyz to match the order)
-    IMATH_HOSTDEVICE void angleMapping (int& i, int& j, int& k) const noexcept;
+    IMATH_HOSTDEVICE void angleMapping (int& i, int& j, int& k) const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -271,14 +271,14 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Euler : public Vec3<T>
     
     /// Set the order. This does NOT convert the angles, but it
     /// does reorder the input vector.
-    IMATH_HOSTDEVICE void setOrder (Order) noexcept;
+    IMATH_HOSTDEVICE void setOrder (Order) IMATH_NOEXCEPT;
 
     /// Set the euler value: set the first angle to `v[0]`, the second to
     /// `v[1]`, the third to `v[2]`.
-    IMATH_HOSTDEVICE void setXYZVector (const Vec3<T>&) noexcept;
+    IMATH_HOSTDEVICE void setXYZVector (const Vec3<T>&) IMATH_NOEXCEPT;
 
     /// Set the value.
-    IMATH_HOSTDEVICE void set (Axis initial, bool relative, bool parityEven, bool firstRepeats) noexcept;
+    IMATH_HOSTDEVICE void set (Axis initial, bool relative, bool parityEven, bool firstRepeats) IMATH_NOEXCEPT;
 
     /// @}
     
@@ -287,33 +287,33 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Euler : public Vec3<T>
     ///
 
     /// Assignment
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Euler<T>& operator= (const Euler<T>&) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Euler<T>& operator= (const Euler<T>&) IMATH_NOEXCEPT;
 
     /// Assignment
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Euler<T>& operator= (const Vec3<T>&) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Euler<T>& operator= (const Vec3<T>&) IMATH_NOEXCEPT;
 
     /// Assign from Matrix33, assumed to be affine
-    IMATH_HOSTDEVICE void extract (const Matrix33<T>&) noexcept;
+    IMATH_HOSTDEVICE void extract (const Matrix33<T>&) IMATH_NOEXCEPT;
 
     /// Assign from Matrix44, assumed to be affine
-    IMATH_HOSTDEVICE void extract (const Matrix44<T>&) noexcept;
+    IMATH_HOSTDEVICE void extract (const Matrix44<T>&) IMATH_NOEXCEPT;
 
     /// Assign from Quaternion
-    IMATH_HOSTDEVICE void extract (const Quat<T>&) noexcept;
+    IMATH_HOSTDEVICE void extract (const Quat<T>&) IMATH_NOEXCEPT;
 
     /// Convert to Matrix33
-    IMATH_HOSTDEVICE Matrix33<T> toMatrix33() const noexcept;
+    IMATH_HOSTDEVICE Matrix33<T> toMatrix33() const IMATH_NOEXCEPT;
 
     /// Convert to Matrix44
-    IMATH_HOSTDEVICE Matrix44<T> toMatrix44() const noexcept;
+    IMATH_HOSTDEVICE Matrix44<T> toMatrix44() const IMATH_NOEXCEPT;
 
     /// Convert to Quat
-    IMATH_HOSTDEVICE Quat<T> toQuat() const noexcept;
+    IMATH_HOSTDEVICE Quat<T> toQuat() const IMATH_NOEXCEPT;
 
     /// Reorder the angles so that the X rotation comes first,
     ///  followed by the Y and Z in cases like XYX ordering, the
     ///  repeated angle will be in the "z" component
-    IMATH_HOSTDEVICE Vec3<T> toXYZVector() const noexcept;
+    IMATH_HOSTDEVICE Vec3<T> toXYZVector() const IMATH_NOEXCEPT;
 
     /// @}
     
@@ -325,21 +325,21 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Euler : public Vec3<T>
     ///  that is the intent).
 
     /// Convert an angle to its equivalent in [-PI, PI]
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 static float angleMod (T angle) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 static float angleMod (T angle) IMATH_NOEXCEPT;
 
     /// Adjust xyzRot so that its components differ from targetXyzRot by no more than +/-PI
-    IMATH_HOSTDEVICE static void simpleXYZRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot) noexcept;
+    IMATH_HOSTDEVICE static void simpleXYZRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot) IMATH_NOEXCEPT;
 
     /// Adjust xyzRot so that its components differ from targetXyzRot by as little as possible.
     /// Note that xyz here really means ijk, because the order must be provided.
     IMATH_HOSTDEVICE static void
-    nearestRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot, Order order = XYZ) noexcept;
+    nearestRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot, Order order = XYZ) IMATH_NOEXCEPT;
 
     /// Adjusts "this" Euler so that its components differ from target
     /// by as little as possible. This method might not make sense for
     /// Eulers with different order and it probably doesn't work for
     /// repeated axis and relative orderings (TODO).
-    IMATH_HOSTDEVICE void makeNear (const Euler<T>& target) noexcept;
+    IMATH_HOSTDEVICE void makeNear (const Euler<T>& target) IMATH_NOEXCEPT;
 
     /// @}
 
@@ -380,7 +380,7 @@ typedef Euler<double> Eulerd;
 
 template <class T>
 inline void
-Euler<T>::angleOrder (int& i, int& j, int& k) const noexcept
+Euler<T>::angleOrder (int& i, int& j, int& k) const IMATH_NOEXCEPT
 {
     i = _initialAxis;
     j = _parityEven ? (i + 1) % 3 : (i > 0 ? i - 1 : 2);
@@ -389,7 +389,7 @@ Euler<T>::angleOrder (int& i, int& j, int& k) const noexcept
 
 template <class T>
 inline void
-Euler<T>::angleMapping (int& i, int& j, int& k) const noexcept
+Euler<T>::angleMapping (int& i, int& j, int& k) const IMATH_NOEXCEPT
 {
     int m[3];
 
@@ -403,7 +403,7 @@ Euler<T>::angleMapping (int& i, int& j, int& k) const noexcept
 
 template <class T>
 inline void
-Euler<T>::setXYZVector (const Vec3<T>& v) noexcept
+Euler<T>::setXYZVector (const Vec3<T>& v) IMATH_NOEXCEPT
 {
     int i, j, k;
     angleMapping (i, j, k);
@@ -414,7 +414,7 @@ Euler<T>::setXYZVector (const Vec3<T>& v) noexcept
 
 template <class T>
 inline Vec3<T>
-Euler<T>::toXYZVector() const noexcept
+Euler<T>::toXYZVector() const IMATH_NOEXCEPT
 {
     int i, j, k;
     angleMapping (i, j, k);
@@ -422,7 +422,7 @@ Euler<T>::toXYZVector() const noexcept
 }
 
 template <class T>
-constexpr inline Euler<T>::Euler() noexcept
+constexpr inline Euler<T>::Euler() IMATH_NOEXCEPT
     : Vec3<T> (0, 0, 0),
       _frameStatic (true),
       _initialRepeated (false),
@@ -431,7 +431,7 @@ constexpr inline Euler<T>::Euler() noexcept
 {}
 
 template <class T>
-IMATH_CONSTEXPR14 inline Euler<T>::Euler (typename Euler<T>::Order p) noexcept
+IMATH_CONSTEXPR14 inline Euler<T>::Euler (typename Euler<T>::Order p) IMATH_NOEXCEPT
     : Vec3<T> (0, 0, 0),
       _frameStatic (true),
       _initialRepeated (false),
@@ -444,7 +444,7 @@ IMATH_CONSTEXPR14 inline Euler<T>::Euler (typename Euler<T>::Order p) noexcept
 template <class T>
 IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Vec3<T>& v,
                                           typename Euler<T>::Order p,
-                                          typename Euler<T>::InputLayout l) noexcept
+                                          typename Euler<T>::InputLayout l) IMATH_NOEXCEPT
 {
     setOrder (p);
     if (l == XYZLayout)
@@ -457,12 +457,12 @@ IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Vec3<T>& v,
     }
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Euler<T>& euler) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Euler<T>& euler) IMATH_NOEXCEPT
 {
     operator= (euler);
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Euler<T>& euler, Order p) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Euler<T>& euler, Order p) IMATH_NOEXCEPT
 {
     setOrder (p);
     Matrix33<T> M = euler.toMatrix33();
@@ -474,7 +474,7 @@ IMATH_CONSTEXPR14 inline Euler<T>::Euler (T xi,
                                           T yi,
                                           T zi,
                                           typename Euler<T>::Order p,
-                                          typename Euler<T>::InputLayout l) noexcept
+                                          typename Euler<T>::InputLayout l) IMATH_NOEXCEPT
 {
     setOrder (p);
     if (l == XYZLayout)
@@ -488,14 +488,14 @@ IMATH_CONSTEXPR14 inline Euler<T>::Euler (T xi,
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Matrix33<T>& M, typename Euler::Order p) noexcept
+IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Matrix33<T>& M, typename Euler::Order p) IMATH_NOEXCEPT
 {
     setOrder (p);
     extract (M);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Matrix44<T>& M, typename Euler::Order p) noexcept
+IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Matrix44<T>& M, typename Euler::Order p) IMATH_NOEXCEPT
 {
     setOrder (p);
     extract (M);
@@ -503,14 +503,14 @@ IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Matrix44<T>& M, typename Euler::
 
 template <class T>
 inline void
-Euler<T>::extract (const Quat<T>& q) noexcept
+Euler<T>::extract (const Quat<T>& q) IMATH_NOEXCEPT
 {
     extract (q.toMatrix33());
 }
 
 template <class T>
 void
-Euler<T>::extract (const Matrix33<T>& M) noexcept
+Euler<T>::extract (const Matrix33<T>& M) IMATH_NOEXCEPT
 {
     int i, j, k;
     angleOrder (i, j, k);
@@ -617,7 +617,7 @@ Euler<T>::extract (const Matrix33<T>& M) noexcept
 
 template <class T>
 void
-Euler<T>::extract (const Matrix44<T>& M) noexcept
+Euler<T>::extract (const Matrix44<T>& M) IMATH_NOEXCEPT
 {
     int i, j, k;
     angleOrder (i, j, k);
@@ -694,7 +694,7 @@ Euler<T>::extract (const Matrix44<T>& M) noexcept
 
 template <class T>
 Matrix33<T>
-Euler<T>::toMatrix33() const noexcept
+Euler<T>::toMatrix33() const IMATH_NOEXCEPT
 {
     int i, j, k;
     angleOrder (i, j, k);
@@ -753,7 +753,7 @@ Euler<T>::toMatrix33() const noexcept
 
 template <class T>
 Matrix44<T>
-Euler<T>::toMatrix44() const noexcept
+Euler<T>::toMatrix44() const IMATH_NOEXCEPT
 {
     int i, j, k;
     angleOrder (i, j, k);
@@ -812,7 +812,7 @@ Euler<T>::toMatrix44() const noexcept
 
 template <class T>
 Quat<T>
-Euler<T>::toQuat() const noexcept
+Euler<T>::toQuat() const IMATH_NOEXCEPT
 {
     Vec3<T> angles;
     int i, j, k;
@@ -867,14 +867,14 @@ Euler<T>::toQuat() const noexcept
 
 template <class T>
 constexpr inline bool
-Euler<T>::legal (typename Euler<T>::Order order) noexcept
+Euler<T>::legal (typename Euler<T>::Order order) IMATH_NOEXCEPT
 {
     return (order & ~Legal) ? false : true;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 typename Euler<T>::Order
-Euler<T>::order() const noexcept
+Euler<T>::order() const IMATH_NOEXCEPT
 {
     int foo = (_initialAxis == Z ? 0x2000 : (_initialAxis == Y ? 0x1000 : 0));
 
@@ -890,7 +890,7 @@ Euler<T>::order() const noexcept
 
 template <class T>
 inline void
-Euler<T>::setOrder (typename Euler<T>::Order p) noexcept
+Euler<T>::setOrder (typename Euler<T>::Order p) IMATH_NOEXCEPT
 {
     set (p & 0x2000 ? Z : (p & 0x1000 ? Y : X), // initial axis
          !(p & 0x1),                            // static?
@@ -900,7 +900,7 @@ Euler<T>::setOrder (typename Euler<T>::Order p) noexcept
 
 template <class T>
 inline void
-Euler<T>::set (typename Euler<T>::Axis axis, bool relative, bool parityEven, bool firstRepeats) noexcept
+Euler<T>::set (typename Euler<T>::Axis axis, bool relative, bool parityEven, bool firstRepeats) IMATH_NOEXCEPT
 {
     _initialAxis     = axis;
     _frameStatic     = !relative;
@@ -910,7 +910,7 @@ Euler<T>::set (typename Euler<T>::Axis axis, bool relative, bool parityEven, boo
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Euler<T>&
-Euler<T>::operator= (const Euler<T>& euler) noexcept
+Euler<T>::operator= (const Euler<T>& euler) IMATH_NOEXCEPT
 {
     x                = euler.x;
     y                = euler.y;
@@ -924,7 +924,7 @@ Euler<T>::operator= (const Euler<T>& euler) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Euler<T>&
-Euler<T>::operator= (const Vec3<T>& v) noexcept
+Euler<T>::operator= (const Vec3<T>& v) IMATH_NOEXCEPT
 {
     x = v.x;
     y = v.y;
@@ -935,7 +935,7 @@ Euler<T>::operator= (const Vec3<T>& v) noexcept
 /// Stream ouput
 template <class T>
 std::ostream&
-operator<< (std::ostream& o, const Euler<T>& euler) noexcept
+operator<< (std::ostream& o, const Euler<T>& euler) IMATH_NOEXCEPT
 {
     char a[3] = { 'X', 'Y', 'Z' };
 
@@ -952,7 +952,7 @@ operator<< (std::ostream& o, const Euler<T>& euler) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline float
-Euler<T>::angleMod (T angle) noexcept
+Euler<T>::angleMod (T angle) IMATH_NOEXCEPT
 {
     const T pi = static_cast<T> (M_PI);
     angle      = fmod (T (angle), T (2 * pi));
@@ -967,7 +967,7 @@ Euler<T>::angleMod (T angle) noexcept
 
 template <class T>
 inline void
-Euler<T>::simpleXYZRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot) noexcept
+Euler<T>::simpleXYZRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot) IMATH_NOEXCEPT
 {
     Vec3<T> d = xyzRot - targetXyzRot;
     xyzRot[0] = targetXyzRot[0] + angleMod (d[0]);
@@ -977,7 +977,7 @@ Euler<T>::simpleXYZRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot) noexc
 
 template <class T>
 void
-Euler<T>::nearestRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot, Order order) noexcept
+Euler<T>::nearestRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot, Order order) IMATH_NOEXCEPT
 {
     int i, j, k;
     Euler<T> e (0, 0, 0, order);
@@ -1005,7 +1005,7 @@ Euler<T>::nearestRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot, Order o
 
 template <class T>
 void
-Euler<T>::makeNear (const Euler<T>& target) noexcept
+Euler<T>::makeNear (const Euler<T>& target) IMATH_NOEXCEPT
 {
     Vec3<T> xyzRot = toXYZVector();
     Vec3<T> targetXyz;

--- a/src/Imath/ImathFrame.h
+++ b/src/Imath/ImathFrame.h
@@ -43,19 +43,19 @@ template <class T> class Matrix44;
 template <class T>
 Matrix44<T> constexpr firstFrame (const Vec3<T>&,  // First point
                                   const Vec3<T>&,  // Second point
-                                  const Vec3<T>&) noexcept; // Third point
+                                  const Vec3<T>&) IMATH_NOEXCEPT; // Third point
 
 template <class T>
 Matrix44<T> constexpr nextFrame (const Matrix44<T>&, // Previous matrix
                                  const Vec3<T>&,     // Previous point
                                  const Vec3<T>&,     // Current point
                                  Vec3<T>&,           // Previous tangent
-                                 Vec3<T>&) noexcept;          // Current tangent
+                                 Vec3<T>&) IMATH_NOEXCEPT;          // Current tangent
 
 template <class T>
 Matrix44<T> constexpr lastFrame (const Matrix44<T>&, // Previous matrix
                                  const Vec3<T>&,     // Previous point
-                                 const Vec3<T>&) noexcept;    // Last point
+                                 const Vec3<T>&) IMATH_NOEXCEPT;    // Last point
 
 ///
 /// Compute the first reference frame along a curve.
@@ -77,7 +77,7 @@ Matrix44<T> constexpr lastFrame (const Matrix44<T>&, // Previous matrix
 template <class T>
 Matrix44<T> constexpr firstFrame (const Vec3<T>& pi, // first point
                                   const Vec3<T>& pj, // secont point
-                                  const Vec3<T>& pk) noexcept // third point
+                                  const Vec3<T>& pk) IMATH_NOEXCEPT // third point
 {
     Vec3<T> t = pj - pi;
     t.normalizeExc();
@@ -140,7 +140,7 @@ Matrix44<T> constexpr nextFrame (const Matrix44<T>& Mi, // Previous matrix
                                  const Vec3<T>& pi,     // Previous point
                                  const Vec3<T>& pj,     // Current point
                                  Vec3<T>& ti,           // Previous tangent vector
-                                 Vec3<T>& tj) noexcept  // Current tangent vector
+                                 Vec3<T>& tj) IMATH_NOEXCEPT  // Current tangent vector
 {
     Vec3<T> a (0.0, 0.0, 0.0); /// Rotation axis.
     T r = 0.0;                 // Rotation angle.
@@ -201,7 +201,7 @@ Matrix44<T> constexpr nextFrame (const Matrix44<T>& Mi, // Previous matrix
 template <class T>
 Matrix44<T> constexpr lastFrame (const Matrix44<T>& Mi, // Previous matrix
                                  const Vec3<T>& pi,     // Previous point
-                                 const Vec3<T>& pj) noexcept // Last point
+                                 const Vec3<T>& pj) IMATH_NOEXCEPT // Last point
 {
     Matrix44<T> Tr;
     Tr.translate (pj - pi);

--- a/src/Imath/ImathFrustum.h
+++ b/src/Imath/ImathFrustum.h
@@ -46,23 +46,23 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Frustum
 
     /// Initialize with default values:
     ///  near=0.1, far=1000.0, left=-1.0, right=1.0, top=1.0, bottom=-1.0, ortho=false
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Frustum() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Frustum() IMATH_NOEXCEPT;
 
     /// Copy constructor
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Frustum (const Frustum&) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Frustum (const Frustum&) IMATH_NOEXCEPT;
 
     /// Initialize to specific values
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14
-    Frustum (T nearPlane, T farPlane, T left, T right, T top, T bottom, bool ortho = false) noexcept;
+    Frustum (T nearPlane, T farPlane, T left, T right, T top, T bottom, bool ortho = false) IMATH_NOEXCEPT;
 
     /// Initialize with fov and aspect 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Frustum (T nearPlane, T farPlane, T fovx, T fovy, T aspect) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Frustum (T nearPlane, T farPlane, T fovx, T fovy, T aspect) IMATH_NOEXCEPT;
 
     /// Destructor
-    virtual ~Frustum() noexcept;
+    virtual ~Frustum() IMATH_NOEXCEPT;
 
     /// Component-wise assignment
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Frustum& operator= (const Frustum&) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Frustum& operator= (const Frustum&) IMATH_NOEXCEPT;
 
     /// @}
 
@@ -70,10 +70,10 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Frustum
     /// @name Comparison
 
     /// Equality
-    IMATH_HOSTDEVICE constexpr bool operator== (const Frustum<T>& src) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Frustum<T>& src) const IMATH_NOEXCEPT;
 
     /// Inequality
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Frustum<T>& src) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Frustum<T>& src) const IMATH_NOEXCEPT;
 
     /// @}
     
@@ -81,54 +81,54 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Frustum
     /// @name Query
     
     /// Return true if the frustum is orthographic, false if perspective
-    IMATH_HOSTDEVICE constexpr bool orthographic() const noexcept { return _orthographic; }
+    IMATH_HOSTDEVICE constexpr bool orthographic() const IMATH_NOEXCEPT { return _orthographic; }
 
     /// Return the near clipping plane
-    IMATH_HOSTDEVICE constexpr T nearPlane() const noexcept { return _nearPlane; }
+    IMATH_HOSTDEVICE constexpr T nearPlane() const IMATH_NOEXCEPT { return _nearPlane; }
 
     /// Return the near clipping plane
-    IMATH_HOSTDEVICE constexpr T hither() const noexcept { return _nearPlane; }
+    IMATH_HOSTDEVICE constexpr T hither() const IMATH_NOEXCEPT { return _nearPlane; }
 
     /// Return the far clipping plane
-    IMATH_HOSTDEVICE constexpr T farPlane() const noexcept { return _farPlane; }
+    IMATH_HOSTDEVICE constexpr T farPlane() const IMATH_NOEXCEPT { return _farPlane; }
 
     /// Return the far clipping plane
-    IMATH_HOSTDEVICE constexpr T yon() const noexcept { return _farPlane; }
+    IMATH_HOSTDEVICE constexpr T yon() const IMATH_NOEXCEPT { return _farPlane; }
 
     /// Return the left of the frustum
-    IMATH_HOSTDEVICE constexpr T left() const noexcept { return _left; }
+    IMATH_HOSTDEVICE constexpr T left() const IMATH_NOEXCEPT { return _left; }
 
     /// Return the right of the frustum
-    IMATH_HOSTDEVICE constexpr T right() const noexcept { return _right; }
+    IMATH_HOSTDEVICE constexpr T right() const IMATH_NOEXCEPT { return _right; }
 
     /// Return the bottom of the frustum
-    IMATH_HOSTDEVICE constexpr T bottom() const noexcept { return _bottom; }
+    IMATH_HOSTDEVICE constexpr T bottom() const IMATH_NOEXCEPT { return _bottom; }
 
     /// Return the top of the frustum
-    IMATH_HOSTDEVICE constexpr T top() const noexcept { return _top; }
+    IMATH_HOSTDEVICE constexpr T top() const IMATH_NOEXCEPT { return _top; }
 
     /// Return the field of view in X
-    IMATH_HOSTDEVICE constexpr T fovx() const noexcept;
+    IMATH_HOSTDEVICE constexpr T fovx() const IMATH_NOEXCEPT;
 
     /// Return the field of view in Y
-    IMATH_HOSTDEVICE constexpr T fovy() const noexcept;
+    IMATH_HOSTDEVICE constexpr T fovy() const IMATH_NOEXCEPT;
 
     /// Return the aspect ratio
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T aspect() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T aspect() const IMATH_NOEXCEPT;
 
     /// Return the aspect ratio. Throw an exception if the aspect
     /// ratio is undefined.
     IMATH_CONSTEXPR14 T aspectExc() const;
 
     /// Return the project matrix that the frustum defines
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44<T> projectionMatrix() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44<T> projectionMatrix() const IMATH_NOEXCEPT;
 
     /// Return the project matrix that the frustum defines. Throw an
     /// exception if the frustum is degenerate.
     IMATH_CONSTEXPR14 Matrix44<T> projectionMatrixExc() const;
 
     /// Return true if the frustum is degenerate.
-    IMATH_HOSTDEVICE constexpr bool degenerate() const noexcept;
+    IMATH_HOSTDEVICE constexpr bool degenerate() const IMATH_NOEXCEPT;
 
     /// @}
     
@@ -137,11 +137,11 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Frustum
     
     /// Set functions change the entire state of the Frustum
     IMATH_HOSTDEVICE void
-    set (T nearPlane, T farPlane, T left, T right, T top, T bottom, bool ortho = false) noexcept;
+    set (T nearPlane, T farPlane, T left, T right, T top, T bottom, bool ortho = false) IMATH_NOEXCEPT;
 
     /// Set functions change the entire state of the Frustum using
     /// field of view and aspect ratio
-    IMATH_HOSTDEVICE void set (T nearPlane, T farPlane, T fovx, T fovy, T aspect) noexcept;
+    IMATH_HOSTDEVICE void set (T nearPlane, T farPlane, T fovx, T fovy, T aspect) IMATH_NOEXCEPT;
 
     /// Set functions change the entire state of the Frustum using
     /// field of view and aspect ratio. Throw an exception if `fovx`
@@ -149,29 +149,29 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Frustum
     void setExc (T nearPlane, T farPlane, T fovx, T fovy, T aspect);
 
     /// Set the near and far clipping planes
-    IMATH_HOSTDEVICE void modifyNearAndFar (T nearPlane, T farPlane) noexcept;
+    IMATH_HOSTDEVICE void modifyNearAndFar (T nearPlane, T farPlane) IMATH_NOEXCEPT;
 
     /// Set the ortographic state
-    IMATH_HOSTDEVICE void setOrthographic (bool) noexcept;
+    IMATH_HOSTDEVICE void setOrthographic (bool) IMATH_NOEXCEPT;
 
     /// Set the planes in p to be the six bounding planes of the frustum, in
     /// the following order: top, right, bottom, left, near, far.
     /// Note that the planes have normals that point out of the frustum.
-    IMATH_HOSTDEVICE void planes (Plane3<T> p[6]) const noexcept;
+    IMATH_HOSTDEVICE void planes (Plane3<T> p[6]) const IMATH_NOEXCEPT;
 
     /// Set the planes in p to be the six bounding planes of the
     /// frustum, in the following order: top, right, bottom, left,
     /// near, far.  Note that the planes have normals that point out
     /// of the frustum.  Apply the given matrix to transform the
     /// frustum before setting the planes.
-    IMATH_HOSTDEVICE void planes (Plane3<T> p[6], const Matrix44<T>& M) const noexcept;
+    IMATH_HOSTDEVICE void planes (Plane3<T> p[6], const Matrix44<T>& M) const IMATH_NOEXCEPT;
 
     /// Takes a rectangle in the screen space (i.e., -1 <= left <= right <= 1
     /// and -1 <= bottom <= top <= 1) of this Frustum, and returns a new
     /// Frustum whose near clipping-plane window is that rectangle in local
     /// space.
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 IMATH_HOSTDEVICE Frustum<T>
-    window (T left, T right, T top, T bottom) const noexcept;
+    window (T left, T right, T top, T bottom) const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -179,10 +179,10 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Frustum
     /// @name Utility Methods
     
     /// Project a point in screen spaced to 3d ray
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Line3<T> projectScreenToRay (const Vec2<T>&) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Line3<T> projectScreenToRay (const Vec2<T>&) const IMATH_NOEXCEPT;
 
     /// Project a 3D point into screen coordinates
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2<T> projectPointToScreen (const Vec3<T>&) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2<T> projectPointToScreen (const Vec3<T>&) const IMATH_NOEXCEPT;
 
     /// Project a 3D point into screen coordinates. Throw an
     /// exception if the point cannot be projected.
@@ -191,12 +191,12 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Frustum
     /// Map a z value to its depth in the frustum.
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T ZToDepth (long zval,
                                                    long min,
-                                                   long max) const noexcept;
+                                                   long max) const IMATH_NOEXCEPT;
     /// Map a z value to its depth in the frustum.
     IMATH_CONSTEXPR14 T ZToDepthExc (long zval, long min, long max) const;
 
     /// Map a normalized z value to its depth in the frustum.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T normalizedZToDepth (T zval) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T normalizedZToDepth (T zval) const IMATH_NOEXCEPT;
 
     /// Map a normalized z value to its depth in the frustum. Throw an
     /// exception on error.
@@ -204,19 +204,19 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Frustum
 
     /// Map depth to z value.
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 long
-    DepthToZ (T depth, long zmin, long zmax) const noexcept;
+    DepthToZ (T depth, long zmin, long zmax) const IMATH_NOEXCEPT;
 
     /// Map depth to z value. Throw an exception on error.
     IMATH_CONSTEXPR14 long DepthToZExc (T depth, long zmin, long zmax) const;
 
     /// Compute worldRadius
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T worldRadius (const Vec3<T>& p, T radius) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T worldRadius (const Vec3<T>& p, T radius) const IMATH_NOEXCEPT;
 
     /// Compute worldRadius. Throw an exception on error.
     IMATH_CONSTEXPR14 T worldRadiusExc (const Vec3<T>& p, T radius) const;
 
     /// Compute screen radius
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T screenRadius (const Vec3<T>& p, T radius) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T screenRadius (const Vec3<T>& p, T radius) const IMATH_NOEXCEPT;
 
     /// Compute screen radius. Throw an exception on error.
     IMATH_CONSTEXPR14 T screenRadiusExc (const Vec3<T>& p, T radius) const;
@@ -226,11 +226,11 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Frustum
   protected:
 
     /// Map point from screen space to local space
-    IMATH_HOSTDEVICE constexpr Vec2<T> screenToLocal (const Vec2<T>&) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2<T> screenToLocal (const Vec2<T>&) const IMATH_NOEXCEPT;
 
     /// Map point from local space to screen space
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec2<T>
-    localToScreen (const Vec2<T>&) const noexcept;
+    localToScreen (const Vec2<T>&) const IMATH_NOEXCEPT;
 
     /// Map point from local space to screen space. Throw an exception
     /// on error.
@@ -251,34 +251,34 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Frustum
     /// @endcond
 };
 
-template <class T> IMATH_CONSTEXPR14 inline Frustum<T>::Frustum() noexcept
+template <class T> IMATH_CONSTEXPR14 inline Frustum<T>::Frustum() IMATH_NOEXCEPT
 {
     set (T (0.1), T (1000.0), T (-1.0), T (1.0), T (1.0), T (-1.0), false);
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Frustum<T>::Frustum (const Frustum& f) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Frustum<T>::Frustum (const Frustum& f) IMATH_NOEXCEPT
 {
     *this = f;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Frustum<T>::Frustum (T n, T f, T l, T r, T t, T b, bool o) noexcept
+IMATH_CONSTEXPR14 inline Frustum<T>::Frustum (T n, T f, T l, T r, T t, T b, bool o) IMATH_NOEXCEPT
 {
     set (n, f, l, r, t, b, o);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Frustum<T>::Frustum (T nearPlane, T farPlane, T fovx, T fovy, T aspect) noexcept
+IMATH_CONSTEXPR14 inline Frustum<T>::Frustum (T nearPlane, T farPlane, T fovx, T fovy, T aspect) IMATH_NOEXCEPT
 {
     set (nearPlane, farPlane, fovx, fovy, aspect);
 }
 
-template <class T> Frustum<T>::~Frustum() noexcept
+template <class T> Frustum<T>::~Frustum() IMATH_NOEXCEPT
 {}
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Frustum<T>&
-Frustum<T>::operator= (const Frustum& f) noexcept
+Frustum<T>::operator= (const Frustum& f) IMATH_NOEXCEPT
 {
     _nearPlane    = f._nearPlane;
     _farPlane     = f._farPlane;
@@ -293,7 +293,7 @@ Frustum<T>::operator= (const Frustum& f) noexcept
 
 template <class T>
 constexpr inline bool
-Frustum<T>::operator== (const Frustum<T>& src) const noexcept
+Frustum<T>::operator== (const Frustum<T>& src) const IMATH_NOEXCEPT
 {
     return _nearPlane == src._nearPlane && _farPlane == src._farPlane && _left == src._left &&
            _right == src._right && _top == src._top && _bottom == src._bottom &&
@@ -302,14 +302,14 @@ Frustum<T>::operator== (const Frustum<T>& src) const noexcept
 
 template <class T>
 constexpr inline bool
-Frustum<T>::operator!= (const Frustum<T>& src) const noexcept
+Frustum<T>::operator!= (const Frustum<T>& src) const IMATH_NOEXCEPT
 {
     return !operator== (src);
 }
 
 template <class T>
 inline void
-Frustum<T>::set (T n, T f, T l, T r, T t, T b, bool o) noexcept
+Frustum<T>::set (T n, T f, T l, T r, T t, T b, bool o) IMATH_NOEXCEPT
 {
     _nearPlane    = n;
     _farPlane     = f;
@@ -322,7 +322,7 @@ Frustum<T>::set (T n, T f, T l, T r, T t, T b, bool o) noexcept
 
 template <class T>
 inline void
-Frustum<T>::modifyNearAndFar (T n, T f) noexcept
+Frustum<T>::modifyNearAndFar (T n, T f) IMATH_NOEXCEPT
 {
     if (_orthographic)
     {
@@ -352,7 +352,7 @@ Frustum<T>::modifyNearAndFar (T n, T f) noexcept
 
 template <class T>
 inline void
-Frustum<T>::setOrthographic (bool ortho) noexcept
+Frustum<T>::setOrthographic (bool ortho) IMATH_NOEXCEPT
 {
     _orthographic = ortho;
 }
@@ -387,7 +387,7 @@ Frustum<T>::setExc (T nearPlane, T farPlane, T fovx, T fovy, T aspect)
 
 template <class T>
 inline void
-Frustum<T>::set (T nearPlane, T farPlane, T fovx, T fovy, T aspect) noexcept
+Frustum<T>::set (T nearPlane, T farPlane, T fovx, T fovy, T aspect) IMATH_NOEXCEPT
 {
     const T two = static_cast<T> (2);
 
@@ -412,14 +412,14 @@ Frustum<T>::set (T nearPlane, T farPlane, T fovx, T fovy, T aspect) noexcept
 
 template <class T>
 constexpr inline T
-Frustum<T>::fovx() const noexcept
+Frustum<T>::fovx() const IMATH_NOEXCEPT
 {
     return std::atan2 (_right, _nearPlane) - std::atan2 (_left, _nearPlane);
 }
 
 template <class T>
 constexpr inline T
-Frustum<T>::fovy() const noexcept
+Frustum<T>::fovy() const IMATH_NOEXCEPT
 {
     return std::atan2 (_top, _nearPlane) - std::atan2 (_bottom, _nearPlane);
 }
@@ -442,7 +442,7 @@ Frustum<T>::aspectExc() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Frustum<T>::aspect() const noexcept
+Frustum<T>::aspect() const IMATH_NOEXCEPT
 {
     T rightMinusLeft = _right - _left;
     T topMinusBottom = _top - _bottom;
@@ -527,7 +527,7 @@ Frustum<T>::projectionMatrixExc() const
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix44<T>
-Frustum<T>::projectionMatrix() const noexcept
+Frustum<T>::projectionMatrix() const IMATH_NOEXCEPT
 {
     T rightPlusLeft  = _right + _left;
     T rightMinusLeft = _right - _left;
@@ -571,14 +571,14 @@ Frustum<T>::projectionMatrix() const noexcept
 
 template <class T>
 constexpr inline bool
-Frustum<T>::degenerate() const noexcept
+Frustum<T>::degenerate() const IMATH_NOEXCEPT
 {
     return (_nearPlane == _farPlane) || (_left == _right) || (_top == _bottom);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline Frustum<T>
-Frustum<T>::window (T l, T r, T t, T b) const noexcept
+Frustum<T>::window (T l, T r, T t, T b) const IMATH_NOEXCEPT
 {
     // move it to 0->1 space
 
@@ -590,7 +590,7 @@ Frustum<T>::window (T l, T r, T t, T b) const noexcept
 
 template <class T>
 constexpr inline Vec2<T>
-Frustum<T>::screenToLocal (const Vec2<T>& s) const noexcept
+Frustum<T>::screenToLocal (const Vec2<T>& s) const IMATH_NOEXCEPT
 {
     return Vec2<T> (_left + (_right - _left) * (1.f + s.x) / 2.f,
                     _bottom + (_top - _bottom) * (1.f + s.y) / 2.f);
@@ -619,7 +619,7 @@ Frustum<T>::localToScreenExc (const Vec2<T>& p) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline Vec2<T>
-Frustum<T>::localToScreen (const Vec2<T>& p) const noexcept
+Frustum<T>::localToScreen (const Vec2<T>& p) const IMATH_NOEXCEPT
 {
     T leftPlusRight  = _left - T (2) * p.x + _right;
     T leftMinusRight = _left - _right;
@@ -631,7 +631,7 @@ Frustum<T>::localToScreen (const Vec2<T>& p) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline Line3<T>
-Frustum<T>::projectScreenToRay (const Vec2<T>& p) const noexcept
+Frustum<T>::projectScreenToRay (const Vec2<T>& p) const IMATH_NOEXCEPT
 {
     Vec2<T> point = screenToLocal (p);
     if (orthographic())
@@ -653,7 +653,7 @@ Frustum<T>::projectPointToScreenExc (const Vec3<T>& point) const
 
 template <class T>
 IMATH_CONSTEXPR14 Vec2<T>
-Frustum<T>::projectPointToScreen (const Vec3<T>& point) const noexcept
+Frustum<T>::projectPointToScreen (const Vec3<T>& point) const IMATH_NOEXCEPT
 {
     if (orthographic() || point.z == T (0))
         return localToScreen (Vec2<T> (point.x, point.y));
@@ -682,7 +682,7 @@ Frustum<T>::ZToDepthExc (long zval, long zmin, long zmax) const
 
 template <class T>
 IMATH_CONSTEXPR14 T
-Frustum<T>::ZToDepth (long zval, long zmin, long zmax) const noexcept
+Frustum<T>::ZToDepth (long zval, long zmin, long zmax) const IMATH_NOEXCEPT
 {
     int zdiff = zmax - zmin;
 
@@ -721,7 +721,7 @@ Frustum<T>::normalizedZToDepthExc (T zval) const
 
 template <class T>
 IMATH_CONSTEXPR14 T
-Frustum<T>::normalizedZToDepth (T zval) const noexcept
+Frustum<T>::normalizedZToDepth (T zval) const IMATH_NOEXCEPT
 {
     T Zp = zval * T (2) - T (1);
 
@@ -785,7 +785,7 @@ Frustum<T>::DepthToZExc (T depth, long zmin, long zmax) const
 
 template <class T>
 IMATH_CONSTEXPR14 long
-Frustum<T>::DepthToZ (T depth, long zmin, long zmax) const noexcept
+Frustum<T>::DepthToZ (T depth, long zmin, long zmax) const IMATH_NOEXCEPT
 {
     long zdiff     = zmax - zmin;
     T farMinusNear = _farPlane - _nearPlane;
@@ -839,7 +839,7 @@ Frustum<T>::screenRadiusExc (const Vec3<T>& p, T radius) const
 
 template <class T>
 IMATH_CONSTEXPR14 T
-Frustum<T>::screenRadius (const Vec3<T>& p, T radius) const noexcept
+Frustum<T>::screenRadius (const Vec3<T>& p, T radius) const IMATH_NOEXCEPT
 {
     // Derivation:
     // Consider X-Z plane.
@@ -871,14 +871,14 @@ Frustum<T>::worldRadiusExc (const Vec3<T>& p, T radius) const
 
 template <class T>
 IMATH_CONSTEXPR14 T
-Frustum<T>::worldRadius (const Vec3<T>& p, T radius) const noexcept
+Frustum<T>::worldRadius (const Vec3<T>& p, T radius) const IMATH_NOEXCEPT
 {
     return radius * (p.z / -_nearPlane);
 }
 
 template <class T>
 void
-Frustum<T>::planes (Plane3<T> p[6]) const noexcept
+Frustum<T>::planes (Plane3<T> p[6]) const IMATH_NOEXCEPT
 {
     //
     //        Plane order: Top, Right, Bottom, Left, Near, Far.
@@ -911,7 +911,7 @@ Frustum<T>::planes (Plane3<T> p[6]) const noexcept
 
 template <class T>
 void
-Frustum<T>::planes (Plane3<T> p[6], const Matrix44<T>& M) const noexcept
+Frustum<T>::planes (Plane3<T> p[6], const Matrix44<T>& M) const IMATH_NOEXCEPT
 {
     //
     //  Plane order: Top, Right, Bottom, Left, Near, Far.

--- a/src/Imath/ImathFrustumTest.h
+++ b/src/Imath/ImathFrustumTest.h
@@ -89,7 +89,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE FrustumTest
     /// @name Constructors
 
     /// Initialize camera matrix to identity
-    FrustumTest() noexcept
+    FrustumTest() IMATH_NOEXCEPT
     {
         Frustum<T> frust;
         Matrix44<T> cameraMat;
@@ -98,7 +98,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE FrustumTest
     }
 
     /// Initialize to a given frustum and camera matrix.
-    FrustumTest (const Frustum<T>& frustum, const Matrix44<T>& cameraMat) noexcept
+    FrustumTest (const Frustum<T>& frustum, const Matrix44<T>& cameraMat) IMATH_NOEXCEPT
     {
         setFrustum (frustum, cameraMat);
     }
@@ -111,7 +111,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE FrustumTest
     /// Update the frustum test with a new frustum and matrix.
     /// This should usually be called just once per frame, or however
     /// often the camera moves.
-    void setFrustum (const Frustum<T>& frustum, const Matrix44<T>& cameraMat) noexcept;
+    void setFrustum (const Frustum<T>& frustum, const Matrix44<T>& cameraMat) IMATH_NOEXCEPT;
 
     /// @}
 
@@ -120,28 +120,28 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE FrustumTest
     
     /// Return true if any part of the sphere is inside the frustum.
     /// The result MAY return close false-positives, but not false-negatives.
-    bool isVisible (const Sphere3<T>& sphere) const noexcept;
+    bool isVisible (const Sphere3<T>& sphere) const IMATH_NOEXCEPT;
 
     /// Return true if any part of the box is inside the frustum.
     /// The result MAY return close false-positives, but not false-negatives.
-    bool isVisible (const Box<Vec3<T>>& box) const noexcept;
+    bool isVisible (const Box<Vec3<T>>& box) const IMATH_NOEXCEPT;
 
     /// Return true if the point is inside the frustum.
-    bool isVisible (const Vec3<T>& vec) const noexcept;
+    bool isVisible (const Vec3<T>& vec) const IMATH_NOEXCEPT;
 
     /// Return true if every part of the sphere is inside the frustum.
     /// The result MAY return close false-negatives, but not false-positives.
-    bool completelyContains (const Sphere3<T>& sphere) const noexcept;
+    bool completelyContains (const Sphere3<T>& sphere) const IMATH_NOEXCEPT;
 
     /// Return true if every part of the box is inside the frustum.
     /// The result MAY return close false-negatives, but not false-positives.
-    bool completelyContains (const Box<Vec3<T>>& box) const noexcept;
+    bool completelyContains (const Box<Vec3<T>>& box) const IMATH_NOEXCEPT;
 
     /// Return the camera matrix (primarily for debugging)
-    IMATH_INTERNAL_NAMESPACE::Matrix44<T> cameraMat() const noexcept { return cameraMatrix; }
+    IMATH_INTERNAL_NAMESPACE::Matrix44<T> cameraMat() const IMATH_NOEXCEPT { return cameraMatrix; }
 
     /// Return the viewing frustum (primarily for debugging)
-    IMATH_INTERNAL_NAMESPACE::Frustum<T> currentFrustum() const noexcept { return currFrustum; }
+    IMATH_INTERNAL_NAMESPACE::Frustum<T> currentFrustum() const IMATH_NOEXCEPT { return currFrustum; }
 
     /// @}
     
@@ -172,7 +172,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE FrustumTest
 
 template <class T>
 void
-FrustumTest<T>::setFrustum (const Frustum<T>& frustum, const Matrix44<T>& cameraMat) noexcept
+FrustumTest<T>::setFrustum (const Frustum<T>& frustum, const Matrix44<T>& cameraMat) IMATH_NOEXCEPT
 {
     Plane3<T> frustumPlanes[6];
     frustum.planes (frustumPlanes, cameraMat);
@@ -213,7 +213,7 @@ FrustumTest<T>::setFrustum (const Frustum<T>& frustum, const Matrix44<T>& camera
 
 template <typename T>
 bool
-FrustumTest<T>::isVisible (const Sphere3<T>& sphere) const noexcept
+FrustumTest<T>::isVisible (const Sphere3<T>& sphere) const IMATH_NOEXCEPT
 {
     Vec3<T> center    = sphere.center;
     Vec3<T> radiusVec = Vec3<T> (sphere.radius, sphere.radius, sphere.radius);
@@ -236,7 +236,7 @@ FrustumTest<T>::isVisible (const Sphere3<T>& sphere) const noexcept
 
 template <typename T>
 bool
-FrustumTest<T>::completelyContains (const Sphere3<T>& sphere) const noexcept
+FrustumTest<T>::completelyContains (const Sphere3<T>& sphere) const IMATH_NOEXCEPT
 {
     Vec3<T> center    = sphere.center;
     Vec3<T> radiusVec = Vec3<T> (sphere.radius, sphere.radius, sphere.radius);
@@ -259,7 +259,7 @@ FrustumTest<T>::completelyContains (const Sphere3<T>& sphere) const noexcept
 
 template <typename T>
 bool
-FrustumTest<T>::isVisible (const Box<Vec3<T>>& box) const noexcept
+FrustumTest<T>::isVisible (const Box<Vec3<T>>& box) const IMATH_NOEXCEPT
 {
     if (box.isEmpty())
         return false;
@@ -287,7 +287,7 @@ FrustumTest<T>::isVisible (const Box<Vec3<T>>& box) const noexcept
 
 template <typename T>
 bool
-FrustumTest<T>::completelyContains (const Box<Vec3<T>>& box) const noexcept
+FrustumTest<T>::completelyContains (const Box<Vec3<T>>& box) const IMATH_NOEXCEPT
 {
     if (box.isEmpty())
         return false;
@@ -315,7 +315,7 @@ FrustumTest<T>::completelyContains (const Box<Vec3<T>>& box) const noexcept
 
 template <typename T>
 bool
-FrustumTest<T>::isVisible (const Vec3<T>& vec) const noexcept
+FrustumTest<T>::isVisible (const Vec3<T>& vec) const IMATH_NOEXCEPT
 {
     // This is a vertical dot-product on three vectors at once.
     Vec3<T> d0 = (planeNormX[0] * vec.x) + (planeNormY[0] * vec.y) + (planeNormZ[0] * vec.z) -

--- a/src/Imath/ImathFun.cpp
+++ b/src/Imath/ImathFun.cpp
@@ -8,7 +8,7 @@
 IMATH_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 float
-succf (float f) noexcept
+succf (float f) IMATH_NOEXCEPT
 {
     union
     {
@@ -46,7 +46,7 @@ succf (float f) noexcept
 }
 
 float
-predf (float f) noexcept
+predf (float f) IMATH_NOEXCEPT
 {
     union
     {
@@ -84,7 +84,7 @@ predf (float f) noexcept
 }
 
 double
-succd (double d) noexcept
+succd (double d) IMATH_NOEXCEPT
 {
     union
     {
@@ -122,7 +122,7 @@ succd (double d) noexcept
 }
 
 double
-predd (double d) noexcept
+predd (double d) IMATH_NOEXCEPT
 {
     union
     {

--- a/src/Imath/ImathFun.h
+++ b/src/Imath/ImathFun.h
@@ -23,35 +23,35 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline T
-abs (T a) noexcept
+abs (T a) IMATH_NOEXCEPT
 {
     return (a > T (0)) ? a : -a;
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline int
-sign (T a) noexcept
+sign (T a) IMATH_NOEXCEPT
 {
     return (a > T (0)) ? 1 : ((a < T (0)) ? -1 : 0);
 }
 
 template <class T, class Q>
 IMATH_HOSTDEVICE constexpr inline T
-lerp (T a, T b, Q t) noexcept
+lerp (T a, T b, Q t) IMATH_NOEXCEPT
 {
     return (T) (a * (1 - t) + b * t);
 }
 
 template <class T, class Q>
 IMATH_HOSTDEVICE constexpr inline T
-ulerp (T a, T b, Q t) noexcept
+ulerp (T a, T b, Q t) IMATH_NOEXCEPT
 {
     return (T) ((a > b) ? (a - (a - b) * t) : (a + (b - a) * t));
 }
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T
-lerpfactor (T m, T a, T b) noexcept
+lerpfactor (T m, T a, T b) IMATH_NOEXCEPT
 {
     //
     // Return how far m is between a and b, that is return t such that
@@ -74,56 +74,56 @@ lerpfactor (T m, T a, T b) noexcept
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline T
-clamp (T a, T l, T h) noexcept
+clamp (T a, T l, T h) IMATH_NOEXCEPT
 {
     return (a < l) ? l : ((a > h) ? h : a);
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline int
-cmp (T a, T b) noexcept
+cmp (T a, T b) IMATH_NOEXCEPT
 {
     return IMATH_INTERNAL_NAMESPACE::sign (a - b);
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline int
-cmpt (T a, T b, T t) noexcept
+cmpt (T a, T b, T t) IMATH_NOEXCEPT
 {
     return (IMATH_INTERNAL_NAMESPACE::abs (a - b) <= t) ? 0 : cmp (a, b);
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline bool
-iszero (T a, T t) noexcept
+iszero (T a, T t) IMATH_NOEXCEPT
 {
     return (IMATH_INTERNAL_NAMESPACE::abs (a) <= t) ? 1 : 0;
 }
 
 template <class T1, class T2, class T3>
 IMATH_HOSTDEVICE constexpr inline bool
-equal (T1 a, T2 b, T3 t) noexcept
+equal (T1 a, T2 b, T3 t) IMATH_NOEXCEPT
 {
     return IMATH_INTERNAL_NAMESPACE::abs (a - b) <= t;
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline int
-floor (T x) noexcept
+floor (T x) IMATH_NOEXCEPT
 {
     return (x >= 0) ? int (x) : -(int (-x) + (-x > int (-x)));
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline int
-ceil (T x) noexcept
+ceil (T x) IMATH_NOEXCEPT
 {
     return -floor (-x);
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline int
-trunc (T x) noexcept
+trunc (T x) IMATH_NOEXCEPT
 {
     return (x >= 0) ? int (x) : -int (-x);
 }
@@ -137,13 +137,13 @@ trunc (T x) noexcept
 //
 
 IMATH_HOSTDEVICE constexpr inline int
-divs (int x, int y) noexcept
+divs (int x, int y) IMATH_NOEXCEPT
 {
     return (x >= 0) ? ((y >= 0) ? (x / y) : -(x / -y)) : ((y >= 0) ? -(-x / y) : (-x / -y));
 }
 
 IMATH_HOSTDEVICE constexpr inline int
-mods (int x, int y) noexcept
+mods (int x, int y) IMATH_NOEXCEPT
 {
     return (x >= 0) ? ((y >= 0) ? (x % y) : (x % -y)) : ((y >= 0) ? -(-x % y) : -(-x % -y));
 }
@@ -157,14 +157,14 @@ mods (int x, int y) noexcept
 //
 
 IMATH_HOSTDEVICE constexpr inline int
-divp (int x, int y) noexcept
+divp (int x, int y) IMATH_NOEXCEPT
 {
     return (x >= 0) ? ((y >= 0) ? (x / y) : -(x / -y))
                     : ((y >= 0) ? -((y - 1 - x) / y) : ((-y - 1 - x) / -y));
 }
 
 IMATH_HOSTDEVICE constexpr inline int
-modp (int x, int y) noexcept
+modp (int x, int y) IMATH_NOEXCEPT
 {
     return x - y * divp (x, y);
 }
@@ -190,18 +190,18 @@ modp (int x, int y) noexcept
 //
 //----------------------------------------------------------
 
-IMATH_EXPORT float succf (float f) noexcept;
-IMATH_EXPORT float predf (float f) noexcept;
+IMATH_EXPORT float succf (float f) IMATH_NOEXCEPT;
+IMATH_EXPORT float predf (float f) IMATH_NOEXCEPT;
 
-IMATH_EXPORT double succd (double d) noexcept;
-IMATH_EXPORT double predd (double d) noexcept;
+IMATH_EXPORT double succd (double d) IMATH_NOEXCEPT;
+IMATH_EXPORT double predd (double d) IMATH_NOEXCEPT;
 
 //
 // Return true if the number is not a NaN or Infinity.
 //
 
 inline bool IMATH_HOSTDEVICE
-finitef (float f) noexcept
+finitef (float f) IMATH_NOEXCEPT
 {
     union
     {
@@ -214,7 +214,7 @@ finitef (float f) noexcept
 }
 
 inline bool IMATH_HOSTDEVICE
-finited (double d) noexcept
+finited (double d) IMATH_NOEXCEPT
 {
     union
     {

--- a/src/Imath/ImathInterval.h
+++ b/src/Imath/ImathInterval.h
@@ -41,13 +41,13 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Interval
     /// @name Constructors
 
     /// Initialize to the empty interval
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Interval() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Interval() IMATH_NOEXCEPT;
 
     /// Intitialize to a single point
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Interval (const T& point) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Interval (const T& point) IMATH_NOEXCEPT;
 
     /// Intitialize to a given (min,max)
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Interval (const T& minT, const T& maxT) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Interval (const T& minT, const T& maxT) IMATH_NOEXCEPT;
 
     /// @}
 
@@ -55,9 +55,9 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Interval
     /// @name Comparison
 
     /// Equality
-    IMATH_HOSTDEVICE constexpr bool operator== (const Interval<T>& src) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Interval<T>& src) const IMATH_NOEXCEPT;
     /// Inequality
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Interval<T>& src) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Interval<T>& src) const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -66,16 +66,16 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Interval
 
     /// Set the interval to be empty. An interval is empty if the
     /// minimum is greater than the maximum.
-    IMATH_HOSTDEVICE void makeEmpty() noexcept;
+    IMATH_HOSTDEVICE void makeEmpty() IMATH_NOEXCEPT;
 
     /// Extend the interval to include the given point.
-    IMATH_HOSTDEVICE void extendBy (const T& point) noexcept;
+    IMATH_HOSTDEVICE void extendBy (const T& point) IMATH_NOEXCEPT;
 
     /// Extend the interval to include the given interval
-    IMATH_HOSTDEVICE void extendBy (const Interval<T>& interval) noexcept;
+    IMATH_HOSTDEVICE void extendBy (const Interval<T>& interval) IMATH_NOEXCEPT;
 
     /// Make the interval include the entire range of the base type.
-    IMATH_HOSTDEVICE void makeInfinite() noexcept;
+    IMATH_HOSTDEVICE void makeInfinite() IMATH_NOEXCEPT;
 
     /// @}
 
@@ -83,30 +83,30 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Interval
     ///	@name Query
 
     /// Return the size of the interval. The size is (max-min). An empty box has a size of 0.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T size() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T size() const IMATH_NOEXCEPT;
 
     /// Return the center of the interval. The center is defined as
     /// (max+min)/2. The center of an empty interval is undefined.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T center() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T center() const IMATH_NOEXCEPT;
 
     /// Return true if the given point is inside the interval, false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const T& point) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const T& point) const IMATH_NOEXCEPT;
 
     /// Return true if the given interval is inside the interval, false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Interval<T>& interval) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersects (const Interval<T>& interval) const IMATH_NOEXCEPT;
 
     /// Return true if the interval is empty, false otherwise. An
     /// empty interval's minimum is greater than its maximum.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isEmpty() const IMATH_NOEXCEPT;
 
     /// Return true if the interval is larger than a single point,
     /// false otherwise.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool hasVolume() const IMATH_NOEXCEPT;
 
     /// Return true if the interval contains all points, false
     /// otherwise.  An infinite box has a mimimum of `numeric_limits<T>::lowest()`
     /// and a maximum of `numeric_limits<T>::max()`
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool isInfinite() const IMATH_NOEXCEPT;
 
     /// @}
 };
@@ -126,18 +126,18 @@ typedef Interval<short> Intervals;
 /// Interval of type integer
 typedef Interval<int> Intervali;
 
-template <class T> inline IMATH_CONSTEXPR14 Interval<T>::Interval() noexcept
+template <class T> inline IMATH_CONSTEXPR14 Interval<T>::Interval() IMATH_NOEXCEPT
 {
     makeEmpty();
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Interval<T>::Interval (const T& point) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Interval<T>::Interval (const T& point) IMATH_NOEXCEPT
 {
     min = point;
     max = point;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Interval<T>::Interval (const T& minV, const T& maxV) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Interval<T>::Interval (const T& minV, const T& maxV) IMATH_NOEXCEPT
 {
     min = minV;
     max = maxV;
@@ -145,21 +145,21 @@ template <class T> IMATH_CONSTEXPR14 inline Interval<T>::Interval (const T& minV
 
 template <class T>
 constexpr inline bool
-Interval<T>::operator== (const Interval<T>& src) const noexcept
+Interval<T>::operator== (const Interval<T>& src) const IMATH_NOEXCEPT
 {
     return (min == src.min && max == src.max);
 }
 
 template <class T>
 constexpr inline bool
-Interval<T>::operator!= (const Interval<T>& src) const noexcept
+Interval<T>::operator!= (const Interval<T>& src) const IMATH_NOEXCEPT
 {
     return (min != src.min || max != src.max);
 }
 
 template <class T>
 inline void
-Interval<T>::makeEmpty() noexcept
+Interval<T>::makeEmpty() IMATH_NOEXCEPT
 {
     min = std::numeric_limits<T>::max();
     max = std::numeric_limits<T>::lowest();
@@ -167,7 +167,7 @@ Interval<T>::makeEmpty() noexcept
 
 template <class T>
 inline void
-Interval<T>::makeInfinite() noexcept
+Interval<T>::makeInfinite() IMATH_NOEXCEPT
 {
     min = std::numeric_limits<T>::lowest();
     max = std::numeric_limits<T>::max();
@@ -176,7 +176,7 @@ Interval<T>::makeInfinite() noexcept
 
 template <class T>
 inline void
-Interval<T>::extendBy (const T& point) noexcept
+Interval<T>::extendBy (const T& point) IMATH_NOEXCEPT
 {
     if (point < min)
         min = point;
@@ -187,7 +187,7 @@ Interval<T>::extendBy (const T& point) noexcept
 
 template <class T>
 inline void
-Interval<T>::extendBy (const Interval<T>& interval) noexcept
+Interval<T>::extendBy (const Interval<T>& interval) IMATH_NOEXCEPT
 {
     if (interval.min < min)
         min = interval.min;
@@ -198,21 +198,21 @@ Interval<T>::extendBy (const Interval<T>& interval) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Interval<T>::intersects (const T& point) const noexcept
+Interval<T>::intersects (const T& point) const IMATH_NOEXCEPT
 {
     return point >= min && point <= max;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Interval<T>::intersects (const Interval<T>& interval) const noexcept
+Interval<T>::intersects (const Interval<T>& interval) const IMATH_NOEXCEPT
 {
     return interval.max >= min && interval.min <= max;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Interval<T>::size() const noexcept
+Interval<T>::size() const IMATH_NOEXCEPT
 {
     if (isEmpty())
         return T(0);
@@ -222,28 +222,28 @@ Interval<T>::size() const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Interval<T>::center() const noexcept
+Interval<T>::center() const IMATH_NOEXCEPT
 {
     return (max + min) / 2;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Interval<T>::isEmpty() const noexcept
+Interval<T>::isEmpty() const IMATH_NOEXCEPT
 {
     return max < min;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Interval<T>::hasVolume() const noexcept
+Interval<T>::hasVolume() const IMATH_NOEXCEPT
 {
     return max > min;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Interval<T>::isInfinite() const noexcept
+Interval<T>::isInfinite() const IMATH_NOEXCEPT
 {
     if (min != std::numeric_limits<T>::lowest() || max != std::numeric_limits<T>::max())
         return false;

--- a/src/Imath/ImathLine.h
+++ b/src/Imath/ImathLine.h
@@ -40,11 +40,11 @@ template <class T> class Line3
     ///	@name Constructors
 
     /// Uninitialized by default
-    IMATH_HOSTDEVICE constexpr Line3() noexcept {}
+    IMATH_HOSTDEVICE constexpr Line3() IMATH_NOEXCEPT {}
 
     /// Initialize with two points. The direction is the difference
     /// between the points.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Line3 (const Vec3<T>& point1, const Vec3<T>& point2) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Line3 (const Vec3<T>& point1, const Vec3<T>& point2) IMATH_NOEXCEPT;
 
     /// @}
     
@@ -53,7 +53,7 @@ template <class T> class Line3
     
     /// Set the line defined by two points. The direction is the difference
     /// between the points.
-    IMATH_HOSTDEVICE void set (const Vec3<T>& point1, const Vec3<T>& point2) noexcept;
+    IMATH_HOSTDEVICE void set (const Vec3<T>& point1, const Vec3<T>& point2) IMATH_NOEXCEPT;
 
     /// @}
 
@@ -62,18 +62,18 @@ template <class T> class Line3
     
     /// Return the point on the line at the given parameter value,
     ///	e.g. L(t)
-    IMATH_HOSTDEVICE constexpr Vec3<T> operator() (T parameter) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3<T> operator() (T parameter) const IMATH_NOEXCEPT;
 
     /// Return the distance to the given point
-    IMATH_HOSTDEVICE constexpr T distanceTo (const Vec3<T>& point) const noexcept;
+    IMATH_HOSTDEVICE constexpr T distanceTo (const Vec3<T>& point) const IMATH_NOEXCEPT;
     /// Return the distance to the given line
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T distanceTo (const Line3<T>& line) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T distanceTo (const Line3<T>& line) const IMATH_NOEXCEPT;
 
     /// Return the point on the line closest to the given point
-    IMATH_HOSTDEVICE constexpr Vec3<T> closestPointTo (const Vec3<T>& point) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3<T> closestPointTo (const Vec3<T>& point) const IMATH_NOEXCEPT;
 
     /// Return the point on the line closest to the given line
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T> closestPointTo (const Line3<T>& line) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T> closestPointTo (const Line3<T>& line) const IMATH_NOEXCEPT;
 
     /// @}
 };
@@ -84,14 +84,14 @@ typedef Line3<float> Line3f;
 /// Line of type double
 typedef Line3<double> Line3d;
 
-template <class T> IMATH_CONSTEXPR14 inline Line3<T>::Line3 (const Vec3<T>& p0, const Vec3<T>& p1) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Line3<T>::Line3 (const Vec3<T>& p0, const Vec3<T>& p1) IMATH_NOEXCEPT
 {
     set (p0, p1);
 }
 
 template <class T>
 inline void
-Line3<T>::set (const Vec3<T>& p0, const Vec3<T>& p1) noexcept
+Line3<T>::set (const Vec3<T>& p0, const Vec3<T>& p1) IMATH_NOEXCEPT
 {
     pos = p0;
     dir = p1 - p0;
@@ -100,28 +100,28 @@ Line3<T>::set (const Vec3<T>& p0, const Vec3<T>& p1) noexcept
 
 template <class T>
 constexpr inline Vec3<T>
-Line3<T>::operator() (T parameter) const noexcept
+Line3<T>::operator() (T parameter) const IMATH_NOEXCEPT
 {
     return pos + dir * parameter;
 }
 
 template <class T>
 constexpr inline T
-Line3<T>::distanceTo (const Vec3<T>& point) const noexcept
+Line3<T>::distanceTo (const Vec3<T>& point) const IMATH_NOEXCEPT
 {
     return (closestPointTo (point) - point).length();
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Line3<T>::closestPointTo (const Vec3<T>& point) const noexcept
+Line3<T>::closestPointTo (const Vec3<T>& point) const IMATH_NOEXCEPT
 {
     return ((point - pos) ^ dir) * dir + pos;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Line3<T>::distanceTo (const Line3<T>& line) const noexcept
+Line3<T>::distanceTo (const Line3<T>& line) const IMATH_NOEXCEPT
 {
     T d = (dir % line.dir) ^ (line.pos - pos);
     return (d >= 0) ? d : -d;
@@ -129,7 +129,7 @@ Line3<T>::distanceTo (const Line3<T>& line) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline Vec3<T>
-Line3<T>::closestPointTo (const Line3<T>& line) const noexcept
+Line3<T>::closestPointTo (const Line3<T>& line) const IMATH_NOEXCEPT
 {
     // Assumes the lines are normalized
 
@@ -165,7 +165,7 @@ operator<< (std::ostream& o, const Line3<T>& line)
 /// Transform a line by a matrix
 template <class S, class T>
 constexpr inline Line3<S>
-operator* (const Line3<S>& line, const Matrix44<T>& M) noexcept
+operator* (const Line3<S>& line, const Matrix44<T>& M) IMATH_NOEXCEPT
 {
     return Line3<S> (line.pos * M, (line.pos + line.dir) * M);
 }

--- a/src/Imath/ImathLineAlgo.h
+++ b/src/Imath/ImathLineAlgo.h
@@ -28,7 +28,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 template <class T>
 IMATH_CONSTEXPR14 bool
-closestPoints (const Line3<T>& line1, const Line3<T>& line2, Vec3<T>& point1, Vec3<T>& point2) noexcept
+closestPoints (const Line3<T>& line1, const Line3<T>& line2, Vec3<T>& point1, Vec3<T>& point2) IMATH_NOEXCEPT
 {
     Vec3<T> w = line1.pos - line2.pos;
     T d1w     = line1.dir ^ w;
@@ -83,7 +83,7 @@ intersect (const Line3<T>& line,
            const Vec3<T>& v2,
            Vec3<T>& pt,
            Vec3<T>& barycentric,
-           bool& front) noexcept
+           bool& front) IMATH_NOEXCEPT
 {
     Vec3<T> edge0  = v1 - v0;
     Vec3<T> edge1  = v2 - v1;
@@ -161,7 +161,7 @@ intersect (const Line3<T>& line,
 
 template <class T>
 IMATH_CONSTEXPR14 Vec3<T>
-closestVertex (const Vec3<T>& v0, const Vec3<T>& v1, const Vec3<T>& v2, const Line3<T>& l) noexcept
+closestVertex (const Vec3<T>& v0, const Vec3<T>& v1, const Vec3<T>& v2, const Line3<T>& l) IMATH_NOEXCEPT
 {
     Vec3<T> nearest = v0;
     T neardot       = (v0 - l.closestPointTo (v0)).length2();
@@ -190,7 +190,7 @@ closestVertex (const Vec3<T>& v0, const Vec3<T>& v1, const Vec3<T>& v2, const Li
 
 template <class T>
 IMATH_CONSTEXPR14 Vec3<T>
-rotatePoint (const Vec3<T> p, Line3<T> l, T angle) noexcept
+rotatePoint (const Vec3<T> p, Line3<T> l, T angle) IMATH_NOEXCEPT
 {
     //
     // Form a coordinate frame with <x,y,a>. The rotation is the in xy

--- a/src/Imath/ImathMath.h
+++ b/src/Imath/ImathMath.h
@@ -128,7 +128,7 @@ sinx_over_x (T x)
 ///	abs (x1 - x2) <= e
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
-equalWithAbsError (T x1, T x2, T e) noexcept
+equalWithAbsError (T x1, T x2, T e) IMATH_NOEXCEPT
 {
     return ((x1 > x2) ? x1 - x2 : x2 - x1) <= e;
 }
@@ -141,7 +141,7 @@ equalWithAbsError (T x1, T x2, T e) noexcept
 /// abs (x1 - x2) <= e * x1
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
-equalWithRelError (T x1, T x2, T e) noexcept
+equalWithRelError (T x1, T x2, T e) IMATH_NOEXCEPT
 {
     return ((x1 > x2) ? x1 - x2 : x2 - x1) <= e * ((x1 > 0) ? x1 : -x1);
 }

--- a/src/Imath/ImathMatrix.h
+++ b/src/Imath/ImathMatrix.h
@@ -55,55 +55,55 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix22
     /// @}
     
     /// Row access
-    IMATH_HOSTDEVICE T* operator[] (int i) noexcept;
+    IMATH_HOSTDEVICE T* operator[] (int i) IMATH_NOEXCEPT;
 
     /// Row access
-    IMATH_HOSTDEVICE const T* operator[] (int i) const noexcept;
+    IMATH_HOSTDEVICE const T* operator[] (int i) const IMATH_NOEXCEPT;
 
     /// @{
     ///	@name Constructors and Assignment
 
     /// Uninitialized
-    IMATH_HOSTDEVICE Matrix22 (Uninitialized) noexcept {}
+    IMATH_HOSTDEVICE Matrix22 (Uninitialized) IMATH_NOEXCEPT {}
 
     /// Default constructor: initialize to identity
     ///
     ///   1 0
     ///   0 1
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22() IMATH_NOEXCEPT;
 
     /// Initialize to scalar constant:
     ///
     ///   a a
     ///   a a
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (T a) IMATH_NOEXCEPT;
 
     /// Construct from 2x2 array:
     ///
     ///   a[0][0] a[0][1]
     ///   a[1][0] a[1][1]
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (const T a[2][2]) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (const T a[2][2]) IMATH_NOEXCEPT;
 
     /// Construct from given scalar values:
     ///
     ///   a b
     ///   c d
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (T a, T b, T c, T d) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (T a, T b, T c, T d) IMATH_NOEXCEPT;
 
     /// Copy constructor
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (const Matrix22& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (const Matrix22& v) IMATH_NOEXCEPT;
 
     /// Construct from Matrix22 of another base type
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix22 (const Matrix22<S>& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix22 (const Matrix22<S>& v) IMATH_NOEXCEPT;
 
     /// Assignment
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator= (const Matrix22& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator= (const Matrix22& v) IMATH_NOEXCEPT;
 
     /// Assignment from scalar
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator= (T a) IMATH_NOEXCEPT;
 
     /// Destructor
-    ~Matrix22() noexcept = default;
+    ~Matrix22() IMATH_NOEXCEPT = default;
 
     /// @}
 
@@ -140,20 +140,20 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix22
     /// @name Compatibility with Sb
 
     /// Return a raw pointer to the array of values
-    IMATH_HOSTDEVICE T* getValue() noexcept;
+    IMATH_HOSTDEVICE T* getValue() IMATH_NOEXCEPT;
 
     /// Return a raw pointer to the array of values
-    IMATH_HOSTDEVICE const T* getValue() const noexcept;
+    IMATH_HOSTDEVICE const T* getValue() const IMATH_NOEXCEPT;
 
     /// Return the value in `v`
-    template <class S> IMATH_HOSTDEVICE void getValue (Matrix22<S>& v) const noexcept;
+    template <class S> IMATH_HOSTDEVICE void getValue (Matrix22<S>& v) const IMATH_NOEXCEPT;
 
     /// Set the value
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22& setValue (const Matrix22<S>& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22& setValue (const Matrix22<S>& v) IMATH_NOEXCEPT;
 
     /// Set the value
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22& setTheMatrix (const Matrix22<S>& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22& setTheMatrix (const Matrix22<S>& v) IMATH_NOEXCEPT;
 
     /// @}
 
@@ -161,71 +161,71 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix22
     /// @name Arithmetic and Comparison
     
     /// Equality
-    IMATH_HOSTDEVICE constexpr bool operator== (const Matrix22& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Matrix22& v) const IMATH_NOEXCEPT;
 
     /// Inequality
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Matrix22& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Matrix22& v) const IMATH_NOEXCEPT;
 
     /// Compare two matrices and test if they are "approximately equal":
     /// @return True if the coefficients of this and `m` are the same
     /// with an absolute error of no more than e, i.e., for all i, j:
     ///
     ///   abs (this[i][j] - m[i][j]) <= e
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Matrix22<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Matrix22<T>& v, T e) const IMATH_NOEXCEPT;
 
     /// Compare two matrices and test if they are "approximately equal":
     /// @return True if the coefficients of this and m are the same with
     /// a relative error of no more than e, i.e., for all i, j:
     ///
     ///   abs (this[i] - v[i][j]) <= e * abs (this[i][j])
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Matrix22<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Matrix22<T>& v, T e) const IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator+= (const Matrix22& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator+= (const Matrix22& v) IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator+= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator+= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE constexpr Matrix22 operator+ (const Matrix22& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix22 operator+ (const Matrix22& v) const IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator-= (const Matrix22& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator-= (const Matrix22& v) IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator-= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator-= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE constexpr Matrix22 operator- (const Matrix22& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix22 operator- (const Matrix22& v) const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE constexpr Matrix22 operator-() const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix22 operator-() const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& negate() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& negate() IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator*= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator*= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE constexpr Matrix22 operator* (T a) const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix22 operator* (T a) const IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator/= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator/= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE constexpr Matrix22 operator/ (T a) const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix22 operator/ (T a) const IMATH_NOEXCEPT;
 
     /// Matrix-matrix multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator*= (const Matrix22& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& operator*= (const Matrix22& v) IMATH_NOEXCEPT;
 
     /// Matrix-matrix multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 operator* (const Matrix22& v) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 operator* (const Matrix22& v) const IMATH_NOEXCEPT;
 
     /// Vector * matrix multiplication
     /// @param[in] src Input vector
     /// @param[out] dst transformed vector
-    template <class S> IMATH_HOSTDEVICE void multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept;
+    template <class S> IMATH_HOSTDEVICE void multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -233,13 +233,13 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix22
     /// @name Maniplation
 
     /// Set to the identity
-    IMATH_HOSTDEVICE void makeIdentity() noexcept;
+    IMATH_HOSTDEVICE void makeIdentity() IMATH_NOEXCEPT;
 
     /// Transpose
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& transpose() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& transpose() IMATH_NOEXCEPT;
 
     /// Return the transpose
-    IMATH_HOSTDEVICE constexpr Matrix22 transposed() const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix22 transposed() const IMATH_NOEXCEPT;
 
     /// Invert in place
     /// @param singExc If true, throw an exception if the matrix cannot be inverted.
@@ -248,38 +248,38 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix22
 
     /// Invert in place
     /// @return const reference to this
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& invert() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& invert() IMATH_NOEXCEPT;
 
     /// Return the inverse, leaving this unmodified.
     /// @param singExc If true, throw an exception if the matrix cannot be inverted.
     IMATH_CONSTEXPR14 Matrix22<T> inverse (bool singExc) const;
 
     /// Return the inverse, leaving this unmodified.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22<T> inverse() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22<T> inverse() const IMATH_NOEXCEPT;
 
     /// Determinant
-    IMATH_HOSTDEVICE constexpr T determinant() const noexcept;
+    IMATH_HOSTDEVICE constexpr T determinant() const IMATH_NOEXCEPT;
 
     /// Set matrix to rotation by r (in radians)
     /// @return const referenced to this
-    template <class S> IMATH_HOSTDEVICE const Matrix22& setRotation (S r) noexcept;
+    template <class S> IMATH_HOSTDEVICE const Matrix22& setRotation (S r) IMATH_NOEXCEPT;
 
     /// Rotate the given matrix by r (in radians)
     /// @return const referenced to this
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& rotate (S r) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& rotate (S r) IMATH_NOEXCEPT;
 
     /// Set matrix to scale by given uniform factor
     /// @return const referenced to this
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& setScale (T s) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& setScale (T s) IMATH_NOEXCEPT;
 
     /// Set matrix to scale by given vector
     /// @return const referenced to this
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& setScale (const Vec2<S>& s) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& setScale (const Vec2<S>& s) IMATH_NOEXCEPT;
 
     // Scale the matrix by s
     /// @return const referenced to this
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& scale (const Vec2<S>& s) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix22& scale (const Vec2<S>& s) IMATH_NOEXCEPT;
 
     /// @}
     
@@ -287,21 +287,21 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix22
     /// @name Numeric Limits
     
     /// Largest possible negative value
-    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() noexcept { return std::numeric_limits<T>::lowest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() IMATH_NOEXCEPT { return std::numeric_limits<T>::lowest(); }
 
     /// Largest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return std::numeric_limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() IMATH_NOEXCEPT { return std::numeric_limits<T>::max(); }
 
     /// Smallest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return std::numeric_limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() IMATH_NOEXCEPT { return std::numeric_limits<T>::min(); }
 
     /// Smallest possible e for which 1+e != 1
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return std::numeric_limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() IMATH_NOEXCEPT { return std::numeric_limits<T>::epsilon(); }
 
     /// @}
     
     /// Return the number of the row and column dimensions, i.e. 2.
-    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() noexcept { return 2; }
+    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() IMATH_NOEXCEPT { return 2; }
 
     /// The base type: In templates that accept a parameter `V`, you
     /// can refer to `T` as `V::BaseType`
@@ -328,55 +328,55 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix33
     /// @}
     
     /// Row access
-    IMATH_HOSTDEVICE T* operator[] (int i) noexcept;
+    IMATH_HOSTDEVICE T* operator[] (int i) IMATH_NOEXCEPT;
 
     /// Row access
-    IMATH_HOSTDEVICE const T* operator[] (int i) const noexcept;
+    IMATH_HOSTDEVICE const T* operator[] (int i) const IMATH_NOEXCEPT;
 
     /// @{
     ///	@name Constructors and Assignment
 
     /// Uninitialized
-    IMATH_HOSTDEVICE Matrix33 (Uninitialized) noexcept {}
+    IMATH_HOSTDEVICE Matrix33 (Uninitialized) IMATH_NOEXCEPT {}
 
     /// Default constructor: initialize to identity
     ///   1 0 0
     ///   0 1 0
     ///   0 0 1
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33() IMATH_NOEXCEPT;
 
     /// Initialize to scalar constant
     ///   a a a
     ///   a a a
     ///   a a a
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (T a) IMATH_NOEXCEPT;
 
     /// Construct from 3x3 array 
     ///   a[0][0] a[0][1] a[0][2]
     ///   a[1][0] a[1][1] a[1][2]
     ///   a[2][0] a[2][1] a[2][2]
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (const T a[3][3]) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (const T a[3][3]) IMATH_NOEXCEPT;
 
     /// Construct from given scalar values
     ///   a b c
     ///   d e f
     ///   g h i
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (T a, T b, T c, T d, T e, T f, T g, T h, T i) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (T a, T b, T c, T d, T e, T f, T g, T h, T i) IMATH_NOEXCEPT;
 
     /// Copy constructor
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (const Matrix33& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (const Matrix33& v) IMATH_NOEXCEPT;
 
     /// Construct from Matrix33 of another base type
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix33 (const Matrix33<S>& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix33 (const Matrix33<S>& v) IMATH_NOEXCEPT;
 
     /// Assignment operator
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator= (const Matrix33& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator= (const Matrix33& v) IMATH_NOEXCEPT;
 
     /// Assignment from scalar
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator= (T a) IMATH_NOEXCEPT;
 
     /// Destructor
-    ~Matrix33() noexcept = default;
+    ~Matrix33() IMATH_NOEXCEPT = default;
 
     /// @}
 
@@ -419,20 +419,20 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix33
     /// @name Compatibility with Sb
 
     /// Return a raw pointer to the array of values
-    IMATH_HOSTDEVICE T* getValue() noexcept;
+    IMATH_HOSTDEVICE T* getValue() IMATH_NOEXCEPT;
 
     /// Return a raw pointer to the array of values
-    IMATH_HOSTDEVICE const T* getValue() const noexcept;
+    IMATH_HOSTDEVICE const T* getValue() const IMATH_NOEXCEPT;
 
     /// Return the value in `v`
-    template <class S> IMATH_HOSTDEVICE void getValue (Matrix33<S>& v) const noexcept;
+    template <class S> IMATH_HOSTDEVICE void getValue (Matrix33<S>& v) const IMATH_NOEXCEPT;
 
     /// Set the value
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33& setValue (const Matrix33<S>& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33& setValue (const Matrix33<S>& v) IMATH_NOEXCEPT;
 
     /// Set the value
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33& setTheMatrix (const Matrix33<S>& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33& setTheMatrix (const Matrix33<S>& v) IMATH_NOEXCEPT;
 
     /// @}
     
@@ -440,79 +440,79 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix33
     /// @name Arithmetic and Comparison
     
     /// Equality
-    IMATH_HOSTDEVICE constexpr bool operator== (const Matrix33& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Matrix33& v) const IMATH_NOEXCEPT;
 
     /// Inequality
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Matrix33& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Matrix33& v) const IMATH_NOEXCEPT;
 
     /// Compare two matrices and test if they are "approximately equal":
     /// @return True if the coefficients of this and `m` are the same
     /// with an absolute error of no more than e, i.e., for all i, j:
     ///
     ///   abs (this[i][j] - m[i][j]) <= e
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Matrix33<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Matrix33<T>& v, T e) const IMATH_NOEXCEPT;
 
     /// Compare two matrices and test if they are "approximately equal":
     /// @return True if the coefficients of this and m are the same with
     /// a relative error of no more than e, i.e., for all i, j:
     ///
     ///   abs (this[i] - v[i][j]) <= e * abs (this[i][j])
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Matrix33<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Matrix33<T>& v, T e) const IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator+= (const Matrix33& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator+= (const Matrix33& v) IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator+= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator+= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE constexpr Matrix33 operator+ (const Matrix33& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix33 operator+ (const Matrix33& v) const IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator-= (const Matrix33& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator-= (const Matrix33& v) IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator-= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator-= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE constexpr Matrix33 operator- (const Matrix33& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix33 operator- (const Matrix33& v) const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE constexpr Matrix33 operator-() const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix33 operator-() const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& negate() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& negate() IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator*= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator*= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE constexpr Matrix33 operator* (T a) const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix33 operator* (T a) const IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator/= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator/= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE constexpr Matrix33 operator/ (T a) const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix33 operator/ (T a) const IMATH_NOEXCEPT;
 
     /// Matrix-matrix multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator*= (const Matrix33& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& operator*= (const Matrix33& v) IMATH_NOEXCEPT;
 
     /// Matrix-matrix multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 operator* (const Matrix33& v) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 operator* (const Matrix33& v) const IMATH_NOEXCEPT;
 
     /// Vector-matrix multiplication: a homogeneous transformation
     /// by computing Vec3 (src.x, src.y, 1) * m and dividing by the
     /// result's third element.
     /// @param[in] src The input vector
     /// @param[out] dst The output vector
-    template <class S> IMATH_HOSTDEVICE void multVecMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept;
+    template <class S> IMATH_HOSTDEVICE void multVecMatrix (const Vec2<S>& src, Vec2<S>& dst) const IMATH_NOEXCEPT;
 
     /// Vector-matrix multiplication: multiply `src` by the upper left 2x2
     /// submatrix, ignoring the rest of matrix.
     /// @param[in] src The input vector
     /// @param[out] dst The output vector
-    template <class S> IMATH_HOSTDEVICE void multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept;
+    template <class S> IMATH_HOSTDEVICE void multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -520,13 +520,13 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix33
     /// @name Maniplation
 
     /// Set to the identity matrix
-    IMATH_HOSTDEVICE void makeIdentity() noexcept;
+    IMATH_HOSTDEVICE void makeIdentity() IMATH_NOEXCEPT;
 
     /// Transpose
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& transpose() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& transpose() IMATH_NOEXCEPT;
 
     /// Return the transpose
-    IMATH_HOSTDEVICE constexpr Matrix33 transposed() const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix33 transposed() const IMATH_NOEXCEPT;
 
     /// Invert in place using the determinant.
     /// @param singExc If true, throw an exception if the matrix cannot be inverted.
@@ -535,14 +535,14 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix33
 
     /// Invert in place using the determinant.
     /// @return const reference to this
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& invert() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& invert() IMATH_NOEXCEPT;
 
     /// Return the inverse using the determinant, leaving this unmodified.
     /// @param singExc If true, throw an exception if the matrix cannot be inverted.
     IMATH_CONSTEXPR14 Matrix33<T> inverse (bool singExc) const;
 
     /// Return the inverse using the determinant, leaving this unmodified.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33<T> inverse() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33<T> inverse() const IMATH_NOEXCEPT;
 
     /// Invert in place using the Gauss-Jordan method. Significantly slower
     /// but more accurate than invert().
@@ -553,7 +553,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix33
     /// Invert in place using the Gauss-Jordan method. Significantly slower
     /// but more accurate than invert().
     /// @return const reference to this
-    IMATH_HOSTDEVICE const Matrix33& gjInvert() noexcept;
+    IMATH_HOSTDEVICE const Matrix33& gjInvert() IMATH_NOEXCEPT;
 
     /// Return the inverse using the Gauss-Jordan method, leaving this
     /// unmodified. Significantly slower but more accurate than inverse().
@@ -561,70 +561,70 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix33
 
     /// Return the inverse using the Gauss-Jordan method. Significantly slower,
     /// leaving this unmodified. Slower but more accurate than inverse().
-    IMATH_HOSTDEVICE Matrix33<T> gjInverse() const noexcept;
+    IMATH_HOSTDEVICE Matrix33<T> gjInverse() const IMATH_NOEXCEPT;
 
     /// Calculate the matrix minor of the (r,c) element
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T minorOf (const int r, const int c) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T minorOf (const int r, const int c) const IMATH_NOEXCEPT;
 
     /// Build a minor using the specified rows and columns
     IMATH_HOSTDEVICE
-    constexpr T fastMinor (const int r0, const int r1, const int c0, const int c1) const noexcept;
+    constexpr T fastMinor (const int r0, const int r1, const int c0, const int c1) const IMATH_NOEXCEPT;
 
     /// Determinant
-    IMATH_HOSTDEVICE constexpr T determinant() const noexcept;
+    IMATH_HOSTDEVICE constexpr T determinant() const IMATH_NOEXCEPT;
 
     /// Set matrix to rotation by r (in radians)
     /// @return const referenced to this
-    template <class S> IMATH_HOSTDEVICE const Matrix33& setRotation (S r) noexcept;
+    template <class S> IMATH_HOSTDEVICE const Matrix33& setRotation (S r) IMATH_NOEXCEPT;
 
     // Rotate the given matrix by r (in radians)
     /// @return const referenced to this
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& rotate (S r) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& rotate (S r) IMATH_NOEXCEPT;
 
     /// Set matrix to scale by given uniform factor
     /// @return const referenced to this
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setScale (T s) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setScale (T s) IMATH_NOEXCEPT;
 
     /// Set matrix to scale by given vector
     /// @return const referenced to this
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setScale (const Vec2<S>& s) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setScale (const Vec2<S>& s) IMATH_NOEXCEPT;
 
     /// Scale the matrix by s
     /// @return const referenced to this
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& scale (const Vec2<S>& s) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& scale (const Vec2<S>& s) IMATH_NOEXCEPT;
 
     /// Set matrix to translation by given vector
     /// @return const referenced to this
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setTranslation (const Vec2<S>& t) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setTranslation (const Vec2<S>& t) IMATH_NOEXCEPT;
 
     /// Return the translation component
-    IMATH_HOSTDEVICE constexpr Vec2<T> translation() const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2<T> translation() const IMATH_NOEXCEPT;
 
     /// Translate the matrix by t
     /// @return const referenced to this
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& translate (const Vec2<S>& t) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& translate (const Vec2<S>& t) IMATH_NOEXCEPT;
 
     /// Set matrix to shear x for each y coord. by given factor xy
     /// @return const referenced to this
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setShear (const S& h) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setShear (const S& h) IMATH_NOEXCEPT;
 
     /// Set matrix to shear x for each y coord. by given factor h[0]
     /// and to shear y for each x coord. by given factor h[1]
     /// @return const referenced to this
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setShear (const Vec2<S>& h) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& setShear (const Vec2<S>& h) IMATH_NOEXCEPT;
 
     /// Shear the matrix in x for each y coord. by given factor xy
     /// @return const referenced to this
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& shear (const S& xy) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& shear (const S& xy) IMATH_NOEXCEPT;
 
     /// Shear the matrix in x for each y coord. by given factor xy
     /// and shear y for each x coord. by given factor yx
     /// @return const referenced to this
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& shear (const Vec2<S>& h) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix33& shear (const Vec2<S>& h) IMATH_NOEXCEPT;
 
     /// @}
     
@@ -632,21 +632,21 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix33
     /// @name Numeric Limits
     
     /// Largest possible negative value
-    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() noexcept { return std::numeric_limits<T>::lowest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() IMATH_NOEXCEPT { return std::numeric_limits<T>::lowest(); }
 
     /// Largest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return std::numeric_limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() IMATH_NOEXCEPT { return std::numeric_limits<T>::max(); }
 
     /// Smallest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return std::numeric_limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() IMATH_NOEXCEPT { return std::numeric_limits<T>::min(); }
 
     /// Smallest possible e for which 1+e != 1
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return std::numeric_limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() IMATH_NOEXCEPT { return std::numeric_limits<T>::epsilon(); }
 
     /// @}
     
     /// Return the number of the row and column dimensions, i.e. 3.
-    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() noexcept { return 3; }
+    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() IMATH_NOEXCEPT { return 3; }
 
     /// The base type: In templates that accept a parameter `V` (could be a Color4), you can refer to `T` as `V::BaseType`
     typedef T BaseType;
@@ -672,37 +672,37 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
     /// @}
     
     /// Row access
-    IMATH_HOSTDEVICE T* operator[] (int i) noexcept;
+    IMATH_HOSTDEVICE T* operator[] (int i) IMATH_NOEXCEPT;
 
     /// Row access
-    IMATH_HOSTDEVICE const T* operator[] (int i) const noexcept;
+    IMATH_HOSTDEVICE const T* operator[] (int i) const IMATH_NOEXCEPT;
 
     /// @{
     ///	@name Constructors and Assignment
 
     /// Uninitialized
-    IMATH_HOSTDEVICE constexpr Matrix44 (Uninitialized) noexcept {}
+    IMATH_HOSTDEVICE constexpr Matrix44 (Uninitialized) IMATH_NOEXCEPT {}
 
     /// Default constructor: initialize to identity
     ///   1 0 0 0
     ///   0 1 0 0
     ///   0 0 1 0
     ///   0 0 0 1
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44() IMATH_NOEXCEPT;
 
     /// Initialize to scalar constant
     ///   a a a a
     ///   a a a a
     ///   a a a a
     ///   a a a a
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (T a) IMATH_NOEXCEPT;
 
     /// Construct from 4x4 array 
     ///   a[0][0] a[0][1] a[0][2] a[0][3]
     ///   a[1][0] a[1][1] a[1][2] a[1][3]
     ///   a[2][0] a[2][1] a[2][2] a[2][3]
     ///   a[3][0] a[3][1] a[3][2] a[3][3]
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (const T a[4][4]) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (const T a[4][4]) IMATH_NOEXCEPT;
 
     /// Construct from given scalar values
     ///   a b c d
@@ -710,7 +710,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
     ///   i j k l
     ///   m n o p
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14
-    Matrix44 (T a, T b, T c, T d, T e, T f, T g, T h, T i, T j, T k, T l, T m, T n, T o, T p) noexcept;
+    Matrix44 (T a, T b, T c, T d, T e, T f, T g, T h, T i, T j, T k, T l, T m, T n, T o, T p) IMATH_NOEXCEPT;
 
 
     /// Construct from a 3x3 rotation matrix and a translation vector
@@ -718,22 +718,22 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
     ///   r r r 0
     ///   r r r 0
     ///   t t t 1
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (Matrix33<T> r, Vec3<T> t) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (Matrix33<T> r, Vec3<T> t) IMATH_NOEXCEPT;
 
     /// Copy constructor
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (const Matrix44& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (const Matrix44& v) IMATH_NOEXCEPT;
 
     /// Construct from Matrix44 of another base type
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix44 (const Matrix44<S>& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 explicit Matrix44 (const Matrix44<S>& v) IMATH_NOEXCEPT;
 
     /// Assignment operator
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator= (const Matrix44& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator= (const Matrix44& v) IMATH_NOEXCEPT;
 
     /// Assignment from scalar
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator= (T a) IMATH_NOEXCEPT;
 
     /// Destructor
-    ~Matrix44() noexcept = default;
+    ~Matrix44() IMATH_NOEXCEPT = default;
 
     /// @}
 
@@ -778,20 +778,20 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
     /// @name Compatibility with Sb
 
     /// Return a raw pointer to the array of values
-    IMATH_HOSTDEVICE T* getValue() noexcept;
+    IMATH_HOSTDEVICE T* getValue() IMATH_NOEXCEPT;
 
     /// Return a raw pointer to the array of values
-    IMATH_HOSTDEVICE const T* getValue() const noexcept;
+    IMATH_HOSTDEVICE const T* getValue() const IMATH_NOEXCEPT;
 
     /// Return the value in `v`
-    template <class S> IMATH_HOSTDEVICE void getValue (Matrix44<S>& v) const noexcept;
+    template <class S> IMATH_HOSTDEVICE void getValue (Matrix44<S>& v) const IMATH_NOEXCEPT;
 
     /// Set the value
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44& setValue (const Matrix44<S>& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44& setValue (const Matrix44<S>& v) IMATH_NOEXCEPT;
 
     /// Set the value
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44& setTheMatrix (const Matrix44<S>& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44& setTheMatrix (const Matrix44<S>& v) IMATH_NOEXCEPT;
 
     /// @}
 
@@ -799,85 +799,85 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
     /// @name Arithmetic and Comparison
     
     /// Equality
-    IMATH_HOSTDEVICE constexpr bool operator== (const Matrix44& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator== (const Matrix44& v) const IMATH_NOEXCEPT;
 
     /// Inequality
-    IMATH_HOSTDEVICE constexpr bool operator!= (const Matrix44& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr bool operator!= (const Matrix44& v) const IMATH_NOEXCEPT;
 
     /// Compare two matrices and test if they are "approximately equal":
     /// @return True if the coefficients of this and `m` are the same
     /// with an absolute error of no more than e, i.e., for all i, j:
     ///
     ///   abs (this[i][j] - m[i][j]) <= e
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Matrix44<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Matrix44<T>& v, T e) const IMATH_NOEXCEPT;
 
     /// Compare two matrices and test if they are "approximately equal":
     /// @return True if the coefficients of this and m are the same with
     /// a relative error of no more than e, i.e., for all i, j:
     ///
     ///   abs (this[i] - v[i][j]) <= e * abs (this[i][j])
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Matrix44<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Matrix44<T>& v, T e) const IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator+= (const Matrix44& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator+= (const Matrix44& v) IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator+= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator+= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE constexpr Matrix44 operator+ (const Matrix44& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix44 operator+ (const Matrix44& v) const IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator-= (const Matrix44& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator-= (const Matrix44& v) IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator-= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator-= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE constexpr Matrix44 operator- (const Matrix44& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix44 operator- (const Matrix44& v) const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE constexpr Matrix44 operator-() const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix44 operator-() const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& negate() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& negate() IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator*= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator*= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE constexpr Matrix44 operator* (T a) const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix44 operator* (T a) const IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator/= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator/= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE constexpr Matrix44 operator/ (T a) const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix44 operator/ (T a) const IMATH_NOEXCEPT;
 
     /// Matrix-matrix multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator*= (const Matrix44& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& operator*= (const Matrix44& v) IMATH_NOEXCEPT;
 
     /// Matrix-matrix multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 operator* (const Matrix44& v) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 operator* (const Matrix44& v) const IMATH_NOEXCEPT;
 
     /// Matrix-matrix multiplication: compute c = a * b
     IMATH_HOSTDEVICE
     static void multiply (const Matrix44& a,     // assumes that
                           const Matrix44& b,     // &a != &c and
-                          Matrix44& c) noexcept; // &b != &c.
+                          Matrix44& c) IMATH_NOEXCEPT; // &b != &c.
 
     /// Vector-matrix multiplication: a homogeneous transformation
     /// by computing Vec3 (src.x, src.y, src.z, 1) * m and dividing by the
     /// result's third element.
     /// @param[in] src The input vector
     /// @param[out] dst The output vector
-    template <class S> IMATH_HOSTDEVICE void multVecMatrix (const Vec3<S>& src, Vec3<S>& dst) const noexcept;
+    template <class S> IMATH_HOSTDEVICE void multVecMatrix (const Vec3<S>& src, Vec3<S>& dst) const IMATH_NOEXCEPT;
 
     /// Vector-matrix multiplication: multiply `src` by the upper left 2x2
     /// submatrix, ignoring the rest of matrix.
     /// @param[in] src The input vector
     /// @param[out] dst The output vector
-    template <class S> IMATH_HOSTDEVICE void multDirMatrix (const Vec3<S>& src, Vec3<S>& dst) const noexcept;
+    template <class S> IMATH_HOSTDEVICE void multDirMatrix (const Vec3<S>& src, Vec3<S>& dst) const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -885,13 +885,13 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
     /// @name Maniplation
 
     /// Set to the identity matrix
-    IMATH_HOSTDEVICE void makeIdentity() noexcept;
+    IMATH_HOSTDEVICE void makeIdentity() IMATH_NOEXCEPT;
 
     /// Transpose
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& transpose() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& transpose() IMATH_NOEXCEPT;
 
     /// Return the transpose
-    IMATH_HOSTDEVICE constexpr Matrix44 transposed() const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix44 transposed() const IMATH_NOEXCEPT;
 
     /// Invert in place using the determinant.
     /// @param singExc If true, throw an exception if the matrix cannot be inverted.
@@ -900,14 +900,14 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
 
     /// Invert in place using the determinant.
     /// @return const reference to this
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& invert() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& invert() IMATH_NOEXCEPT;
 
     /// Return the inverse using the determinant, leaving this unmodified.
     /// @param singExc If true, throw an exception if the matrix cannot be inverted.
     IMATH_CONSTEXPR14 Matrix44<T> inverse (bool singExc) const;
 
     /// Return the inverse using the determinant, leaving this unmodified.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44<T> inverse() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44<T> inverse() const IMATH_NOEXCEPT;
 
     /// Invert in place using the Gauss-Jordan method. Significantly slower
     /// but more accurate than invert().
@@ -918,7 +918,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
     /// Invert in place using the Gauss-Jordan method. Significantly slower
     /// but more accurate than invert().
     /// @return const reference to this
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& gjInvert() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& gjInvert() IMATH_NOEXCEPT;
 
     /// Return the inverse using the Gauss-Jordan method, leaving this
     /// unmodified. Significantly slower but more accurate than inverse().
@@ -926,10 +926,10 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
 
     /// Return the inverse using the Gauss-Jordan method, leaving this
     /// unmodified Significantly slower but more accurate than inverse().
-    IMATH_HOSTDEVICE Matrix44<T> gjInverse() const noexcept;
+    IMATH_HOSTDEVICE Matrix44<T> gjInverse() const IMATH_NOEXCEPT;
 
     /// Calculate the matrix minor of the (r,c) element
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T minorOf (const int r, const int c) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T minorOf (const int r, const int c) const IMATH_NOEXCEPT;
 
     /// Build a minor using the specified rows and columns
     IMATH_HOSTDEVICE
@@ -938,49 +938,49 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
                            const int r2,
                            const int c0,
                            const int c1,
-                           const int c2) const noexcept;
+                           const int c2) const IMATH_NOEXCEPT;
 
     /// Determinant
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T determinant() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T determinant() const IMATH_NOEXCEPT;
 
     /// Set matrix to rotation by XYZ euler angles (in radians)
     /// @return const referenced to this
-    template <class S> IMATH_HOSTDEVICE const Matrix44& setEulerAngles (const Vec3<S>& r) noexcept;
+    template <class S> IMATH_HOSTDEVICE const Matrix44& setEulerAngles (const Vec3<S>& r) IMATH_NOEXCEPT;
 
     /// Set matrix to rotation around given axis by given angle (in radians)
     /// @return const referenced to this
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setAxisAngle (const Vec3<S>& ax, S ang) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setAxisAngle (const Vec3<S>& ax, S ang) IMATH_NOEXCEPT;
 
     /// Rotate the matrix by XYZ euler angles in r (in radians)
     /// @return const referenced to this
-    template <class S> IMATH_HOSTDEVICE const Matrix44& rotate (const Vec3<S>& r) noexcept;
+    template <class S> IMATH_HOSTDEVICE const Matrix44& rotate (const Vec3<S>& r) IMATH_NOEXCEPT;
 
     /// Set matrix to scale by given uniform factor
     /// @return const referenced to this
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setScale (T s) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setScale (T s) IMATH_NOEXCEPT;
 
     /// Set matrix to scale by given vector
     /// @return const referenced to this
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setScale (const Vec3<S>& s) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setScale (const Vec3<S>& s) IMATH_NOEXCEPT;
 
     /// Scale the matrix by s
     /// @return const referenced to this
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& scale (const Vec3<S>& s) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& scale (const Vec3<S>& s) IMATH_NOEXCEPT;
 
     /// Set matrix to translation by given vector
     /// @return const referenced to this
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setTranslation (const Vec3<S>& t) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setTranslation (const Vec3<S>& t) IMATH_NOEXCEPT;
 
     /// Return translation component
-    IMATH_HOSTDEVICE constexpr const Vec3<T> translation() const noexcept;
+    IMATH_HOSTDEVICE constexpr const Vec3<T> translation() const IMATH_NOEXCEPT;
 
     /// Translate the matrix by t
     /// @return const referenced to this
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& translate (const Vec3<S>& t) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& translate (const Vec3<S>& t) IMATH_NOEXCEPT;
 
     /// Set matrix to shear by given vector h.  The resulting matrix
     ///   - will shear x for each y coord. by a factor of h[0] ;
@@ -988,7 +988,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
     ///   - will shear y for each z coord. by a factor of h[2] .
     /// @return const referenced to this
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setShear (const Vec3<S>& h) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setShear (const Vec3<S>& h) IMATH_NOEXCEPT;
 
     /// Set matrix to shear by given factors.  The resulting matrix
     ///   - will shear x for each y coord. by a factor of h.xy ;
@@ -999,7 +999,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
     ///   - will shear z for each y coord. by a factor of h.zy .
     /// @return const referenced to this
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setShear (const Shear6<S>& h) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& setShear (const Shear6<S>& h) IMATH_NOEXCEPT;
 
     /// Shear the matrix by given vector.  The composed matrix
     /// will be `shear` * `this`, where the shear matrix ...
@@ -1007,7 +1007,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
     ///   - will shear x for each z coord. by a factor of h[1] ;
     ///   - will shear y for each z coord. by a factor of h[2] .
     /// @return const referenced to this
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& shear (const Vec3<S>& h) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& shear (const Vec3<S>& h) IMATH_NOEXCEPT;
 
     /// Shear the matrix by the given factors.  The composed matrix
     /// will be `shear` * `this`, where the shear matrix ...
@@ -1019,7 +1019,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
     ///   - will shear z for each y coord. by a factor of h.zy .
     /// @return const referenced to this
     template <class S>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& shear (const Shear6<S>& h) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Matrix44& shear (const Shear6<S>& h) IMATH_NOEXCEPT;
 
     /// @}
     
@@ -1027,21 +1027,21 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
     /// @name Numeric Limits
     
     /// Largest possible negative value
-    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() noexcept { return std::numeric_limits<T>::lowest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() IMATH_NOEXCEPT { return std::numeric_limits<T>::lowest(); }
 
     /// Largest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return std::numeric_limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() IMATH_NOEXCEPT { return std::numeric_limits<T>::max(); }
 
     /// Smallest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return std::numeric_limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() IMATH_NOEXCEPT { return std::numeric_limits<T>::min(); }
 
     /// Smallest possible e for which 1+e != 1
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return std::numeric_limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() IMATH_NOEXCEPT { return std::numeric_limits<T>::epsilon(); }
 
     /// @}
     
     /// Return the number of the row and column dimensions, i.e. 4
-    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() noexcept { return 4; }
+    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() IMATH_NOEXCEPT { return 4; }
 
     /// The base type: In templates that accept a parameter `V` (could be a Color4), you can refer to `T` as `V::BaseType`
     typedef T BaseType;
@@ -1065,43 +1065,43 @@ template <class T> std::ostream& operator<< (std::ostream& s, const Matrix44<T>&
 
 /// Vector-matrix multiplication: v *= m
 template <class S, class T>
-IMATH_HOSTDEVICE inline const Vec2<S>& operator*= (Vec2<S>& v, const Matrix22<T>& m) noexcept;
+IMATH_HOSTDEVICE inline const Vec2<S>& operator*= (Vec2<S>& v, const Matrix22<T>& m) IMATH_NOEXCEPT;
 
 /// Vector-matrix multiplication: r = v * m
 template <class S, class T>
-IMATH_HOSTDEVICE inline Vec2<S> operator* (const Vec2<S>& v, const Matrix22<T>& m) noexcept;
+IMATH_HOSTDEVICE inline Vec2<S> operator* (const Vec2<S>& v, const Matrix22<T>& m) IMATH_NOEXCEPT;
 
 /// Vector-matrix multiplication: v *= m
 template <class S, class T>
-IMATH_HOSTDEVICE inline const Vec2<S>& operator*= (Vec2<S>& v, const Matrix33<T>& m) noexcept;
+IMATH_HOSTDEVICE inline const Vec2<S>& operator*= (Vec2<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT;
 
 /// Vector-matrix multiplication: r = v * m
 template <class S, class T>
-IMATH_HOSTDEVICE inline Vec2<S> operator* (const Vec2<S>& v, const Matrix33<T>& m) noexcept;
+IMATH_HOSTDEVICE inline Vec2<S> operator* (const Vec2<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT;
 
 /// Vector-matrix multiplication: v *= m
 template <class S, class T>
-IMATH_HOSTDEVICE inline const Vec3<S>& operator*= (Vec3<S>& v, const Matrix33<T>& m) noexcept;
+IMATH_HOSTDEVICE inline const Vec3<S>& operator*= (Vec3<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT;
 
 /// Vector-matrix multiplication: r = v * m
 template <class S, class T>
-IMATH_HOSTDEVICE inline Vec3<S> operator* (const Vec3<S>& v, const Matrix33<T>& m) noexcept;
+IMATH_HOSTDEVICE inline Vec3<S> operator* (const Vec3<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT;
 
 /// Vector-matrix multiplication: v *= m
 template <class S, class T>
-IMATH_HOSTDEVICE inline const Vec3<S>& operator*= (Vec3<S>& v, const Matrix44<T>& m) noexcept;
+IMATH_HOSTDEVICE inline const Vec3<S>& operator*= (Vec3<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT;
 
 /// Vector-matrix multiplication: r = v * m
 template <class S, class T>
-IMATH_HOSTDEVICE inline Vec3<S> operator* (const Vec3<S>& v, const Matrix44<T>& m) noexcept;
+IMATH_HOSTDEVICE inline Vec3<S> operator* (const Vec3<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT;
 
 /// Vector-matrix multiplication: v *= m
 template <class S, class T>
-IMATH_HOSTDEVICE inline const Vec4<S>& operator*= (Vec4<S>& v, const Matrix44<T>& m) noexcept;
+IMATH_HOSTDEVICE inline const Vec4<S>& operator*= (Vec4<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT;
 
 /// Vector-matrix multiplication: r = v * m
 template <class S, class T>
-IMATH_HOSTDEVICE inline Vec4<S> operator* (const Vec4<S>& v, const Matrix44<T>& m) noexcept;
+IMATH_HOSTDEVICE inline Vec4<S> operator* (const Vec4<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT;
 
 //-------------------------
 // Typedefs for convenience
@@ -1131,19 +1131,19 @@ typedef Matrix44<double> M44d;
 
 template <class T>
 inline T*
-Matrix22<T>::operator[] (int i) noexcept
+Matrix22<T>::operator[] (int i) IMATH_NOEXCEPT
 {
     return x[i];
 }
 
 template <class T>
 inline const T*
-Matrix22<T>::operator[] (int i) const noexcept
+Matrix22<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
     return x[i];
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22() noexcept
+template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22() IMATH_NOEXCEPT
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -1151,7 +1151,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22() noexcept
     x[1][1] = 1;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a) IMATH_NOEXCEPT
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -1159,7 +1159,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a) noexcept
     x[1][1] = a;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const T a[2][2]) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const T a[2][2]) IMATH_NOEXCEPT
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so instead of this:
@@ -1171,7 +1171,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const T a[2][
     x[1][1] = a[1][1];
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a, T b, T c, T d) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a, T b, T c, T d) IMATH_NOEXCEPT
 {
     x[0][0] = a;
     x[0][1] = b;
@@ -1179,7 +1179,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a, T b, T c
     x[1][1] = d;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22& v) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22& v) IMATH_NOEXCEPT
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so we don't do this:
@@ -1193,7 +1193,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix2
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22<S>& v) noexcept
+IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = T (v.x[0][0]);
     x[0][1] = T (v.x[0][1]);
@@ -1203,7 +1203,7 @@ IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22<S>& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator= (const Matrix22& v) noexcept
+Matrix22<T>::operator= (const Matrix22& v) IMATH_NOEXCEPT
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so we don't do this:
@@ -1218,7 +1218,7 @@ Matrix22<T>::operator= (const Matrix22& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator= (T a) noexcept
+Matrix22<T>::operator= (T a) IMATH_NOEXCEPT
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -1229,14 +1229,14 @@ Matrix22<T>::operator= (T a) noexcept
 
 template <class T>
 inline T*
-Matrix22<T>::getValue() noexcept
+Matrix22<T>::getValue() IMATH_NOEXCEPT
 {
     return (T*) &x[0][0];
 }
 
 template <class T>
 inline const T*
-Matrix22<T>::getValue() const noexcept
+Matrix22<T>::getValue() const IMATH_NOEXCEPT
 {
     return (const T*) &x[0][0];
 }
@@ -1244,7 +1244,7 @@ Matrix22<T>::getValue() const noexcept
 template <class T>
 template <class S>
 inline void
-Matrix22<T>::getValue (Matrix22<S>& v) const noexcept
+Matrix22<T>::getValue (Matrix22<S>& v) const IMATH_NOEXCEPT
 {
     v.x[0][0] = x[0][0];
     v.x[0][1] = x[0][1];
@@ -1255,7 +1255,7 @@ Matrix22<T>::getValue (Matrix22<S>& v) const noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline Matrix22<T>&
-Matrix22<T>::setValue (const Matrix22<S>& v) noexcept
+Matrix22<T>::setValue (const Matrix22<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -1267,7 +1267,7 @@ Matrix22<T>::setValue (const Matrix22<S>& v) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline Matrix22<T>&
-Matrix22<T>::setTheMatrix (const Matrix22<S>& v) noexcept
+Matrix22<T>::setTheMatrix (const Matrix22<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -1278,7 +1278,7 @@ Matrix22<T>::setTheMatrix (const Matrix22<S>& v) noexcept
 
 template <class T>
 inline void
-Matrix22<T>::makeIdentity() noexcept
+Matrix22<T>::makeIdentity() IMATH_NOEXCEPT
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -1288,7 +1288,7 @@ Matrix22<T>::makeIdentity() noexcept
 
 template <class T>
 constexpr inline bool
-Matrix22<T>::operator== (const Matrix22& v) const noexcept
+Matrix22<T>::operator== (const Matrix22& v) const IMATH_NOEXCEPT
 {
     return x[0][0] == v.x[0][0] && x[0][1] == v.x[0][1] && x[1][0] == v.x[1][0] &&
            x[1][1] == v.x[1][1];
@@ -1296,7 +1296,7 @@ Matrix22<T>::operator== (const Matrix22& v) const noexcept
 
 template <class T>
 constexpr inline bool
-Matrix22<T>::operator!= (const Matrix22& v) const noexcept
+Matrix22<T>::operator!= (const Matrix22& v) const IMATH_NOEXCEPT
 {
     return x[0][0] != v.x[0][0] || x[0][1] != v.x[0][1] || x[1][0] != v.x[1][0] ||
            x[1][1] != v.x[1][1];
@@ -1304,7 +1304,7 @@ Matrix22<T>::operator!= (const Matrix22& v) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Matrix22<T>::equalWithAbsError (const Matrix22<T>& m, T e) const noexcept
+Matrix22<T>::equalWithAbsError (const Matrix22<T>& m, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 2; i++)
         for (int j = 0; j < 2; j++)
@@ -1316,7 +1316,7 @@ Matrix22<T>::equalWithAbsError (const Matrix22<T>& m, T e) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Matrix22<T>::equalWithRelError (const Matrix22<T>& m, T e) const noexcept
+Matrix22<T>::equalWithRelError (const Matrix22<T>& m, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 2; i++)
         for (int j = 0; j < 2; j++)
@@ -1328,7 +1328,7 @@ Matrix22<T>::equalWithRelError (const Matrix22<T>& m, T e) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator+= (const Matrix22<T>& v) noexcept
+Matrix22<T>::operator+= (const Matrix22<T>& v) IMATH_NOEXCEPT
 {
     x[0][0] += v.x[0][0];
     x[0][1] += v.x[0][1];
@@ -1340,7 +1340,7 @@ Matrix22<T>::operator+= (const Matrix22<T>& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator+= (T a) noexcept
+Matrix22<T>::operator+= (T a) IMATH_NOEXCEPT
 {
     x[0][0] += a;
     x[0][1] += a;
@@ -1352,7 +1352,7 @@ Matrix22<T>::operator+= (T a) noexcept
 
 template <class T>
 constexpr inline Matrix22<T>
-Matrix22<T>::operator+ (const Matrix22<T>& v) const noexcept
+Matrix22<T>::operator+ (const Matrix22<T>& v) const IMATH_NOEXCEPT
 {
     return Matrix22 (x[0][0] + v.x[0][0],
                      x[0][1] + v.x[0][1],
@@ -1362,7 +1362,7 @@ Matrix22<T>::operator+ (const Matrix22<T>& v) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator-= (const Matrix22<T>& v) noexcept
+Matrix22<T>::operator-= (const Matrix22<T>& v) IMATH_NOEXCEPT
 {
     x[0][0] -= v.x[0][0];
     x[0][1] -= v.x[0][1];
@@ -1374,7 +1374,7 @@ Matrix22<T>::operator-= (const Matrix22<T>& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator-= (T a) noexcept
+Matrix22<T>::operator-= (T a) IMATH_NOEXCEPT
 {
     x[0][0] -= a;
     x[0][1] -= a;
@@ -1386,7 +1386,7 @@ Matrix22<T>::operator-= (T a) noexcept
 
 template <class T>
 constexpr inline Matrix22<T>
-Matrix22<T>::operator- (const Matrix22<T>& v) const noexcept
+Matrix22<T>::operator- (const Matrix22<T>& v) const IMATH_NOEXCEPT
 {
     return Matrix22 (x[0][0] - v.x[0][0],
                      x[0][1] - v.x[0][1],
@@ -1396,14 +1396,14 @@ Matrix22<T>::operator- (const Matrix22<T>& v) const noexcept
 
 template <class T>
 constexpr inline Matrix22<T>
-Matrix22<T>::operator-() const noexcept
+Matrix22<T>::operator-() const IMATH_NOEXCEPT
 {
     return Matrix22 (-x[0][0], -x[0][1], -x[1][0], -x[1][1]);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::negate() noexcept
+Matrix22<T>::negate() IMATH_NOEXCEPT
 {
     x[0][0] = -x[0][0];
     x[0][1] = -x[0][1];
@@ -1415,7 +1415,7 @@ Matrix22<T>::negate() noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator*= (T a) noexcept
+Matrix22<T>::operator*= (T a) IMATH_NOEXCEPT
 {
     x[0][0] *= a;
     x[0][1] *= a;
@@ -1427,7 +1427,7 @@ Matrix22<T>::operator*= (T a) noexcept
 
 template <class T>
 constexpr inline Matrix22<T>
-Matrix22<T>::operator* (T a) const noexcept
+Matrix22<T>::operator* (T a) const IMATH_NOEXCEPT
 {
     return Matrix22 (x[0][0] * a, x[0][1] * a, x[1][0] * a, x[1][1] * a);
 }
@@ -1435,14 +1435,14 @@ Matrix22<T>::operator* (T a) const noexcept
 /// Matrix-scalar multiplication
 template <class T>
 inline Matrix22<T>
-operator* (T a, const Matrix22<T>& v) noexcept
+operator* (T a, const Matrix22<T>& v) IMATH_NOEXCEPT
 {
     return v * a;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator*= (const Matrix22<T>& v) noexcept
+Matrix22<T>::operator*= (const Matrix22<T>& v) IMATH_NOEXCEPT
 {
     Matrix22 tmp (T (0));
 
@@ -1457,7 +1457,7 @@ Matrix22<T>::operator*= (const Matrix22<T>& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix22<T>
-Matrix22<T>::operator* (const Matrix22<T>& v) const noexcept
+Matrix22<T>::operator* (const Matrix22<T>& v) const IMATH_NOEXCEPT
 {
     Matrix22 tmp (T (0));
 
@@ -1472,7 +1472,7 @@ Matrix22<T>::operator* (const Matrix22<T>& v) const noexcept
 template <class T>
 template <class S>
 inline void
-Matrix22<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept
+Matrix22<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const IMATH_NOEXCEPT
 {
     S a, b;
 
@@ -1485,7 +1485,7 @@ Matrix22<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::operator/= (T a) noexcept
+Matrix22<T>::operator/= (T a) IMATH_NOEXCEPT
 {
     x[0][0] /= a;
     x[0][1] /= a;
@@ -1497,14 +1497,14 @@ Matrix22<T>::operator/= (T a) noexcept
 
 template <class T>
 constexpr inline Matrix22<T>
-Matrix22<T>::operator/ (T a) const noexcept
+Matrix22<T>::operator/ (T a) const IMATH_NOEXCEPT
 {
     return Matrix22 (x[0][0] / a, x[0][1] / a, x[1][0] / a, x[1][1] / a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::transpose() noexcept
+Matrix22<T>::transpose() IMATH_NOEXCEPT
 {
     Matrix22 tmp (x[0][0], x[1][0], x[0][1], x[1][1]);
     *this = tmp;
@@ -1513,7 +1513,7 @@ Matrix22<T>::transpose() noexcept
 
 template <class T>
 constexpr inline Matrix22<T>
-Matrix22<T>::transposed() const noexcept
+Matrix22<T>::transposed() const IMATH_NOEXCEPT
 {
     return Matrix22 (x[0][0], x[1][0], x[0][1], x[1][1]);
 }
@@ -1528,7 +1528,7 @@ Matrix22<T>::invert (bool singExc)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::invert() noexcept
+Matrix22<T>::invert() IMATH_NOEXCEPT
 {
     *this = inverse();
     return *this;
@@ -1579,7 +1579,7 @@ Matrix22<T>::inverse (bool singExc) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix22<T>
-Matrix22<T>::inverse() const noexcept
+Matrix22<T>::inverse() const IMATH_NOEXCEPT
 {
     Matrix22 s (x[1][1], -x[0][1], -x[1][0], x[0][0]);
 
@@ -1619,7 +1619,7 @@ Matrix22<T>::inverse() const noexcept
 
 template <class T>
 constexpr inline T
-Matrix22<T>::determinant() const noexcept
+Matrix22<T>::determinant() const IMATH_NOEXCEPT
 {
     return x[0][0] * x[1][1] - x[1][0] * x[0][1];
 }
@@ -1627,7 +1627,7 @@ Matrix22<T>::determinant() const noexcept
 template <class T>
 template <class S>
 inline const Matrix22<T>&
-Matrix22<T>::setRotation (S r) noexcept
+Matrix22<T>::setRotation (S r) IMATH_NOEXCEPT
 {
     S cos_r, sin_r;
 
@@ -1647,7 +1647,7 @@ template <class T>
 template <class S>
 
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::rotate (S r) noexcept
+Matrix22<T>::rotate (S r) IMATH_NOEXCEPT
 {
     *this *= Matrix22<T>().setRotation (r);
     return *this;
@@ -1656,7 +1656,7 @@ Matrix22<T>::rotate (S r) noexcept
 template <class T>
 
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::setScale (T s) noexcept
+Matrix22<T>::setScale (T s) IMATH_NOEXCEPT
 {
     //
     // Set the matrix to:
@@ -1676,7 +1676,7 @@ template <class T>
 template <class S>
 
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::setScale (const Vec2<S>& s) noexcept
+Matrix22<T>::setScale (const Vec2<S>& s) IMATH_NOEXCEPT
 {
     //
     // Set the matrix to:
@@ -1696,7 +1696,7 @@ template <class T>
 template <class S>
 
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
-Matrix22<T>::scale (const Vec2<S>& s) noexcept
+Matrix22<T>::scale (const Vec2<S>& s) IMATH_NOEXCEPT
 {
     x[0][0] *= s.x;
     x[0][1] *= s.x;
@@ -1713,21 +1713,21 @@ Matrix22<T>::scale (const Vec2<S>& s) noexcept
 
 template <class T>
 inline T*
-Matrix33<T>::operator[] (int i) noexcept
+Matrix33<T>::operator[] (int i) IMATH_NOEXCEPT
 {
     return x[i];
 }
 
 template <class T>
 inline const T*
-Matrix33<T>::operator[] (int i) const noexcept
+Matrix33<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
     return x[i];
 }
 
 template <class T>
 inline IMATH_CONSTEXPR14
-Matrix33<T>::Matrix33() noexcept
+Matrix33<T>::Matrix33() IMATH_NOEXCEPT
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -1740,7 +1740,7 @@ Matrix33<T>::Matrix33() noexcept
     x[2][2] = 1;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a) IMATH_NOEXCEPT
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -1753,7 +1753,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a) noexcept
     x[2][2] = a;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const T a[3][3]) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const T a[3][3]) IMATH_NOEXCEPT
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so instead of this:
@@ -1772,7 +1772,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const T a[3][
 
 template <class T>
 
-IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a, T b, T c, T d, T e, T f, T g, T h, T i) noexcept
+IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a, T b, T c, T d, T e, T f, T g, T h, T i) IMATH_NOEXCEPT
 {
     x[0][0] = a;
     x[0][1] = b;
@@ -1785,7 +1785,7 @@ IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a, T b, T c, T d, T e, T f, T 
     x[2][2] = i;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33& v) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33& v) IMATH_NOEXCEPT
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so instead of this:
@@ -1805,7 +1805,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix3
 template <class T>
 template <class S>
 
-IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33<S>& v) noexcept
+IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = T (v.x[0][0]);
     x[0][1] = T (v.x[0][1]);
@@ -1821,7 +1821,7 @@ IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33<S>& v) noexcept
 template <class T>
 
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator= (const Matrix33& v) noexcept
+Matrix33<T>::operator= (const Matrix33& v) IMATH_NOEXCEPT
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so instead of this:
@@ -1842,7 +1842,7 @@ Matrix33<T>::operator= (const Matrix33& v) noexcept
 template <class T>
 
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator= (T a) noexcept
+Matrix33<T>::operator= (T a) IMATH_NOEXCEPT
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -1858,14 +1858,14 @@ Matrix33<T>::operator= (T a) noexcept
 
 template <class T>
 inline T*
-Matrix33<T>::getValue() noexcept
+Matrix33<T>::getValue() IMATH_NOEXCEPT
 {
     return (T*) &x[0][0];
 }
 
 template <class T>
 inline const T*
-Matrix33<T>::getValue() const noexcept
+Matrix33<T>::getValue() const IMATH_NOEXCEPT
 {
     return (const T*) &x[0][0];
 }
@@ -1873,7 +1873,7 @@ Matrix33<T>::getValue() const noexcept
 template <class T>
 template <class S>
 inline void
-Matrix33<T>::getValue (Matrix33<S>& v) const noexcept
+Matrix33<T>::getValue (Matrix33<S>& v) const IMATH_NOEXCEPT
 {
     v.x[0][0] = x[0][0];
     v.x[0][1] = x[0][1];
@@ -1889,7 +1889,7 @@ Matrix33<T>::getValue (Matrix33<S>& v) const noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline Matrix33<T>&
-Matrix33<T>::setValue (const Matrix33<S>& v) noexcept
+Matrix33<T>::setValue (const Matrix33<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -1906,7 +1906,7 @@ Matrix33<T>::setValue (const Matrix33<S>& v) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline Matrix33<T>&
-Matrix33<T>::setTheMatrix (const Matrix33<S>& v) noexcept
+Matrix33<T>::setTheMatrix (const Matrix33<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -1922,7 +1922,7 @@ Matrix33<T>::setTheMatrix (const Matrix33<S>& v) noexcept
 
 template <class T>
 inline void
-Matrix33<T>::makeIdentity() noexcept
+Matrix33<T>::makeIdentity() IMATH_NOEXCEPT
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -1937,7 +1937,7 @@ Matrix33<T>::makeIdentity() noexcept
 
 template <class T>
 constexpr inline bool
-Matrix33<T>::operator== (const Matrix33& v) const noexcept
+Matrix33<T>::operator== (const Matrix33& v) const IMATH_NOEXCEPT
 {
     return x[0][0] == v.x[0][0] && x[0][1] == v.x[0][1] && x[0][2] == v.x[0][2] &&
            x[1][0] == v.x[1][0] && x[1][1] == v.x[1][1] && x[1][2] == v.x[1][2] &&
@@ -1946,7 +1946,7 @@ Matrix33<T>::operator== (const Matrix33& v) const noexcept
 
 template <class T>
 constexpr inline bool
-Matrix33<T>::operator!= (const Matrix33& v) const noexcept
+Matrix33<T>::operator!= (const Matrix33& v) const IMATH_NOEXCEPT
 {
     return x[0][0] != v.x[0][0] || x[0][1] != v.x[0][1] || x[0][2] != v.x[0][2] ||
            x[1][0] != v.x[1][0] || x[1][1] != v.x[1][1] || x[1][2] != v.x[1][2] ||
@@ -1955,7 +1955,7 @@ Matrix33<T>::operator!= (const Matrix33& v) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Matrix33<T>::equalWithAbsError (const Matrix33<T>& m, T e) const noexcept
+Matrix33<T>::equalWithAbsError (const Matrix33<T>& m, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 3; i++)
         for (int j = 0; j < 3; j++)
@@ -1967,7 +1967,7 @@ Matrix33<T>::equalWithAbsError (const Matrix33<T>& m, T e) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Matrix33<T>::equalWithRelError (const Matrix33<T>& m, T e) const noexcept
+Matrix33<T>::equalWithRelError (const Matrix33<T>& m, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 3; i++)
         for (int j = 0; j < 3; j++)
@@ -1979,7 +1979,7 @@ Matrix33<T>::equalWithRelError (const Matrix33<T>& m, T e) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator+= (const Matrix33<T>& v) noexcept
+Matrix33<T>::operator+= (const Matrix33<T>& v) IMATH_NOEXCEPT
 {
     x[0][0] += v.x[0][0];
     x[0][1] += v.x[0][1];
@@ -1996,7 +1996,7 @@ Matrix33<T>::operator+= (const Matrix33<T>& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator+= (T a) noexcept
+Matrix33<T>::operator+= (T a) IMATH_NOEXCEPT
 {
     x[0][0] += a;
     x[0][1] += a;
@@ -2013,7 +2013,7 @@ Matrix33<T>::operator+= (T a) noexcept
 
 template <class T>
 constexpr inline Matrix33<T>
-Matrix33<T>::operator+ (const Matrix33<T>& v) const noexcept
+Matrix33<T>::operator+ (const Matrix33<T>& v) const IMATH_NOEXCEPT
 {
     return Matrix33 (x[0][0] + v.x[0][0],
                      x[0][1] + v.x[0][1],
@@ -2028,7 +2028,7 @@ Matrix33<T>::operator+ (const Matrix33<T>& v) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator-= (const Matrix33<T>& v) noexcept
+Matrix33<T>::operator-= (const Matrix33<T>& v) IMATH_NOEXCEPT
 {
     x[0][0] -= v.x[0][0];
     x[0][1] -= v.x[0][1];
@@ -2045,7 +2045,7 @@ Matrix33<T>::operator-= (const Matrix33<T>& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator-= (T a) noexcept
+Matrix33<T>::operator-= (T a) IMATH_NOEXCEPT
 {
     x[0][0] -= a;
     x[0][1] -= a;
@@ -2062,7 +2062,7 @@ Matrix33<T>::operator-= (T a) noexcept
 
 template <class T>
 constexpr inline Matrix33<T>
-Matrix33<T>::operator- (const Matrix33<T>& v) const noexcept
+Matrix33<T>::operator- (const Matrix33<T>& v) const IMATH_NOEXCEPT
 {
     return Matrix33 (x[0][0] - v.x[0][0],
                      x[0][1] - v.x[0][1],
@@ -2077,7 +2077,7 @@ Matrix33<T>::operator- (const Matrix33<T>& v) const noexcept
 
 template <class T>
 constexpr inline Matrix33<T>
-Matrix33<T>::operator-() const noexcept
+Matrix33<T>::operator-() const IMATH_NOEXCEPT
 {
     return Matrix33 (-x[0][0],
                      -x[0][1],
@@ -2092,7 +2092,7 @@ Matrix33<T>::operator-() const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::negate() noexcept
+Matrix33<T>::negate() IMATH_NOEXCEPT
 {
     x[0][0] = -x[0][0];
     x[0][1] = -x[0][1];
@@ -2109,7 +2109,7 @@ Matrix33<T>::negate() noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator*= (T a) noexcept
+Matrix33<T>::operator*= (T a) IMATH_NOEXCEPT
 {
     x[0][0] *= a;
     x[0][1] *= a;
@@ -2126,7 +2126,7 @@ Matrix33<T>::operator*= (T a) noexcept
 
 template <class T>
 constexpr inline Matrix33<T>
-Matrix33<T>::operator* (T a) const noexcept
+Matrix33<T>::operator* (T a) const IMATH_NOEXCEPT
 {
     return Matrix33 (x[0][0] * a,
                      x[0][1] * a,
@@ -2142,14 +2142,14 @@ Matrix33<T>::operator* (T a) const noexcept
 /// Matrix-scalar multiplication
 template <class T>
 inline Matrix33<T> constexpr
-operator* (T a, const Matrix33<T>& v) noexcept
+operator* (T a, const Matrix33<T>& v) IMATH_NOEXCEPT
 {
     return v * a;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator*= (const Matrix33<T>& v) noexcept
+Matrix33<T>::operator*= (const Matrix33<T>& v) IMATH_NOEXCEPT
 {
     // Avoid initializing with 0 values before immediately overwriting them,
     // and unroll all loops for the best autovectorization.
@@ -2173,7 +2173,7 @@ Matrix33<T>::operator*= (const Matrix33<T>& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix33<T>
-Matrix33<T>::operator* (const Matrix33<T>& v) const noexcept
+Matrix33<T>::operator* (const Matrix33<T>& v) const IMATH_NOEXCEPT
 {
     // Avoid initializing with 0 values before immediately overwriting them,
     // and unroll all loops for the best autovectorization.
@@ -2197,7 +2197,7 @@ Matrix33<T>::operator* (const Matrix33<T>& v) const noexcept
 template <class T>
 template <class S>
 inline void
-Matrix33<T>::multVecMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept
+Matrix33<T>::multVecMatrix (const Vec2<S>& src, Vec2<S>& dst) const IMATH_NOEXCEPT
 {
     S a, b, w;
 
@@ -2212,7 +2212,7 @@ Matrix33<T>::multVecMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept
 template <class T>
 template <class S>
 inline void
-Matrix33<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept
+Matrix33<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const IMATH_NOEXCEPT
 {
     S a, b;
 
@@ -2225,7 +2225,7 @@ Matrix33<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::operator/= (T a) noexcept
+Matrix33<T>::operator/= (T a) IMATH_NOEXCEPT
 {
     x[0][0] /= a;
     x[0][1] /= a;
@@ -2242,7 +2242,7 @@ Matrix33<T>::operator/= (T a) noexcept
 
 template <class T>
 constexpr inline Matrix33<T>
-Matrix33<T>::operator/ (T a) const noexcept
+Matrix33<T>::operator/ (T a) const IMATH_NOEXCEPT
 {
     return Matrix33 (x[0][0] / a,
                      x[0][1] / a,
@@ -2257,7 +2257,7 @@ Matrix33<T>::operator/ (T a) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::transpose() noexcept
+Matrix33<T>::transpose() IMATH_NOEXCEPT
 {
     Matrix33 tmp (x[0][0], x[1][0], x[2][0], x[0][1], x[1][1], x[2][1], x[0][2], x[1][2], x[2][2]);
     *this = tmp;
@@ -2266,7 +2266,7 @@ Matrix33<T>::transpose() noexcept
 
 template <class T>
 constexpr inline Matrix33<T>
-Matrix33<T>::transposed() const noexcept
+Matrix33<T>::transposed() const IMATH_NOEXCEPT
 {
     return Matrix33 (x[0][0],
                      x[1][0],
@@ -2289,7 +2289,7 @@ Matrix33<T>::gjInvert (bool singExc)
 
 template <class T>
 const inline Matrix33<T>&
-Matrix33<T>::gjInvert() noexcept
+Matrix33<T>::gjInvert() IMATH_NOEXCEPT
 {
     *this = gjInverse();
     return *this;
@@ -2401,7 +2401,7 @@ Matrix33<T>::gjInverse (bool singExc) const
 
 template <class T>
 inline Matrix33<T>
-Matrix33<T>::gjInverse() const noexcept
+Matrix33<T>::gjInverse() const IMATH_NOEXCEPT
 {
     int i, j, k;
     Matrix33 s;
@@ -2507,7 +2507,7 @@ Matrix33<T>::invert (bool singExc)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::invert() noexcept
+Matrix33<T>::invert() IMATH_NOEXCEPT
 {
     *this = inverse();
     return *this;
@@ -2626,7 +2626,7 @@ Matrix33<T>::inverse (bool singExc) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix33<T>
-Matrix33<T>::inverse() const noexcept
+Matrix33<T>::inverse() const IMATH_NOEXCEPT
 {
     if (x[0][2] != 0 || x[1][2] != 0 || x[2][2] != 1)
     {
@@ -2731,7 +2731,7 @@ Matrix33<T>::inverse() const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Matrix33<T>::minorOf (const int r, const int c) const noexcept
+Matrix33<T>::minorOf (const int r, const int c) const IMATH_NOEXCEPT
 {
     int r0 = 0 + (r < 1 ? 1 : 0);
     int r1 = 1 + (r < 2 ? 1 : 0);
@@ -2743,14 +2743,14 @@ Matrix33<T>::minorOf (const int r, const int c) const noexcept
 
 template <class T>
 constexpr inline T
-Matrix33<T>::fastMinor (const int r0, const int r1, const int c0, const int c1) const noexcept
+Matrix33<T>::fastMinor (const int r0, const int r1, const int c0, const int c1) const IMATH_NOEXCEPT
 {
     return x[r0][c0] * x[r1][c1] - x[r0][c1] * x[r1][c0];
 }
 
 template <class T>
 constexpr inline T
-Matrix33<T>::determinant() const noexcept
+Matrix33<T>::determinant() const IMATH_NOEXCEPT
 {
     return x[0][0] * (x[1][1] * x[2][2] - x[1][2] * x[2][1]) +
            x[0][1] * (x[1][2] * x[2][0] - x[1][0] * x[2][2]) +
@@ -2760,7 +2760,7 @@ Matrix33<T>::determinant() const noexcept
 template <class T>
 template <class S>
 inline const Matrix33<T>&
-Matrix33<T>::setRotation (S r) noexcept
+Matrix33<T>::setRotation (S r) IMATH_NOEXCEPT
 {
     S cos_r, sin_r;
 
@@ -2785,7 +2785,7 @@ Matrix33<T>::setRotation (S r) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::rotate (S r) noexcept
+Matrix33<T>::rotate (S r) IMATH_NOEXCEPT
 {
     *this *= Matrix33<T>().setRotation (r);
     return *this;
@@ -2793,7 +2793,7 @@ Matrix33<T>::rotate (S r) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::setScale (T s) noexcept
+Matrix33<T>::setScale (T s) IMATH_NOEXCEPT
 {
     //
     // Set the matrix to a 2D homogeneous transform scale:
@@ -2817,7 +2817,7 @@ Matrix33<T>::setScale (T s) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::setScale (const Vec2<S>& s) noexcept
+Matrix33<T>::setScale (const Vec2<S>& s) IMATH_NOEXCEPT
 {
     //
     // Set the matrix to a 2D homogeneous transform scale:
@@ -2841,7 +2841,7 @@ Matrix33<T>::setScale (const Vec2<S>& s) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::scale (const Vec2<S>& s) noexcept
+Matrix33<T>::scale (const Vec2<S>& s) IMATH_NOEXCEPT
 {
     x[0][0] *= s.x;
     x[0][1] *= s.x;
@@ -2857,7 +2857,7 @@ Matrix33<T>::scale (const Vec2<S>& s) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::setTranslation (const Vec2<S>& t) noexcept
+Matrix33<T>::setTranslation (const Vec2<S>& t) IMATH_NOEXCEPT
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -2876,7 +2876,7 @@ Matrix33<T>::setTranslation (const Vec2<S>& t) noexcept
 
 template <class T>
 constexpr inline Vec2<T>
-Matrix33<T>::translation() const noexcept
+Matrix33<T>::translation() const IMATH_NOEXCEPT
 {
     return Vec2<T> (x[2][0], x[2][1]);
 }
@@ -2884,7 +2884,7 @@ Matrix33<T>::translation() const noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::translate (const Vec2<S>& t) noexcept
+Matrix33<T>::translate (const Vec2<S>& t) IMATH_NOEXCEPT
 {
     x[2][0] += t.x * x[0][0] + t.y * x[1][0];
     x[2][1] += t.x * x[0][1] + t.y * x[1][1];
@@ -2896,7 +2896,7 @@ Matrix33<T>::translate (const Vec2<S>& t) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::setShear (const S& xy) noexcept
+Matrix33<T>::setShear (const S& xy) IMATH_NOEXCEPT
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -2916,7 +2916,7 @@ Matrix33<T>::setShear (const S& xy) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::setShear (const Vec2<S>& h) noexcept
+Matrix33<T>::setShear (const Vec2<S>& h) IMATH_NOEXCEPT
 {
     x[0][0] = 1;
     x[0][1] = h.y;
@@ -2936,7 +2936,7 @@ Matrix33<T>::setShear (const Vec2<S>& h) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::shear (const S& xy) noexcept
+Matrix33<T>::shear (const S& xy) IMATH_NOEXCEPT
 {
     //
     // In this case, we don't need a temp. copy of the matrix
@@ -2954,7 +2954,7 @@ Matrix33<T>::shear (const S& xy) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix33<T>&
-Matrix33<T>::shear (const Vec2<S>& h) noexcept
+Matrix33<T>::shear (const Vec2<S>& h) IMATH_NOEXCEPT
 {
     Matrix33<T> P (*this);
 
@@ -2975,19 +2975,19 @@ Matrix33<T>::shear (const Vec2<S>& h) noexcept
 
 template <class T>
 inline T*
-Matrix44<T>::operator[] (int i) noexcept
+Matrix44<T>::operator[] (int i) IMATH_NOEXCEPT
 {
     return x[i];
 }
 
 template <class T>
 inline const T*
-Matrix44<T>::operator[] (int i) const noexcept
+Matrix44<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
     return x[i];
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44() noexcept
+template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44() IMATH_NOEXCEPT
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -3007,7 +3007,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44() noexcept
     x[3][3] = 1;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (T a) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (T a) IMATH_NOEXCEPT
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -3027,7 +3027,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (T a) noexcept
     x[3][3] = a;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const T a[4][4]) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const T a[4][4]) IMATH_NOEXCEPT
 {
     x[0][0] = a[0][0];
     x[0][1] = a[0][1];
@@ -3049,7 +3049,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const T a[4][
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix44<
-    T>::Matrix44 (T a, T b, T c, T d, T e, T f, T g, T h, T i, T j, T k, T l, T m, T n, T o, T p) noexcept
+    T>::Matrix44 (T a, T b, T c, T d, T e, T f, T g, T h, T i, T j, T k, T l, T m, T n, T o, T p) IMATH_NOEXCEPT
 {
     x[0][0] = a;
     x[0][1] = b;
@@ -3069,7 +3069,7 @@ IMATH_CONSTEXPR14 inline Matrix44<
     x[3][3] = p;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (Matrix33<T> r, Vec3<T> t) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (Matrix33<T> r, Vec3<T> t) IMATH_NOEXCEPT
 {
     x[0][0] = r[0][0];
     x[0][1] = r[0][1];
@@ -3089,7 +3089,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (Matrix33<T> r
     x[3][3] = 1;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44& v) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -3111,7 +3111,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix4
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44<S>& v) noexcept
+IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = T (v.x[0][0]);
     x[0][1] = T (v.x[0][1]);
@@ -3133,7 +3133,7 @@ IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44<S>& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator= (const Matrix44& v) noexcept
+Matrix44<T>::operator= (const Matrix44& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -3156,7 +3156,7 @@ Matrix44<T>::operator= (const Matrix44& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator= (T a) noexcept
+Matrix44<T>::operator= (T a) IMATH_NOEXCEPT
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -3179,14 +3179,14 @@ Matrix44<T>::operator= (T a) noexcept
 
 template <class T>
 inline T*
-Matrix44<T>::getValue() noexcept
+Matrix44<T>::getValue() IMATH_NOEXCEPT
 {
     return (T*) &x[0][0];
 }
 
 template <class T>
 inline const T*
-Matrix44<T>::getValue() const noexcept
+Matrix44<T>::getValue() const IMATH_NOEXCEPT
 {
     return (const T*) &x[0][0];
 }
@@ -3194,7 +3194,7 @@ Matrix44<T>::getValue() const noexcept
 template <class T>
 template <class S>
 inline void
-Matrix44<T>::getValue (Matrix44<S>& v) const noexcept
+Matrix44<T>::getValue (Matrix44<S>& v) const IMATH_NOEXCEPT
 {
     v.x[0][0] = x[0][0];
     v.x[0][1] = x[0][1];
@@ -3217,7 +3217,7 @@ Matrix44<T>::getValue (Matrix44<S>& v) const noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline Matrix44<T>&
-Matrix44<T>::setValue (const Matrix44<S>& v) noexcept
+Matrix44<T>::setValue (const Matrix44<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -3241,7 +3241,7 @@ Matrix44<T>::setValue (const Matrix44<S>& v) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline Matrix44<T>&
-Matrix44<T>::setTheMatrix (const Matrix44<S>& v) noexcept
+Matrix44<T>::setTheMatrix (const Matrix44<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -3264,7 +3264,7 @@ Matrix44<T>::setTheMatrix (const Matrix44<S>& v) noexcept
 
 template <class T>
 inline void
-Matrix44<T>::makeIdentity() noexcept
+Matrix44<T>::makeIdentity() IMATH_NOEXCEPT
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -3286,7 +3286,7 @@ Matrix44<T>::makeIdentity() noexcept
 
 template <class T>
 constexpr inline bool
-Matrix44<T>::operator== (const Matrix44& v) const noexcept
+Matrix44<T>::operator== (const Matrix44& v) const IMATH_NOEXCEPT
 {
     return x[0][0] == v.x[0][0] && x[0][1] == v.x[0][1] && x[0][2] == v.x[0][2] &&
            x[0][3] == v.x[0][3] && x[1][0] == v.x[1][0] && x[1][1] == v.x[1][1] &&
@@ -3298,7 +3298,7 @@ Matrix44<T>::operator== (const Matrix44& v) const noexcept
 
 template <class T>
 constexpr inline bool
-Matrix44<T>::operator!= (const Matrix44& v) const noexcept
+Matrix44<T>::operator!= (const Matrix44& v) const IMATH_NOEXCEPT
 {
     return x[0][0] != v.x[0][0] || x[0][1] != v.x[0][1] || x[0][2] != v.x[0][2] ||
            x[0][3] != v.x[0][3] || x[1][0] != v.x[1][0] || x[1][1] != v.x[1][1] ||
@@ -3310,7 +3310,7 @@ Matrix44<T>::operator!= (const Matrix44& v) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Matrix44<T>::equalWithAbsError (const Matrix44<T>& m, T e) const noexcept
+Matrix44<T>::equalWithAbsError (const Matrix44<T>& m, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)
@@ -3322,7 +3322,7 @@ Matrix44<T>::equalWithAbsError (const Matrix44<T>& m, T e) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Matrix44<T>::equalWithRelError (const Matrix44<T>& m, T e) const noexcept
+Matrix44<T>::equalWithRelError (const Matrix44<T>& m, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)
@@ -3334,7 +3334,7 @@ Matrix44<T>::equalWithRelError (const Matrix44<T>& m, T e) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator+= (const Matrix44<T>& v) noexcept
+Matrix44<T>::operator+= (const Matrix44<T>& v) IMATH_NOEXCEPT
 {
     x[0][0] += v.x[0][0];
     x[0][1] += v.x[0][1];
@@ -3358,7 +3358,7 @@ Matrix44<T>::operator+= (const Matrix44<T>& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator+= (T a) noexcept
+Matrix44<T>::operator+= (T a) IMATH_NOEXCEPT
 {
     x[0][0] += a;
     x[0][1] += a;
@@ -3382,7 +3382,7 @@ Matrix44<T>::operator+= (T a) noexcept
 
 template <class T>
 constexpr inline Matrix44<T>
-Matrix44<T>::operator+ (const Matrix44<T>& v) const noexcept
+Matrix44<T>::operator+ (const Matrix44<T>& v) const IMATH_NOEXCEPT
 {
     return Matrix44 (x[0][0] + v.x[0][0],
                      x[0][1] + v.x[0][1],
@@ -3404,7 +3404,7 @@ Matrix44<T>::operator+ (const Matrix44<T>& v) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator-= (const Matrix44<T>& v) noexcept
+Matrix44<T>::operator-= (const Matrix44<T>& v) IMATH_NOEXCEPT
 {
     x[0][0] -= v.x[0][0];
     x[0][1] -= v.x[0][1];
@@ -3428,7 +3428,7 @@ Matrix44<T>::operator-= (const Matrix44<T>& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator-= (T a) noexcept
+Matrix44<T>::operator-= (T a) IMATH_NOEXCEPT
 {
     x[0][0] -= a;
     x[0][1] -= a;
@@ -3452,7 +3452,7 @@ Matrix44<T>::operator-= (T a) noexcept
 
 template <class T>
 constexpr inline Matrix44<T>
-Matrix44<T>::operator- (const Matrix44<T>& v) const noexcept
+Matrix44<T>::operator- (const Matrix44<T>& v) const IMATH_NOEXCEPT
 {
     return Matrix44 (x[0][0] - v.x[0][0],
                      x[0][1] - v.x[0][1],
@@ -3474,7 +3474,7 @@ Matrix44<T>::operator- (const Matrix44<T>& v) const noexcept
 
 template <class T>
 constexpr inline Matrix44<T>
-Matrix44<T>::operator-() const noexcept
+Matrix44<T>::operator-() const IMATH_NOEXCEPT
 {
     return Matrix44 (-x[0][0],
                      -x[0][1],
@@ -3496,7 +3496,7 @@ Matrix44<T>::operator-() const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::negate() noexcept
+Matrix44<T>::negate() IMATH_NOEXCEPT
 {
     x[0][0] = -x[0][0];
     x[0][1] = -x[0][1];
@@ -3520,7 +3520,7 @@ Matrix44<T>::negate() noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator*= (T a) noexcept
+Matrix44<T>::operator*= (T a) IMATH_NOEXCEPT
 {
     x[0][0] *= a;
     x[0][1] *= a;
@@ -3544,7 +3544,7 @@ Matrix44<T>::operator*= (T a) noexcept
 
 template <class T>
 constexpr inline Matrix44<T>
-Matrix44<T>::operator* (T a) const noexcept
+Matrix44<T>::operator* (T a) const IMATH_NOEXCEPT
 {
     return Matrix44 (x[0][0] * a,
                      x[0][1] * a,
@@ -3567,14 +3567,14 @@ Matrix44<T>::operator* (T a) const noexcept
 /// Matrix-scalar multiplication
 template <class T>
 inline Matrix44<T>
-operator* (T a, const Matrix44<T>& v) noexcept
+operator* (T a, const Matrix44<T>& v) IMATH_NOEXCEPT
 {
     return v * a;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator*= (const Matrix44<T>& v) noexcept
+Matrix44<T>::operator*= (const Matrix44<T>& v) IMATH_NOEXCEPT
 {
     Matrix44 tmp (T (0));
 
@@ -3585,7 +3585,7 @@ Matrix44<T>::operator*= (const Matrix44<T>& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix44<T>
-Matrix44<T>::operator* (const Matrix44<T>& v) const noexcept
+Matrix44<T>::operator* (const Matrix44<T>& v) const IMATH_NOEXCEPT
 {
     Matrix44 tmp (T (0));
 
@@ -3595,7 +3595,7 @@ Matrix44<T>::operator* (const Matrix44<T>& v) const noexcept
 
 template <class T>
 inline void
-Matrix44<T>::multiply (const Matrix44<T>& a, const Matrix44<T>& b, Matrix44<T>& c) noexcept
+Matrix44<T>::multiply (const Matrix44<T>& a, const Matrix44<T>& b, Matrix44<T>& c) IMATH_NOEXCEPT
 {
     const T* IMATH_RESTRICT ap = &a.x[0][0];
     const T* IMATH_RESTRICT bp = &b.x[0][0];
@@ -3647,7 +3647,7 @@ Matrix44<T>::multiply (const Matrix44<T>& a, const Matrix44<T>& b, Matrix44<T>& 
 template <class T>
 template <class S>
 inline void
-Matrix44<T>::multVecMatrix (const Vec3<S>& src, Vec3<S>& dst) const noexcept
+Matrix44<T>::multVecMatrix (const Vec3<S>& src, Vec3<S>& dst) const IMATH_NOEXCEPT
 {
     S a, b, c, w;
 
@@ -3664,7 +3664,7 @@ Matrix44<T>::multVecMatrix (const Vec3<S>& src, Vec3<S>& dst) const noexcept
 template <class T>
 template <class S>
 inline void
-Matrix44<T>::multDirMatrix (const Vec3<S>& src, Vec3<S>& dst) const noexcept
+Matrix44<T>::multDirMatrix (const Vec3<S>& src, Vec3<S>& dst) const IMATH_NOEXCEPT
 {
     S a, b, c;
 
@@ -3679,7 +3679,7 @@ Matrix44<T>::multDirMatrix (const Vec3<S>& src, Vec3<S>& dst) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::operator/= (T a) noexcept
+Matrix44<T>::operator/= (T a) IMATH_NOEXCEPT
 {
     x[0][0] /= a;
     x[0][1] /= a;
@@ -3703,7 +3703,7 @@ Matrix44<T>::operator/= (T a) noexcept
 
 template <class T>
 constexpr inline Matrix44<T>
-Matrix44<T>::operator/ (T a) const noexcept
+Matrix44<T>::operator/ (T a) const IMATH_NOEXCEPT
 {
     return Matrix44 (x[0][0] / a,
                      x[0][1] / a,
@@ -3725,7 +3725,7 @@ Matrix44<T>::operator/ (T a) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::transpose() noexcept
+Matrix44<T>::transpose() IMATH_NOEXCEPT
 {
     Matrix44 tmp (x[0][0],
                   x[1][0],
@@ -3749,7 +3749,7 @@ Matrix44<T>::transpose() noexcept
 
 template <class T>
 constexpr inline Matrix44<T>
-Matrix44<T>::transposed() const noexcept
+Matrix44<T>::transposed() const IMATH_NOEXCEPT
 {
     return Matrix44 (x[0][0],
                      x[1][0],
@@ -3779,7 +3779,7 @@ Matrix44<T>::gjInvert (bool singExc)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::gjInvert() noexcept
+Matrix44<T>::gjInvert() IMATH_NOEXCEPT
 {
     *this = gjInverse();
     return *this;
@@ -3891,7 +3891,7 @@ Matrix44<T>::gjInverse (bool singExc) const
 
 template <class T>
 inline Matrix44<T>
-Matrix44<T>::gjInverse() const noexcept
+Matrix44<T>::gjInverse() const IMATH_NOEXCEPT
 {
     int i, j, k;
     Matrix44 s;
@@ -3997,7 +3997,7 @@ Matrix44<T>::invert (bool singExc)
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::invert() noexcept
+Matrix44<T>::invert() IMATH_NOEXCEPT
 {
     *this = inverse();
     return *this;
@@ -4074,7 +4074,7 @@ Matrix44<T>::inverse (bool singExc) const
 
 template <class T>
 IMATH_CONSTEXPR14 inline Matrix44<T>
-Matrix44<T>::inverse() const noexcept
+Matrix44<T>::inverse() const IMATH_NOEXCEPT
 {
     if (x[0][3] != 0 || x[1][3] != 0 || x[2][3] != 0 || x[3][3] != 1)
         return gjInverse();
@@ -4145,7 +4145,7 @@ Matrix44<T>::fastMinor (const int r0,
                         const int r2,
                         const int c0,
                         const int c1,
-                        const int c2) const noexcept
+                        const int c2) const IMATH_NOEXCEPT
 {
     return x[r0][c0] * (x[r1][c1] * x[r2][c2] - x[r1][c2] * x[r2][c1]) +
            x[r0][c1] * (x[r1][c2] * x[r2][c0] - x[r1][c0] * x[r2][c2]) +
@@ -4154,7 +4154,7 @@ Matrix44<T>::fastMinor (const int r0,
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Matrix44<T>::minorOf (const int r, const int c) const noexcept
+Matrix44<T>::minorOf (const int r, const int c) const IMATH_NOEXCEPT
 {
     int r0 = 0 + (r < 1 ? 1 : 0);
     int r1 = 1 + (r < 2 ? 1 : 0);
@@ -4178,7 +4178,7 @@ Matrix44<T>::minorOf (const int r, const int c) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Matrix44<T>::determinant() const noexcept
+Matrix44<T>::determinant() const IMATH_NOEXCEPT
 {
     T sum = (T) 0;
 
@@ -4197,7 +4197,7 @@ Matrix44<T>::determinant() const noexcept
 template <class T>
 template <class S>
 inline const Matrix44<T>&
-Matrix44<T>::setEulerAngles (const Vec3<S>& r) noexcept
+Matrix44<T>::setEulerAngles (const Vec3<S>& r) IMATH_NOEXCEPT
 {
     S cos_rz, sin_rz, cos_ry, sin_ry, cos_rx, sin_rx;
 
@@ -4235,7 +4235,7 @@ Matrix44<T>::setEulerAngles (const Vec3<S>& r) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::setAxisAngle (const Vec3<S>& axis, S angle) noexcept
+Matrix44<T>::setAxisAngle (const Vec3<S>& axis, S angle) IMATH_NOEXCEPT
 {
     Vec3<S> unit (axis.normalized());
     S sine   = std::sin (angle);
@@ -4267,7 +4267,7 @@ Matrix44<T>::setAxisAngle (const Vec3<S>& axis, S angle) noexcept
 template <class T>
 template <class S>
 inline const Matrix44<T>&
-Matrix44<T>::rotate (const Vec3<S>& r) noexcept
+Matrix44<T>::rotate (const Vec3<S>& r) IMATH_NOEXCEPT
 {
     S cos_rz, sin_rz, cos_ry, sin_ry, cos_rx, sin_rx;
     S m00, m01, m02;
@@ -4314,7 +4314,7 @@ Matrix44<T>::rotate (const Vec3<S>& r) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::setScale (T s) noexcept
+Matrix44<T>::setScale (T s) IMATH_NOEXCEPT
 {
     //
     // Set the matrix to a 3D homogeneous transform scale:
@@ -4346,7 +4346,7 @@ Matrix44<T>::setScale (T s) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::setScale (const Vec3<S>& s) noexcept
+Matrix44<T>::setScale (const Vec3<S>& s) IMATH_NOEXCEPT
 {
     //
     // Set the matrix to a 3D homogeneous transform scale:
@@ -4378,7 +4378,7 @@ Matrix44<T>::setScale (const Vec3<S>& s) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::scale (const Vec3<S>& s) noexcept
+Matrix44<T>::scale (const Vec3<S>& s) IMATH_NOEXCEPT
 {
     x[0][0] *= s.x;
     x[0][1] *= s.x;
@@ -4401,7 +4401,7 @@ Matrix44<T>::scale (const Vec3<S>& s) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::setTranslation (const Vec3<S>& t) noexcept
+Matrix44<T>::setTranslation (const Vec3<S>& t) IMATH_NOEXCEPT
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -4428,7 +4428,7 @@ Matrix44<T>::setTranslation (const Vec3<S>& t) noexcept
 
 template <class T>
 constexpr inline const Vec3<T>
-Matrix44<T>::translation() const noexcept
+Matrix44<T>::translation() const IMATH_NOEXCEPT
 {
     return Vec3<T> (x[3][0], x[3][1], x[3][2]);
 }
@@ -4436,7 +4436,7 @@ Matrix44<T>::translation() const noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::translate (const Vec3<S>& t) noexcept
+Matrix44<T>::translate (const Vec3<S>& t) IMATH_NOEXCEPT
 {
     x[3][0] += t.x * x[0][0] + t.y * x[1][0] + t.z * x[2][0];
     x[3][1] += t.x * x[0][1] + t.y * x[1][1] + t.z * x[2][1];
@@ -4449,7 +4449,7 @@ Matrix44<T>::translate (const Vec3<S>& t) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::setShear (const Vec3<S>& h) noexcept
+Matrix44<T>::setShear (const Vec3<S>& h) IMATH_NOEXCEPT
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -4477,7 +4477,7 @@ Matrix44<T>::setShear (const Vec3<S>& h) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::setShear (const Shear6<S>& h) noexcept
+Matrix44<T>::setShear (const Shear6<S>& h) IMATH_NOEXCEPT
 {
     x[0][0] = 1;
     x[0][1] = h.yx;
@@ -4505,7 +4505,7 @@ Matrix44<T>::setShear (const Shear6<S>& h) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::shear (const Vec3<S>& h) noexcept
+Matrix44<T>::shear (const Vec3<S>& h) IMATH_NOEXCEPT
 {
     //
     // In this case, we don't need a temp. copy of the matrix
@@ -4525,7 +4525,7 @@ Matrix44<T>::shear (const Vec3<S>& h) noexcept
 template <class T>
 template <class S>
 IMATH_CONSTEXPR14 inline const Matrix44<T>&
-Matrix44<T>::shear (const Shear6<S>& h) noexcept
+Matrix44<T>::shear (const Shear6<S>& h) IMATH_NOEXCEPT
 {
     Matrix44<T> P (*this);
 
@@ -4649,7 +4649,7 @@ operator<< (std::ostream& s, const Matrix44<T>& m)
 
 template <class S, class T>
 inline const Vec2<S>&
-operator*= (Vec2<S>& v, const Matrix22<T>& m) noexcept
+operator*= (Vec2<S>& v, const Matrix22<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1]);
@@ -4662,7 +4662,7 @@ operator*= (Vec2<S>& v, const Matrix22<T>& m) noexcept
 
 template <class S, class T>
 inline Vec2<S>
-operator* (const Vec2<S>& v, const Matrix22<T>& m) noexcept
+operator* (const Vec2<S>& v, const Matrix22<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1]);
@@ -4672,7 +4672,7 @@ operator* (const Vec2<S>& v, const Matrix22<T>& m) noexcept
 
 template <class S, class T>
 inline const Vec2<S>&
-operator*= (Vec2<S>& v, const Matrix33<T>& m) noexcept
+operator*= (Vec2<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + m[2][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + m[2][1]);
@@ -4686,7 +4686,7 @@ operator*= (Vec2<S>& v, const Matrix33<T>& m) noexcept
 
 template <class S, class T>
 inline Vec2<S>
-operator* (const Vec2<S>& v, const Matrix33<T>& m) noexcept
+operator* (const Vec2<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + m[2][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + m[2][1]);
@@ -4697,7 +4697,7 @@ operator* (const Vec2<S>& v, const Matrix33<T>& m) noexcept
 
 template <class S, class T>
 inline const Vec3<S>&
-operator*= (Vec3<S>& v, const Matrix33<T>& m) noexcept
+operator*= (Vec3<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1]);
@@ -4712,7 +4712,7 @@ operator*= (Vec3<S>& v, const Matrix33<T>& m) noexcept
 
 template <class S, class T>
 inline Vec3<S>
-operator* (const Vec3<S>& v, const Matrix33<T>& m) noexcept
+operator* (const Vec3<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1]);
@@ -4723,7 +4723,7 @@ operator* (const Vec3<S>& v, const Matrix33<T>& m) noexcept
 
 template <class S, class T>
 inline const Vec3<S>&
-operator*= (Vec3<S>& v, const Matrix44<T>& m) noexcept
+operator*= (Vec3<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0] + m[3][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1] + m[3][1]);
@@ -4739,7 +4739,7 @@ operator*= (Vec3<S>& v, const Matrix44<T>& m) noexcept
 
 template <class S, class T>
 inline Vec3<S>
-operator* (const Vec3<S>& v, const Matrix44<T>& m) noexcept
+operator* (const Vec3<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0] + m[3][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1] + m[3][1]);
@@ -4751,7 +4751,7 @@ operator* (const Vec3<S>& v, const Matrix44<T>& m) noexcept
 
 template <class S, class T>
 inline const Vec4<S>&
-operator*= (Vec4<S>& v, const Matrix44<T>& m) noexcept
+operator*= (Vec4<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0] + v.w * m[3][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1] + v.w * m[3][1]);
@@ -4768,7 +4768,7 @@ operator*= (Vec4<S>& v, const Matrix44<T>& m) noexcept
 
 template <class S, class T>
 inline Vec4<S>
-operator* (const Vec4<S>& v, const Matrix44<T>& m) noexcept
+operator* (const Vec4<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0] + v.w * m[3][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1] + v.w * m[3][1]);

--- a/src/Imath/ImathPlane.h
+++ b/src/Imath/ImathPlane.h
@@ -47,18 +47,18 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Plane3
     ///	@name Constructors
 
     /// Uninitialized by default
-    IMATH_HOSTDEVICE Plane3() noexcept {}
+    IMATH_HOSTDEVICE Plane3() IMATH_NOEXCEPT {}
 
     /// Initialize with a normal and distance
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Plane3 (const Vec3<T>& normal, T distance) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Plane3 (const Vec3<T>& normal, T distance) IMATH_NOEXCEPT;
 
     /// Initialize with a point and a normal
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Plane3 (const Vec3<T>& point, const Vec3<T>& normal) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Plane3 (const Vec3<T>& point, const Vec3<T>& normal) IMATH_NOEXCEPT;
     
     /// Initialize with three points
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Plane3 (const Vec3<T>& point1,
                                                const Vec3<T>& point2,
-                                               const Vec3<T>& point3) noexcept;
+                                               const Vec3<T>& point3) IMATH_NOEXCEPT;
 
     /// @}
     
@@ -66,13 +66,13 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Plane3
     /// @name Manipulation
     
     /// Set via a given normal and distance
-    IMATH_HOSTDEVICE void set (const Vec3<T>& normal, T distance) noexcept;
+    IMATH_HOSTDEVICE void set (const Vec3<T>& normal, T distance) IMATH_NOEXCEPT;
 
     /// Set via a given point and normal
-    IMATH_HOSTDEVICE void set (const Vec3<T>& point, const Vec3<T>& normal) noexcept;
+    IMATH_HOSTDEVICE void set (const Vec3<T>& point, const Vec3<T>& normal) IMATH_NOEXCEPT;
 
     /// Set via three points
-    IMATH_HOSTDEVICE void set (const Vec3<T>& point1, const Vec3<T>& point2, const Vec3<T>& point3) noexcept;
+    IMATH_HOSTDEVICE void set (const Vec3<T>& point1, const Vec3<T>& point2, const Vec3<T>& point3) IMATH_NOEXCEPT;
 
     /// @}
     
@@ -84,22 +84,22 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Plane3
     /// @param[out] intersection The point of intersection
     /// @return True if the line intersects the plane.
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool
-    intersect (const Line3<T>& line, Vec3<T>& intersection) const noexcept;
+    intersect (const Line3<T>& line, Vec3<T>& intersection) const IMATH_NOEXCEPT;
 
     /// Determine if a line intersects the plane.
     /// @param line The line
     /// @param[out] parameter The parametric value of the point of intersection
     /// @return True if the line intersects the plane.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersectT (const Line3<T>& line, T& parameter) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool intersectT (const Line3<T>& line, T& parameter) const IMATH_NOEXCEPT;
 
     /// Return the distance from a point to the plane.
-    IMATH_HOSTDEVICE constexpr T distanceTo (const Vec3<T>& point) const noexcept;
+    IMATH_HOSTDEVICE constexpr T distanceTo (const Vec3<T>& point) const IMATH_NOEXCEPT;
 
     /// Reflect the given point around the plane.
-    IMATH_HOSTDEVICE constexpr Vec3<T> reflectPoint (const Vec3<T>& point) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3<T> reflectPoint (const Vec3<T>& point) const IMATH_NOEXCEPT;
 
     /// Reflect the direction vector around the plane
-    IMATH_HOSTDEVICE constexpr Vec3<T> reflectVector (const Vec3<T>& vec) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3<T> reflectVector (const Vec3<T>& vec) const IMATH_NOEXCEPT;
 
     /// @}
 };
@@ -115,24 +115,24 @@ typedef Plane3<double> Plane3d;
 //---------------
 
 template <class T>
-IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& p0, const Vec3<T>& p1, const Vec3<T>& p2) noexcept
+IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& p0, const Vec3<T>& p1, const Vec3<T>& p2) IMATH_NOEXCEPT
 {
     set (p0, p1, p2);
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& n, T d) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& n, T d) IMATH_NOEXCEPT
 {
     set (n, d);
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& p, const Vec3<T>& n) noexcept
+template <class T> IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& p, const Vec3<T>& n) IMATH_NOEXCEPT
 {
     set (p, n);
 }
 
 template <class T>
 inline void
-Plane3<T>::set (const Vec3<T>& point1, const Vec3<T>& point2, const Vec3<T>& point3) noexcept
+Plane3<T>::set (const Vec3<T>& point1, const Vec3<T>& point2, const Vec3<T>& point3) IMATH_NOEXCEPT
 {
     normal = (point2 - point1) % (point3 - point1);
     normal.normalize();
@@ -141,7 +141,7 @@ Plane3<T>::set (const Vec3<T>& point1, const Vec3<T>& point2, const Vec3<T>& poi
 
 template <class T>
 inline void
-Plane3<T>::set (const Vec3<T>& point, const Vec3<T>& n) noexcept
+Plane3<T>::set (const Vec3<T>& point, const Vec3<T>& n) IMATH_NOEXCEPT
 {
     normal = n;
     normal.normalize();
@@ -150,7 +150,7 @@ Plane3<T>::set (const Vec3<T>& point, const Vec3<T>& n) noexcept
 
 template <class T>
 inline void
-Plane3<T>::set (const Vec3<T>& n, T d) noexcept
+Plane3<T>::set (const Vec3<T>& n, T d) IMATH_NOEXCEPT
 {
     normal = n;
     normal.normalize();
@@ -159,28 +159,28 @@ Plane3<T>::set (const Vec3<T>& n, T d) noexcept
 
 template <class T>
 constexpr inline T
-Plane3<T>::distanceTo (const Vec3<T>& point) const noexcept
+Plane3<T>::distanceTo (const Vec3<T>& point) const IMATH_NOEXCEPT
 {
     return (point ^ normal) - distance;
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Plane3<T>::reflectPoint (const Vec3<T>& point) const noexcept
+Plane3<T>::reflectPoint (const Vec3<T>& point) const IMATH_NOEXCEPT
 {
     return normal * distanceTo (point) * -2.0 + point;
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Plane3<T>::reflectVector (const Vec3<T>& v) const noexcept
+Plane3<T>::reflectVector (const Vec3<T>& v) const IMATH_NOEXCEPT
 {
     return normal * (normal ^ v) * 2.0 - v;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Plane3<T>::intersect (const Line3<T>& line, Vec3<T>& point) const noexcept
+Plane3<T>::intersect (const Line3<T>& line, Vec3<T>& point) const IMATH_NOEXCEPT
 {
     T d = normal ^ line.dir;
     if (d == 0.0)
@@ -192,7 +192,7 @@ Plane3<T>::intersect (const Line3<T>& line, Vec3<T>& point) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Plane3<T>::intersectT (const Line3<T>& line, T& t) const noexcept
+Plane3<T>::intersectT (const Line3<T>& line, T& t) const IMATH_NOEXCEPT
 {
     T d = normal ^ line.dir;
     if (d == 0.0)
@@ -212,7 +212,7 @@ operator<< (std::ostream& o, const Plane3<T>& plane)
 /// Transform a plane by a matrix
 template <class T>
 IMATH_CONSTEXPR14 Plane3<T>
-operator* (const Plane3<T>& plane, const Matrix44<T>& M) noexcept
+operator* (const Plane3<T>& plane, const Matrix44<T>& M) IMATH_NOEXCEPT
 {
     //                        T
     //	                    -1
@@ -248,7 +248,7 @@ operator* (const Plane3<T>& plane, const Matrix44<T>& M) noexcept
 /// Reflect the pla
 template <class T>
 constexpr inline Plane3<T>
-operator- (const Plane3<T>& plane) noexcept
+operator- (const Plane3<T>& plane) IMATH_NOEXCEPT
 {
     return Plane3<T> (-plane.normal, -plane.distance);
 }

--- a/src/Imath/ImathQuat.h
+++ b/src/Imath/ImathQuat.h
@@ -55,38 +55,38 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Quat
 
     /// Element access: q[0] is the real part, (q[1],q[2],q[3]) is the
     /// imaginary part.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int index) noexcept; // as 4D vector
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int index) IMATH_NOEXCEPT; // as 4D vector
 
     /// Element access: q[0] is the real part, (q[1],q[2],q[3]) is the
     /// imaginary part.
-    IMATH_HOSTDEVICE constexpr T operator[] (int index) const noexcept;
+    IMATH_HOSTDEVICE constexpr T operator[] (int index) const IMATH_NOEXCEPT;
 
     /// @{
     ///	@name Constructors
 
     /// Default constructor is the identity quat
-    IMATH_HOSTDEVICE constexpr Quat() noexcept;
+    IMATH_HOSTDEVICE constexpr Quat() IMATH_NOEXCEPT;
 
     /// Copy constructor
-    IMATH_HOSTDEVICE constexpr Quat (const Quat& q) noexcept;
+    IMATH_HOSTDEVICE constexpr Quat (const Quat& q) IMATH_NOEXCEPT;
 
     /// Construct from a quaternion of a another base type
-    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat (const Quat<S>& q) noexcept;
+    template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat (const Quat<S>& q) IMATH_NOEXCEPT;
 
     /// Initialize with real part `s` and imaginary vector 1(i,j,k)`
-    IMATH_HOSTDEVICE constexpr Quat (T s, T i, T j, T k) noexcept;
+    IMATH_HOSTDEVICE constexpr Quat (T s, T i, T j, T k) IMATH_NOEXCEPT;
 
     /// Initialize with real part `s` and imaginary vector `d`
-    IMATH_HOSTDEVICE constexpr Quat (T s, Vec3<T> d) noexcept;
+    IMATH_HOSTDEVICE constexpr Quat (T s, Vec3<T> d) IMATH_NOEXCEPT;
 
     /// The identity quaternion
-    IMATH_HOSTDEVICE constexpr static Quat<T> identity() noexcept;
+    IMATH_HOSTDEVICE constexpr static Quat<T> identity() IMATH_NOEXCEPT;
 
     /// Assignment
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator= (const Quat<T>& q) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator= (const Quat<T>& q) IMATH_NOEXCEPT;
 
     /// Destructor
-    ~Quat() noexcept = default;
+    ~Quat() IMATH_NOEXCEPT = default;
 
     /// @}
 
@@ -97,30 +97,30 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Quat
     //
 
     /// Quaternion multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator*= (const Quat<T>& q) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator*= (const Quat<T>& q) IMATH_NOEXCEPT;
     
     /// Scalar multiplication: multiply both real and imaginary parts
     /// by the given scalar.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator*= (T t) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator*= (T t) IMATH_NOEXCEPT;
 
     /// Quaterion division, using the inverse()
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator/= (const Quat<T>& q) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator/= (const Quat<T>& q) IMATH_NOEXCEPT;
 
     /// Scalar division: multiply both real and imaginary parts
     /// by the given scalar.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator/= (T t) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator/= (T t) IMATH_NOEXCEPT;
 
     /// Quaternion addition
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator+= (const Quat<T>& q) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator+= (const Quat<T>& q) IMATH_NOEXCEPT;
 
     /// Quaternion subtraction
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator-= (const Quat<T>& q) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator-= (const Quat<T>& q) IMATH_NOEXCEPT;
 
     /// Equality
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Quat<S>& q) const noexcept;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Quat<S>& q) const IMATH_NOEXCEPT;
 
     /// Inequality
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Quat<S>& q) const noexcept;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Quat<S>& q) const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -129,25 +129,25 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Quat
     /// @name Query
     
     /// Return the R4 length
-    IMATH_HOSTDEVICE constexpr T length() const noexcept; // in R4
+    IMATH_HOSTDEVICE constexpr T length() const IMATH_NOEXCEPT; // in R4
 
     /// Return the angle of the axis/angle representation
-    IMATH_HOSTDEVICE constexpr T angle() const noexcept;
+    IMATH_HOSTDEVICE constexpr T angle() const IMATH_NOEXCEPT;
 
     /// Return the axis of the axis/angle representation
-    IMATH_HOSTDEVICE constexpr Vec3<T> axis() const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3<T> axis() const IMATH_NOEXCEPT;
 
     /// Return a 3x3 rotation matrix
-    IMATH_HOSTDEVICE constexpr Matrix33<T> toMatrix33() const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix33<T> toMatrix33() const IMATH_NOEXCEPT;
 
     /// Return a 4x4 rotation matrix
-    IMATH_HOSTDEVICE constexpr Matrix44<T> toMatrix44() const noexcept;
+    IMATH_HOSTDEVICE constexpr Matrix44<T> toMatrix44() const IMATH_NOEXCEPT;
 
     /// Return the logarithm of the quaterion
-    IMATH_HOSTDEVICE Quat<T> log() const noexcept;
+    IMATH_HOSTDEVICE Quat<T> log() const IMATH_NOEXCEPT;
 
     /// Return the exponent of the quaterion
-    IMATH_HOSTDEVICE Quat<T> exp() const noexcept;
+    IMATH_HOSTDEVICE Quat<T> exp() const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -156,34 +156,34 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Quat
     
     /// Invert in place: this = 1 / this.
     /// @return const reference to this.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>& invert() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>& invert() IMATH_NOEXCEPT;
 
     /// Return 1/this, leaving this unchanged.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T> inverse() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T> inverse() const IMATH_NOEXCEPT;
 
     /// Normalize in place
     /// @return const reference to this.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>& normalize() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>& normalize() IMATH_NOEXCEPT;
     
     /// Return a normalized quaternion, leaving this unmodified.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T> normalized() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T> normalized() const IMATH_NOEXCEPT;
 
     /// Rotate the given point by the quaterion.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T> rotateVector (const Vec3<T>& original) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T> rotateVector (const Vec3<T>& original) const IMATH_NOEXCEPT;
 
     /// Return the Euclidean inner product.
-    IMATH_HOSTDEVICE constexpr T euclideanInnerProduct (const Quat<T>& q) const noexcept;
+    IMATH_HOSTDEVICE constexpr T euclideanInnerProduct (const Quat<T>& q) const IMATH_NOEXCEPT;
 
     /// Set the quaterion to be a rotation around the given axis by the
     /// given angle.
     /// @return const reference to this.
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>& setAxisAngle (const Vec3<T>& axis, T radians) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>& setAxisAngle (const Vec3<T>& axis, T radians) IMATH_NOEXCEPT;
 
     /// Set the quaternion to be a rotation that transforms the
     /// direction vector `fromDirection` to `toDirection`
     /// @return const reference to this.
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>&
-    setRotation (const Vec3<T>& fromDirection, const Vec3<T>& toDirection) noexcept;
+    setRotation (const Vec3<T>& fromDirection, const Vec3<T>& toDirection) IMATH_NOEXCEPT;
 
     /// @}
     
@@ -192,17 +192,17 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Quat
     typedef T BaseType;
 
   private:
-    IMATH_HOSTDEVICE void setRotationInternal (const Vec3<T>& f0, const Vec3<T>& t0, Quat<T>& q) noexcept;
+    IMATH_HOSTDEVICE void setRotationInternal (const Vec3<T>& f0, const Vec3<T>& t0, Quat<T>& q) IMATH_NOEXCEPT;
 };
 
-template <class T> IMATH_CONSTEXPR14 Quat<T> slerp (const Quat<T>& q1, const Quat<T>& q2, T t) noexcept;
+template <class T> IMATH_CONSTEXPR14 Quat<T> slerp (const Quat<T>& q1, const Quat<T>& q2, T t) IMATH_NOEXCEPT;
 
 template <class T>
-IMATH_CONSTEXPR14 Quat<T> slerpShortestArc (const Quat<T>& q1, const Quat<T>& q2, T t) noexcept;
+IMATH_CONSTEXPR14 Quat<T> slerpShortestArc (const Quat<T>& q1, const Quat<T>& q2, T t) IMATH_NOEXCEPT;
 
 template <class T>
 IMATH_CONSTEXPR14 Quat<T>
-squad (const Quat<T>& q1, const Quat<T>& q2, const Quat<T>& qa, const Quat<T>& qb, T t) noexcept;
+squad (const Quat<T>& q1, const Quat<T>& q2, const Quat<T>& qa, const Quat<T>& qb, T t) IMATH_NOEXCEPT;
 
 ///
 /// From advanced Animation and Rendering Techniques by Watt and Watt,
@@ -216,33 +216,33 @@ void intermediate (const Quat<T>& q0,
                    const Quat<T>& q2,
                    const Quat<T>& q3,
                    Quat<T>& qa,
-                   Quat<T>& qb) noexcept;
+                   Quat<T>& qb) IMATH_NOEXCEPT;
 
-template <class T> constexpr Matrix33<T> operator* (const Matrix33<T>& M, const Quat<T>& q) noexcept;
+template <class T> constexpr Matrix33<T> operator* (const Matrix33<T>& M, const Quat<T>& q) IMATH_NOEXCEPT;
 
-template <class T> constexpr Matrix33<T> operator* (const Quat<T>& q, const Matrix33<T>& M) noexcept;
+template <class T> constexpr Matrix33<T> operator* (const Quat<T>& q, const Matrix33<T>& M) IMATH_NOEXCEPT;
 
 template <class T> std::ostream& operator<< (std::ostream& o, const Quat<T>& q);
 
-template <class T> constexpr Quat<T> operator* (const Quat<T>& q1, const Quat<T>& q2) noexcept;
+template <class T> constexpr Quat<T> operator* (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator/ (const Quat<T>& q1, const Quat<T>& q2) noexcept;
+template <class T> constexpr Quat<T> operator/ (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator/ (const Quat<T>& q, T t) noexcept;
+template <class T> constexpr Quat<T> operator/ (const Quat<T>& q, T t) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator* (const Quat<T>& q, T t) noexcept;
+template <class T> constexpr Quat<T> operator* (const Quat<T>& q, T t) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator* (T t, const Quat<T>& q) noexcept;
+template <class T> constexpr Quat<T> operator* (T t, const Quat<T>& q) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator+ (const Quat<T>& q1, const Quat<T>& q2) noexcept;
+template <class T> constexpr Quat<T> operator+ (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator- (const Quat<T>& q1, const Quat<T>& q2) noexcept;
+template <class T> constexpr Quat<T> operator- (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator~ (const Quat<T>& q) noexcept;
+template <class T> constexpr Quat<T> operator~ (const Quat<T>& q) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator- (const Quat<T>& q) noexcept;
+template <class T> constexpr Quat<T> operator- (const Quat<T>& q) IMATH_NOEXCEPT;
 
-template <class T> IMATH_CONSTEXPR14 Vec3<T> operator* (const Vec3<T>& v, const Quat<T>& q) noexcept;
+template <class T> IMATH_CONSTEXPR14 Vec3<T> operator* (const Vec3<T>& v, const Quat<T>& q) IMATH_NOEXCEPT;
 
 /// Quaternion of type float
 typedef Quat<float> Quatf;
@@ -254,43 +254,43 @@ typedef Quat<double> Quatd;
 // Implementation
 //---------------
 
-template <class T> constexpr inline Quat<T>::Quat() noexcept : r (1), v (0, 0, 0)
+template <class T> constexpr inline Quat<T>::Quat() IMATH_NOEXCEPT : r (1), v (0, 0, 0)
 {
     // empty
 }
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Quat<T>::Quat (const Quat<S>& q) noexcept : r (q.r), v (q.v)
+IMATH_CONSTEXPR14 inline Quat<T>::Quat (const Quat<S>& q) IMATH_NOEXCEPT : r (q.r), v (q.v)
 {
     // empty
 }
 
-template <class T> constexpr inline Quat<T>::Quat (T s, T i, T j, T k) noexcept : r (s), v (i, j, k)
+template <class T> constexpr inline Quat<T>::Quat (T s, T i, T j, T k) IMATH_NOEXCEPT : r (s), v (i, j, k)
 {
     // empty
 }
 
-template <class T> constexpr inline Quat<T>::Quat (T s, Vec3<T> d) noexcept : r (s), v (d)
+template <class T> constexpr inline Quat<T>::Quat (T s, Vec3<T> d) IMATH_NOEXCEPT : r (s), v (d)
 {
     // empty
 }
 
-template <class T> constexpr inline Quat<T>::Quat (const Quat<T>& q) noexcept : r (q.r), v (q.v)
+template <class T> constexpr inline Quat<T>::Quat (const Quat<T>& q) IMATH_NOEXCEPT : r (q.r), v (q.v)
 {
     // empty
 }
 
 template <class T>
 constexpr inline Quat<T>
-Quat<T>::identity() noexcept
+Quat<T>::identity() IMATH_NOEXCEPT
 {
     return Quat<T>();
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Quat<T>&
-Quat<T>::operator= (const Quat<T>& q) noexcept
+Quat<T>::operator= (const Quat<T>& q) IMATH_NOEXCEPT
 {
     r = q.r;
     v = q.v;
@@ -299,7 +299,7 @@ Quat<T>::operator= (const Quat<T>& q) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Quat<T>&
-Quat<T>::operator*= (const Quat<T>& q) noexcept
+Quat<T>::operator*= (const Quat<T>& q) IMATH_NOEXCEPT
 {
     T rtmp = r * q.r - (v ^ q.v);
     v      = r * q.v + v * q.r + v % q.v;
@@ -309,7 +309,7 @@ Quat<T>::operator*= (const Quat<T>& q) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Quat<T>&
-Quat<T>::operator*= (T t) noexcept
+Quat<T>::operator*= (T t) IMATH_NOEXCEPT
 {
     r *= t;
     v *= t;
@@ -318,7 +318,7 @@ Quat<T>::operator*= (T t) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Quat<T>&
-Quat<T>::operator/= (const Quat<T>& q) noexcept
+Quat<T>::operator/= (const Quat<T>& q) IMATH_NOEXCEPT
 {
     *this = *this * q.inverse();
     return *this;
@@ -326,7 +326,7 @@ Quat<T>::operator/= (const Quat<T>& q) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Quat<T>&
-Quat<T>::operator/= (T t) noexcept
+Quat<T>::operator/= (T t) IMATH_NOEXCEPT
 {
     r /= t;
     v /= t;
@@ -335,7 +335,7 @@ Quat<T>::operator/= (T t) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Quat<T>&
-Quat<T>::operator+= (const Quat<T>& q) noexcept
+Quat<T>::operator+= (const Quat<T>& q) IMATH_NOEXCEPT
 {
     r += q.r;
     v += q.v;
@@ -344,7 +344,7 @@ Quat<T>::operator+= (const Quat<T>& q) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Quat<T>&
-Quat<T>::operator-= (const Quat<T>& q) noexcept
+Quat<T>::operator-= (const Quat<T>& q) IMATH_NOEXCEPT
 {
     r -= q.r;
     v -= q.v;
@@ -353,14 +353,14 @@ Quat<T>::operator-= (const Quat<T>& q) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline T&
-Quat<T>::operator[] (int index) noexcept
+Quat<T>::operator[] (int index) IMATH_NOEXCEPT
 {
     return index ? v[index - 1] : r;
 }
 
 template <class T>
 constexpr inline T
-Quat<T>::operator[] (int index) const noexcept
+Quat<T>::operator[] (int index) const IMATH_NOEXCEPT
 {
     return index ? v[index - 1] : r;
 }
@@ -368,7 +368,7 @@ Quat<T>::operator[] (int index) const noexcept
 template <class T>
 template <class S>
 constexpr inline bool
-Quat<T>::operator== (const Quat<S>& q) const noexcept
+Quat<T>::operator== (const Quat<S>& q) const IMATH_NOEXCEPT
 {
     return r == q.r && v == q.v;
 }
@@ -376,7 +376,7 @@ Quat<T>::operator== (const Quat<S>& q) const noexcept
 template <class T>
 template <class S>
 constexpr inline bool
-Quat<T>::operator!= (const Quat<S>& q) const noexcept
+Quat<T>::operator!= (const Quat<S>& q) const IMATH_NOEXCEPT
 {
     return r != q.r || v != q.v;
 }
@@ -384,21 +384,21 @@ Quat<T>::operator!= (const Quat<S>& q) const noexcept
 /// 4D dot product
 template <class T>
 IMATH_HOSTDEVICE constexpr inline T
-operator^ (const Quat<T>& q1, const Quat<T>& q2) noexcept
+operator^ (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 {
     return q1.r * q2.r + (q1.v ^ q2.v);
 }
 
 template <class T>
 constexpr inline T
-Quat<T>::length() const noexcept
+Quat<T>::length() const IMATH_NOEXCEPT
 {
     return std::sqrt (r * r + (v ^ v));
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>&
-Quat<T>::normalize() noexcept
+Quat<T>::normalize() IMATH_NOEXCEPT
 {
     if (T l = length())
     {
@@ -416,7 +416,7 @@ Quat<T>::normalize() noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>
-Quat<T>::normalized() const noexcept
+Quat<T>::normalized() const IMATH_NOEXCEPT
 {
     if (T l = length())
         return Quat (r / l, v / l);
@@ -426,7 +426,7 @@ Quat<T>::normalized() const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>
-Quat<T>::inverse() const noexcept
+Quat<T>::inverse() const IMATH_NOEXCEPT
 {
     //
     // 1    Q*
@@ -440,7 +440,7 @@ Quat<T>::inverse() const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>&
-Quat<T>::invert() noexcept
+Quat<T>::invert() IMATH_NOEXCEPT
 {
     T qdot = (*this) ^ (*this);
     r /= qdot;
@@ -450,7 +450,7 @@ Quat<T>::invert() noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline Vec3<T>
-Quat<T>::rotateVector (const Vec3<T>& original) const noexcept
+Quat<T>::rotateVector (const Vec3<T>& original) const IMATH_NOEXCEPT
 {
     //
     // Given a vector p and a quaternion q (aka this),
@@ -470,7 +470,7 @@ Quat<T>::rotateVector (const Vec3<T>& original) const noexcept
 
 template <class T>
 constexpr inline T
-Quat<T>::euclideanInnerProduct (const Quat<T>& q) const noexcept
+Quat<T>::euclideanInnerProduct (const Quat<T>& q) const IMATH_NOEXCEPT
 {
     return r * q.r + v.x * q.v.x + v.y * q.v.y + v.z * q.v.z;
 }
@@ -480,7 +480,7 @@ Quat<T>::euclideanInnerProduct (const Quat<T>& q) const noexcept
 /// interpreting the quaternions as 4D vectors.
 template <class T>
 IMATH_CONSTEXPR14 inline T
-angle4D (const Quat<T>& q1, const Quat<T>& q2) noexcept
+angle4D (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 {
     Quat<T> d = q1 - q2;
     T lengthD = std::sqrt (d ^ d);
@@ -510,7 +510,7 @@ angle4D (const Quat<T>& q1, const Quat<T>& q2) noexcept
 /// http://www.plunk.org/~hatch/rightway.php
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>
-slerp (const Quat<T>& q1, const Quat<T>& q2, T t) noexcept
+slerp (const Quat<T>& q1, const Quat<T>& q2, T t) IMATH_NOEXCEPT
 {
     T a = angle4D (q1, q2);
     T s = 1 - t;
@@ -527,7 +527,7 @@ slerp (const Quat<T>& q1, const Quat<T>& q2, T t) noexcept
 /// Assumes q1 and q2 are unit quaternions.
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>
-slerpShortestArc (const Quat<T>& q1, const Quat<T>& q2, T t) noexcept
+slerpShortestArc (const Quat<T>& q1, const Quat<T>& q2, T t) IMATH_NOEXCEPT
 {
     if ((q1 ^ q2) >= 0)
         return slerp (q1, q2, t);
@@ -555,7 +555,7 @@ slerpShortestArc (const Quat<T>& q1, const Quat<T>& q2, T t) noexcept
 /// qb.
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>
-spline (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2, const Quat<T>& q3, T t) noexcept
+spline (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2, const Quat<T>& q3, T t) IMATH_NOEXCEPT
 {
     Quat<T> qa     = intermediate (q0, q1, q2);
     Quat<T> qb     = intermediate (q1, q2, q3);
@@ -573,7 +573,7 @@ spline (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2, const Quat<T>& 
 /// quaternions.
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>
-squad (const Quat<T>& q1, const Quat<T>& qa, const Quat<T>& qb, const Quat<T>& q2, T t) noexcept
+squad (const Quat<T>& q1, const Quat<T>& qa, const Quat<T>& qb, const Quat<T>& q2, T t) IMATH_NOEXCEPT
 {
     Quat<T> r1     = slerp (q1, q2, t);
     Quat<T> r2     = slerp (qa, qb, t);
@@ -586,7 +586,7 @@ squad (const Quat<T>& q1, const Quat<T>& qa, const Quat<T>& qb, const Quat<T>& q
 /// and `q2`.
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>
-intermediate (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2) noexcept
+intermediate (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 {
     Quat<T> q1inv = q1.inverse();
     Quat<T> c1    = q1inv * q2;
@@ -599,7 +599,7 @@ intermediate (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2) noexcept
 
 template <class T>
 inline Quat<T>
-Quat<T>::log() const noexcept
+Quat<T>::log() const IMATH_NOEXCEPT
 {
     //
     // For unit quaternion, from Advanced Animation and
@@ -624,7 +624,7 @@ Quat<T>::log() const noexcept
 
 template <class T>
 inline Quat<T>
-Quat<T>::exp() const noexcept
+Quat<T>::exp() const IMATH_NOEXCEPT
 {
     //
     // For pure quaternion (zero scalar part):
@@ -648,21 +648,21 @@ Quat<T>::exp() const noexcept
 
 template <class T>
 constexpr inline T
-Quat<T>::angle() const noexcept
+Quat<T>::angle() const IMATH_NOEXCEPT
 {
     return 2 * std::atan2 (v.length(), r);
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Quat<T>::axis() const noexcept
+Quat<T>::axis() const IMATH_NOEXCEPT
 {
     return v.normalized();
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>&
-Quat<T>::setAxisAngle (const Vec3<T>& axis, T radians) noexcept
+Quat<T>::setAxisAngle (const Vec3<T>& axis, T radians) IMATH_NOEXCEPT
 {
     r = std::cos (radians / 2);
     v = axis.normalized() * std::sin (radians / 2);
@@ -671,7 +671,7 @@ Quat<T>::setAxisAngle (const Vec3<T>& axis, T radians) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline Quat<T>&
-Quat<T>::setRotation (const Vec3<T>& from, const Vec3<T>& to) noexcept
+Quat<T>::setRotation (const Vec3<T>& from, const Vec3<T>& to) IMATH_NOEXCEPT
 {
     //
     // Create a quaternion that rotates vector from into vector to,
@@ -745,7 +745,7 @@ Quat<T>::setRotation (const Vec3<T>& from, const Vec3<T>& to) noexcept
 
 template <class T>
 inline void
-Quat<T>::setRotationInternal (const Vec3<T>& f0, const Vec3<T>& t0, Quat<T>& q) noexcept
+Quat<T>::setRotationInternal (const Vec3<T>& f0, const Vec3<T>& t0, Quat<T>& q) IMATH_NOEXCEPT
 {
     //
     // The following is equivalent to setAxisAngle(n,2*phi),
@@ -776,7 +776,7 @@ Quat<T>::setRotationInternal (const Vec3<T>& f0, const Vec3<T>& t0, Quat<T>& q) 
 
 template <class T>
 constexpr inline Matrix33<T>
-Quat<T>::toMatrix33() const noexcept
+Quat<T>::toMatrix33() const IMATH_NOEXCEPT
 {
     return Matrix33<T> (1 - 2 * (v.y * v.y + v.z * v.z),
                         2 * (v.x * v.y + v.z * r),
@@ -793,7 +793,7 @@ Quat<T>::toMatrix33() const noexcept
 
 template <class T>
 constexpr inline Matrix44<T>
-Quat<T>::toMatrix44() const noexcept
+Quat<T>::toMatrix44() const IMATH_NOEXCEPT
 {
     return Matrix44<T> (1 - 2 * (v.y * v.y + v.z * v.z),
                         2 * (v.x * v.y + v.z * r),
@@ -817,7 +817,7 @@ Quat<T>::toMatrix44() const noexcept
 /// @return M * q
 template <class T>
 constexpr inline Matrix33<T>
-operator* (const Matrix33<T>& M, const Quat<T>& q) noexcept
+operator* (const Matrix33<T>& M, const Quat<T>& q) IMATH_NOEXCEPT
 {
     return M * q.toMatrix33();
 }
@@ -826,7 +826,7 @@ operator* (const Matrix33<T>& M, const Quat<T>& q) noexcept
 /// @return q * M
 template <class T>
 constexpr inline Matrix33<T>
-operator* (const Quat<T>& q, const Matrix33<T>& M) noexcept
+operator* (const Quat<T>& q, const Matrix33<T>& M) IMATH_NOEXCEPT
 {
     return q.toMatrix33() * M;
 }
@@ -842,7 +842,7 @@ operator<< (std::ostream& o, const Quat<T>& q)
 /// Quaterion multiplication
 template <class T>
 constexpr inline Quat<T>
-operator* (const Quat<T>& q1, const Quat<T>& q2) noexcept
+operator* (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 {
     return Quat<T> (q1.r * q2.r - (q1.v ^ q2.v), q1.r * q2.v + q1.v * q2.r + q1.v % q2.v);
 }
@@ -850,7 +850,7 @@ operator* (const Quat<T>& q1, const Quat<T>& q2) noexcept
 /// Quaterion division
 template <class T>
 constexpr inline Quat<T>
-operator/ (const Quat<T>& q1, const Quat<T>& q2) noexcept
+operator/ (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 {
     return q1 * q2.inverse();
 }
@@ -858,7 +858,7 @@ operator/ (const Quat<T>& q1, const Quat<T>& q2) noexcept
 /// Quaterion division
 template <class T>
 constexpr inline Quat<T>
-operator/ (const Quat<T>& q, T t) noexcept
+operator/ (const Quat<T>& q, T t) IMATH_NOEXCEPT
 {
     return Quat<T> (q.r / t, q.v / t);
 }
@@ -867,7 +867,7 @@ operator/ (const Quat<T>& q, T t) noexcept
 /// @return q * t
 template <class T>
 constexpr inline Quat<T>
-operator* (const Quat<T>& q, T t) noexcept
+operator* (const Quat<T>& q, T t) IMATH_NOEXCEPT
 {
     return Quat<T> (q.r * t, q.v * t);
 }
@@ -876,7 +876,7 @@ operator* (const Quat<T>& q, T t) noexcept
 /// @return q * t
 template <class T>
 constexpr inline Quat<T>
-operator* (T t, const Quat<T>& q) noexcept
+operator* (T t, const Quat<T>& q) IMATH_NOEXCEPT
 {
     return Quat<T> (q.r * t, q.v * t);
 }
@@ -884,7 +884,7 @@ operator* (T t, const Quat<T>& q) noexcept
 /// Quaterion addition
 template <class T>
 constexpr inline Quat<T>
-operator+ (const Quat<T>& q1, const Quat<T>& q2) noexcept
+operator+ (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 {
     return Quat<T> (q1.r + q2.r, q1.v + q2.v);
 }
@@ -892,7 +892,7 @@ operator+ (const Quat<T>& q1, const Quat<T>& q2) noexcept
 /// Quaterion subtraction
 template <class T>
 constexpr inline Quat<T>
-operator- (const Quat<T>& q1, const Quat<T>& q2) noexcept
+operator- (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 {
     return Quat<T> (q1.r - q2.r, q1.v - q2.v);
 }
@@ -900,7 +900,7 @@ operator- (const Quat<T>& q1, const Quat<T>& q2) noexcept
 /// Compute the conjugate
 template <class T>
 constexpr inline Quat<T>
-operator~ (const Quat<T>& q) noexcept
+operator~ (const Quat<T>& q) IMATH_NOEXCEPT
 {
     return Quat<T> (q.r, -q.v);
 }
@@ -908,7 +908,7 @@ operator~ (const Quat<T>& q) noexcept
 /// Negate the quaterion
 template <class T>
 constexpr inline Quat<T>
-operator- (const Quat<T>& q) noexcept
+operator- (const Quat<T>& q) IMATH_NOEXCEPT
 {
     return Quat<T> (-q.r, -q.v);
 }
@@ -917,7 +917,7 @@ operator- (const Quat<T>& q) noexcept
 /// @return v * q
 template <class T>
 IMATH_CONSTEXPR14 inline Vec3<T>
-operator* (const Vec3<T>& v, const Quat<T>& q) noexcept
+operator* (const Vec3<T>& v, const Quat<T>& q) IMATH_NOEXCEPT
 {
     Vec3<T> a = q.v % v;
     Vec3<T> b = q.v % a;

--- a/src/Imath/ImathShear.h
+++ b/src/Imath/ImathShear.h
@@ -263,16 +263,16 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Shear6
     /// @name Numerical Limits
     
     /// Largest possible negative value
-    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() noexcept { return std::numeric_limits<T>::lowest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() IMATH_NOEXCEPT { return std::numeric_limits<T>::lowest(); }
 
     /// Largest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return std::numeric_limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() IMATH_NOEXCEPT { return std::numeric_limits<T>::max(); }
 
     /// Smallest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return std::numeric_limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() IMATH_NOEXCEPT { return std::numeric_limits<T>::min(); }
 
     /// Smallest possible e for which 1+e != 1
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return std::numeric_limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() IMATH_NOEXCEPT { return std::numeric_limits<T>::epsilon(); }
 
     /// @}
 

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -54,35 +54,35 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec2
     /// @}
     
     /// Element access by index.  
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i) IMATH_NOEXCEPT;
 
     /// Element access by index.  
-    IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const noexcept;
+    IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const IMATH_NOEXCEPT;
 
     /// @{
     ///	@name Constructors and Assignment
 
     /// Uninitialized by default
-    IMATH_HOSTDEVICE Vec2() noexcept;
+    IMATH_HOSTDEVICE Vec2() IMATH_NOEXCEPT;
 
     /// Initialize to a scalar `(a,a)`
-    IMATH_HOSTDEVICE constexpr explicit Vec2 (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr explicit Vec2 (T a) IMATH_NOEXCEPT;
 
     /// Initialize to given elements `(a,b)`
-    IMATH_HOSTDEVICE constexpr Vec2 (T a, T b) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 (T a, T b) IMATH_NOEXCEPT;
 
     /// Copy constructor
-    IMATH_HOSTDEVICE constexpr Vec2 (const Vec2& v) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 (const Vec2& v) IMATH_NOEXCEPT;
 
     /// Construct from Vec2 of another base type
-    template <class S> IMATH_HOSTDEVICE constexpr Vec2 (const Vec2<S>& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE constexpr Vec2 (const Vec2<S>& v) IMATH_NOEXCEPT;
 
 
     /// Assignment
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator= (const Vec2& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator= (const Vec2& v) IMATH_NOEXCEPT;
 
     /// Destructor
-    ~Vec2() noexcept = default;
+    ~Vec2() IMATH_NOEXCEPT = default;
 
     /// @}
 
@@ -103,7 +103,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec2
     ///
 
     template<typename V, IMATH_ENABLE_IF(has_xy<V,T>::value)>
-    IMATH_HOSTDEVICE explicit constexpr Vec2 (const V& v) noexcept
+    IMATH_HOSTDEVICE explicit constexpr Vec2 (const V& v) IMATH_NOEXCEPT
         : Vec2(T(v.x), T(v.y)) { }
 
     template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,2>::value
@@ -111,7 +111,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec2
     IMATH_HOSTDEVICE explicit Vec2 (const V& v) : Vec2(T(v[0]), T(v[1])) { }
 
     template<typename V, IMATH_ENABLE_IF(has_xy<V,T>::value)>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator= (const V& v) noexcept {
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator= (const V& v) IMATH_NOEXCEPT {
         x = T(v.x);
         y = T(v.y);
         return *this;
@@ -130,22 +130,22 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec2
     /// @name Compatibility with Sb
 
     /// Set the value
-    template <class S> IMATH_HOSTDEVICE void setValue (S a, S b) noexcept;
+    template <class S> IMATH_HOSTDEVICE void setValue (S a, S b) IMATH_NOEXCEPT;
 
     /// Set the value
-    template <class S> IMATH_HOSTDEVICE void setValue (const Vec2<S>& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE void setValue (const Vec2<S>& v) IMATH_NOEXCEPT;
 
     /// Return the value in `a` and `b`
-    template <class S> IMATH_HOSTDEVICE void getValue (S& a, S& b) const noexcept;
+    template <class S> IMATH_HOSTDEVICE void getValue (S& a, S& b) const IMATH_NOEXCEPT;
 
     /// Return the value in `v`
-    template <class S> IMATH_HOSTDEVICE void getValue (Vec2<S>& v) const noexcept;
+    template <class S> IMATH_HOSTDEVICE void getValue (Vec2<S>& v) const IMATH_NOEXCEPT;
 
     /// Return a raw pointer to the array of values
-    IMATH_HOSTDEVICE T* getValue() noexcept;
+    IMATH_HOSTDEVICE T* getValue() IMATH_NOEXCEPT;
 
     /// Return a raw pointer to the array of values
-    IMATH_HOSTDEVICE const T* getValue() const noexcept;
+    IMATH_HOSTDEVICE const T* getValue() const IMATH_NOEXCEPT;
 
     /// @}
     
@@ -153,81 +153,81 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec2
     /// @name Arithmetic and Comparison
     
     /// Equality
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Vec2<S>& v) const noexcept;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Vec2<S>& v) const IMATH_NOEXCEPT;
 
 
     /// Inequality
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Vec2<S>& v) const noexcept;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Vec2<S>& v) const IMATH_NOEXCEPT;
 
     /// Compare two matrices and test if they are "approximately equal":
     /// @return True if the coefficients of this and `m` are the same
     /// with an absolute error of no more than e, i.e., for all i, j:
     ///
     ///   abs (this[i][j] - m[i][j]) <= e
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Vec2<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Vec2<T>& v, T e) const IMATH_NOEXCEPT;
 
     /// Compare two matrices and test if they are "approximately equal":
     /// @return True if the coefficients of this and m are the same with
     /// a relative error of no more than e, i.e., for all i, j:
     ///
     ///   abs (this[i] - v[i][j]) <= e * abs (this[i][j])
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Vec2<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Vec2<T>& v, T e) const IMATH_NOEXCEPT;
 
     /// Dot product
-    IMATH_HOSTDEVICE constexpr T dot (const Vec2& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr T dot (const Vec2& v) const IMATH_NOEXCEPT;
 
     /// Dot product
-    IMATH_HOSTDEVICE constexpr T operator^ (const Vec2& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr T operator^ (const Vec2& v) const IMATH_NOEXCEPT;
 
     /// Right-handed cross product, i.e. z component of
     /// Vec3 (this->x, this->y, 0) % Vec3 (v.x, v.y, 0)
-    IMATH_HOSTDEVICE constexpr T cross (const Vec2& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr T cross (const Vec2& v) const IMATH_NOEXCEPT;
 
     /// Right-handed cross product, i.e. z component of
     /// Vec3 (this->x, this->y, 0) % Vec3 (v.x, v.y, 0)
-    IMATH_HOSTDEVICE constexpr T operator% (const Vec2& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr T operator% (const Vec2& v) const IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator+= (const Vec2& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator+= (const Vec2& v) IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE constexpr Vec2 operator+ (const Vec2& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 operator+ (const Vec2& v) const IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator-= (const Vec2& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator-= (const Vec2& v) IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE constexpr Vec2 operator- (const Vec2& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 operator- (const Vec2& v) const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE constexpr Vec2 operator-() const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 operator-() const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& negate() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& negate() IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator*= (const Vec2& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator*= (const Vec2& v) IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator*= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator*= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE constexpr Vec2 operator* (const Vec2& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 operator* (const Vec2& v) const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE constexpr Vec2 operator* (T a) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 operator* (T a) const IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator/= (const Vec2& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator/= (const Vec2& v) IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator/= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec2& operator/= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE constexpr Vec2 operator/ (const Vec2& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 operator/ (const Vec2& v) const IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE constexpr Vec2 operator/ (T a) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec2 operator/ (T a) const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -235,14 +235,14 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec2
     /// @name Query and Manipulation
 
     /// Return the Euclidean norm
-    IMATH_HOSTDEVICE T length() const noexcept;
+    IMATH_HOSTDEVICE T length() const IMATH_NOEXCEPT;
 
     /// Return the square of the Euclidean norm, i.e. the dot product
     /// with itself.
-    IMATH_HOSTDEVICE constexpr T length2() const noexcept;
+    IMATH_HOSTDEVICE constexpr T length2() const IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, return a null vector.
-    IMATH_HOSTDEVICE const Vec2& normalize() noexcept;
+    IMATH_HOSTDEVICE const Vec2& normalize() IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, throw an exception.
     const Vec2& normalizeExc();
@@ -250,10 +250,10 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec2
     /// Normalize without any checks for length()==0. Slightly faster
     /// than the other normalization routines, but if v.length() is
     /// 0.0, the result is undefined.
-    IMATH_HOSTDEVICE const Vec2& normalizeNonNull() noexcept;
+    IMATH_HOSTDEVICE const Vec2& normalizeNonNull() IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this.
-    IMATH_HOSTDEVICE Vec2<T> normalized() const noexcept; 
+    IMATH_HOSTDEVICE Vec2<T> normalized() const IMATH_NOEXCEPT; 
 
     /// Return a normalized vector. Does not modify *this. Throw an
     /// exception if length()==0.
@@ -263,7 +263,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec2
     /// not check for length()==0. Slightly faster than the other
     /// normalization routines, but if v.length() is 0.0, the result
     /// is undefined.
-    IMATH_HOSTDEVICE Vec2<T> normalizedNonNull() const noexcept;
+    IMATH_HOSTDEVICE Vec2<T> normalizedNonNull() const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -271,21 +271,21 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec2
     /// @name Numeric Limits
     
     /// Largest possible negative value
-    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() noexcept { return std::numeric_limits<T>::lowest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() IMATH_NOEXCEPT { return std::numeric_limits<T>::lowest(); }
 
     /// Largest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return std::numeric_limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() IMATH_NOEXCEPT { return std::numeric_limits<T>::max(); }
 
     /// Smallest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return std::numeric_limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() IMATH_NOEXCEPT { return std::numeric_limits<T>::min(); }
 
     /// Smallest possible e for which 1+e != 1
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return std::numeric_limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() IMATH_NOEXCEPT { return std::numeric_limits<T>::epsilon(); }
 
     /// @}
     
     /// Return the number of dimensions, i.e. 2
-    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() noexcept { return 2; }
+    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() IMATH_NOEXCEPT { return 2; }
 
     /// The base type: In templates that accept a parameter `V`, you
     /// can refer to `T` as `V::BaseType`
@@ -293,7 +293,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec2
 
   private:
 
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T lengthTiny() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T lengthTiny() const IMATH_NOEXCEPT;
 };
 
 ///
@@ -312,33 +312,33 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec3
     /// @}
     
     /// Element access by index.  
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i) IMATH_NOEXCEPT;
 
     /// Element access by index.  
-    IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const noexcept;
+    IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const IMATH_NOEXCEPT;
 
     /// @{
     ///	@name Constructors and Assignment
 
     /// Uninitialized by default
-    IMATH_HOSTDEVICE Vec3() noexcept;
+    IMATH_HOSTDEVICE Vec3() IMATH_NOEXCEPT;
     
     /// Initialize to a scalar `(a,a,a)`
-    IMATH_HOSTDEVICE constexpr explicit Vec3 (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr explicit Vec3 (T a) IMATH_NOEXCEPT;
 
     /// Initialize to given elements `(a,b,c)`
-    IMATH_HOSTDEVICE constexpr Vec3 (T a, T b, T c) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 (T a, T b, T c) IMATH_NOEXCEPT;
 
     /// Copy constructor
-    IMATH_HOSTDEVICE constexpr Vec3 (const Vec3& v) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 (const Vec3& v) IMATH_NOEXCEPT;
 
     /// Construct from Vec3 of another base type
-    template <class S> IMATH_HOSTDEVICE constexpr Vec3 (const Vec3<S>& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE constexpr Vec3 (const Vec3<S>& v) IMATH_NOEXCEPT;
 
     /// Vec4 to Vec3 conversion: divide x, y and z by w, even if w is
     /// 0.  The result depends on how the environment handles
     /// floating-point exceptions.
-    template <class S> IMATH_HOSTDEVICE explicit constexpr Vec3 (const Vec4<S>& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE explicit constexpr Vec3 (const Vec4<S>& v) IMATH_NOEXCEPT;
 
     /// Vec4 to Vec3 conversion: divide x, y and z by w.  Throws an
     /// exception if w is zero or if division by w would overflow.
@@ -346,10 +346,10 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec3
     explicit IMATH_CONSTEXPR14 Vec3 (const Vec4<S>& v, InfException);
 
     /// Assignment
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator= (const Vec3& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator= (const Vec3& v) IMATH_NOEXCEPT;
 
     /// Destructor
-    ~Vec3() noexcept = default;
+    ~Vec3() IMATH_NOEXCEPT = default;
 
     /// @}
 
@@ -370,7 +370,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec3
     ///
 
     template<typename V, IMATH_ENABLE_IF(has_xyz<V,T>::value)>
-    IMATH_HOSTDEVICE explicit constexpr Vec3 (const V& v) noexcept
+    IMATH_HOSTDEVICE explicit constexpr Vec3 (const V& v) IMATH_NOEXCEPT
         : Vec3(T(v.x), T(v.y), T(v.z)) { }
 
     template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,3>::value
@@ -380,7 +380,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec3
     /// Interoperability assignment from another type that behaves as if it
     /// were an equivalent vector.
     template<typename V, IMATH_ENABLE_IF(has_xyz<V,T>::value)>
-    IMATH_HOSTDEVICE const Vec3& operator= (const V& v) noexcept {
+    IMATH_HOSTDEVICE const Vec3& operator= (const V& v) IMATH_NOEXCEPT {
         x = T(v.x);
         y = T(v.y);
         z = T(v.z);
@@ -402,22 +402,22 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec3
     /// @name Compatibility with Sb
 
     /// Set the value
-    template <class S> IMATH_HOSTDEVICE void setValue (S a, S b, S c) noexcept;
+    template <class S> IMATH_HOSTDEVICE void setValue (S a, S b, S c) IMATH_NOEXCEPT;
 
     /// Set the value
-    template <class S> IMATH_HOSTDEVICE void setValue (const Vec3<S>& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE void setValue (const Vec3<S>& v) IMATH_NOEXCEPT;
 
     /// Return the value in `a`, `b`, and `c`
-    template <class S> IMATH_HOSTDEVICE void getValue (S& a, S& b, S& c) const noexcept;
+    template <class S> IMATH_HOSTDEVICE void getValue (S& a, S& b, S& c) const IMATH_NOEXCEPT;
 
     /// Return the value in `v`
-    template <class S> IMATH_HOSTDEVICE void getValue (Vec3<S>& v) const noexcept;
+    template <class S> IMATH_HOSTDEVICE void getValue (Vec3<S>& v) const IMATH_NOEXCEPT;
 
     /// Return a raw pointer to the array of values
-    IMATH_HOSTDEVICE T* getValue() noexcept;
+    IMATH_HOSTDEVICE T* getValue() IMATH_NOEXCEPT;
 
     /// Return a raw pointer to the array of values
-    IMATH_HOSTDEVICE const T* getValue() const noexcept;
+    IMATH_HOSTDEVICE const T* getValue() const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -425,81 +425,81 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec3
     /// @name Arithmetic and Comparison
     
     /// Equality
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Vec3<S>& v) const noexcept;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Vec3<S>& v) const IMATH_NOEXCEPT;
 
     /// Inequality
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Vec3<S>& v) const noexcept;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Vec3<S>& v) const IMATH_NOEXCEPT;
 
     /// Compare two matrices and test if they are "approximately equal":
     /// @return True if the coefficients of this and `m` are the same
     /// with an absolute error of no more than e, i.e., for all i, j:
     ///
     ///   abs (this[i][j] - m[i][j]) <= e
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Vec3<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Vec3<T>& v, T e) const IMATH_NOEXCEPT;
 
     /// Compare two matrices and test if they are "approximately equal":
     /// @return True if the coefficients of this and m are the same with
     /// a relative error of no more than e, i.e., for all i, j:
     ///
     ///   abs (this[i] - v[i][j]) <= e * abs (this[i][j])
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Vec3<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Vec3<T>& v, T e) const IMATH_NOEXCEPT;
 
     /// Dot product
-    IMATH_HOSTDEVICE constexpr T dot (const Vec3& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr T dot (const Vec3& v) const IMATH_NOEXCEPT;
 
     /// Dot product
-    IMATH_HOSTDEVICE constexpr T operator^ (const Vec3& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr T operator^ (const Vec3& v) const IMATH_NOEXCEPT;
 
     /// Right-handed cross product
-    IMATH_HOSTDEVICE constexpr Vec3 cross (const Vec3& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 cross (const Vec3& v) const IMATH_NOEXCEPT;
 
     /// Right-handed cross product
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator%= (const Vec3& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator%= (const Vec3& v) IMATH_NOEXCEPT;
 
     /// Right-handed cross product
-    IMATH_HOSTDEVICE constexpr Vec3 operator% (const Vec3& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator% (const Vec3& v) const IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator+= (const Vec3& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator+= (const Vec3& v) IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE constexpr Vec3 operator+ (const Vec3& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator+ (const Vec3& v) const IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator-= (const Vec3& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator-= (const Vec3& v) IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE constexpr Vec3 operator- (const Vec3& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator- (const Vec3& v) const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE constexpr Vec3 operator-() const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator-() const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& negate() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& negate() IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator*= (const Vec3& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator*= (const Vec3& v) IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator*= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator*= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE constexpr Vec3 operator* (const Vec3& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator* (const Vec3& v) const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE constexpr Vec3 operator* (T a) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator* (T a) const IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator/= (const Vec3& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator/= (const Vec3& v) IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator/= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec3& operator/= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE constexpr Vec3 operator/ (const Vec3& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator/ (const Vec3& v) const IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE constexpr Vec3 operator/ (T a) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec3 operator/ (T a) const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -507,14 +507,14 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec3
     /// @name Query and Manipulation
 
     /// Return the Euclidean norm
-    IMATH_HOSTDEVICE T length() const noexcept;
+    IMATH_HOSTDEVICE T length() const IMATH_NOEXCEPT;
 
     /// Return the square of the Euclidean norm, i.e. the dot product
     /// with itself.
-    IMATH_HOSTDEVICE constexpr T length2() const noexcept;
+    IMATH_HOSTDEVICE constexpr T length2() const IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, return a null vector.
-    IMATH_HOSTDEVICE const Vec3& normalize() noexcept;
+    IMATH_HOSTDEVICE const Vec3& normalize() IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, throw an exception.
     const Vec3& normalizeExc();
@@ -522,10 +522,10 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec3
     /// Normalize without any checks for length()==0. Slightly faster
     /// than the other normalization routines, but if v.length() is
     /// 0.0, the result is undefined.
-    IMATH_HOSTDEVICE const Vec3& normalizeNonNull() noexcept;
+    IMATH_HOSTDEVICE const Vec3& normalizeNonNull() IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this.
-    IMATH_HOSTDEVICE Vec3<T> normalized() const noexcept; // does not modify *this
+    IMATH_HOSTDEVICE Vec3<T> normalized() const IMATH_NOEXCEPT; // does not modify *this
 
     /// Return a normalized vector. Does not modify *this. Throw an
     /// exception if length()==0.
@@ -535,7 +535,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec3
     /// not check for length()==0. Slightly faster than the other
     /// normalization routines, but if v.length() is 0.0, the result
     /// is undefined.
-    IMATH_HOSTDEVICE Vec3<T> normalizedNonNull() const noexcept;
+    IMATH_HOSTDEVICE Vec3<T> normalizedNonNull() const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -543,28 +543,28 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec3
     /// @name Numeric Limits
 
     /// Largest possible negative value
-    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() noexcept { return std::numeric_limits<T>::lowest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() IMATH_NOEXCEPT { return std::numeric_limits<T>::lowest(); }
 
     /// Largest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return std::numeric_limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() IMATH_NOEXCEPT { return std::numeric_limits<T>::max(); }
 
     /// Smallest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return std::numeric_limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() IMATH_NOEXCEPT { return std::numeric_limits<T>::min(); }
 
     /// Smallest possible e for which 1+e != 1
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return std::numeric_limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() IMATH_NOEXCEPT { return std::numeric_limits<T>::epsilon(); }
 
     /// @}
     
     /// Return the number of dimensions, i.e. 3
-    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() noexcept { return 3; }
+    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() IMATH_NOEXCEPT { return 3; }
 
     /// The base type: In templates that accept a parameter `V`, you
     /// can refer to `T` as `V::BaseType`
     typedef T BaseType;
 
   private:
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T lengthTiny() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T lengthTiny() const IMATH_NOEXCEPT;
 };
 
 ///
@@ -583,37 +583,37 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec4
     /// @}
     
     /// Element access by index.  
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i) IMATH_NOEXCEPT;
 
     /// Element access by index.  
-    IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const noexcept;
+    IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const IMATH_NOEXCEPT;
 
     /// @{
     ///	@name Constructors and Assignment
 
     /// Uninitialized by default
-    IMATH_HOSTDEVICE Vec4() noexcept;                            // no initialization
+    IMATH_HOSTDEVICE Vec4() IMATH_NOEXCEPT;                            // no initialization
 
     /// Initialize to a scalar `(a,a,a,a)`
-    IMATH_HOSTDEVICE constexpr explicit Vec4 (T a) noexcept;
+    IMATH_HOSTDEVICE constexpr explicit Vec4 (T a) IMATH_NOEXCEPT;
 
     /// Initialize to given elements `(a,b,c,d)`
-    IMATH_HOSTDEVICE constexpr Vec4 (T a, T b, T c, T d) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 (T a, T b, T c, T d) IMATH_NOEXCEPT;
 
     /// Copy constructor
-    IMATH_HOSTDEVICE constexpr Vec4 (const Vec4& v) noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 (const Vec4& v) IMATH_NOEXCEPT;
 
     /// Construct from Vec4 of another base type
-    template <class S> IMATH_HOSTDEVICE constexpr Vec4 (const Vec4<S>& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE constexpr Vec4 (const Vec4<S>& v) IMATH_NOEXCEPT;
 
     /// Vec3 to Vec4 conversion, sets w to 1.
-    template <class S> IMATH_HOSTDEVICE explicit constexpr Vec4 (const Vec3<S>& v) noexcept;
+    template <class S> IMATH_HOSTDEVICE explicit constexpr Vec4 (const Vec3<S>& v) IMATH_NOEXCEPT;
 
     /// Assignment
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator= (const Vec4& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator= (const Vec4& v) IMATH_NOEXCEPT;
 
     /// Destructor
-    ~Vec4() noexcept = default;
+    ~Vec4() IMATH_NOEXCEPT = default;
 
     /// @}
 
@@ -634,7 +634,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec4
     ///
 
     template<typename V, IMATH_ENABLE_IF(has_xyzw<V,T>::value)>
-    IMATH_HOSTDEVICE explicit constexpr Vec4 (const V& v) noexcept
+    IMATH_HOSTDEVICE explicit constexpr Vec4 (const V& v) IMATH_NOEXCEPT
         : Vec4(T(v.x), T(v.y), T(v.z), T(v.w)) { }
 
     template<typename V, IMATH_ENABLE_IF(has_subscript<V,T,4>::value
@@ -642,7 +642,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec4
     IMATH_HOSTDEVICE explicit Vec4 (const V& v) : Vec4(T(v[0]), T(v[1]), T(v[2]), T(v[3])) { }
 
     template<typename V, IMATH_ENABLE_IF(has_xyzw<V,T>::value)>
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator= (const V& v) noexcept {
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator= (const V& v) IMATH_NOEXCEPT {
         x = T(v.x);
         y = T(v.y);
         z = T(v.z);
@@ -666,72 +666,72 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec4
     /// @name Arithmetic and Comparison
     
     /// Equality
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Vec4<S>& v) const noexcept;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator== (const Vec4<S>& v) const IMATH_NOEXCEPT;
 
     /// Inequality
-    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Vec4<S>& v) const noexcept;
+    template <class S> IMATH_HOSTDEVICE constexpr bool operator!= (const Vec4<S>& v) const IMATH_NOEXCEPT;
 
     /// Compare two matrices and test if they are "approximately equal":
     /// @return True if the coefficients of this and `m` are the same
     /// with an absolute error of no more than e, i.e., for all i, j:
     ///
     ///   abs (this[i][j] - m[i][j]) <= e
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Vec4<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithAbsError (const Vec4<T>& v, T e) const IMATH_NOEXCEPT;
 
     /// Compare two matrices and test if they are "approximately equal":
     /// @return True if the coefficients of this and m are the same with
     /// a relative error of no more than e, i.e., for all i, j:
     ///
     ///   abs (this[i] - v[i][j]) <= e * abs (this[i][j])
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Vec4<T>& v, T e) const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool equalWithRelError (const Vec4<T>& v, T e) const IMATH_NOEXCEPT;
 
     /// Dot product
-    IMATH_HOSTDEVICE constexpr T dot (const Vec4& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr T dot (const Vec4& v) const IMATH_NOEXCEPT;
 
     /// Dot product
-    IMATH_HOSTDEVICE constexpr T operator^ (const Vec4& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr T operator^ (const Vec4& v) const IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator+= (const Vec4& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator+= (const Vec4& v) IMATH_NOEXCEPT;
 
     /// Component-wise addition
-    IMATH_HOSTDEVICE constexpr Vec4 operator+ (const Vec4& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 operator+ (const Vec4& v) const IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator-= (const Vec4& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator-= (const Vec4& v) IMATH_NOEXCEPT;
 
     /// Component-wise subtraction
-    IMATH_HOSTDEVICE constexpr Vec4 operator- (const Vec4& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 operator- (const Vec4& v) const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE constexpr Vec4 operator-() const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 operator-() const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication by -1
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& negate() noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& negate() IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator*= (const Vec4& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator*= (const Vec4& v) IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator*= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator*= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE constexpr Vec4 operator* (const Vec4& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 operator* (const Vec4& v) const IMATH_NOEXCEPT;
 
     /// Component-wise multiplication
-    IMATH_HOSTDEVICE constexpr Vec4 operator* (T a) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 operator* (T a) const IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator/= (const Vec4& v) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator/= (const Vec4& v) IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator/= (T a) noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Vec4& operator/= (T a) IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE constexpr Vec4 operator/ (const Vec4& v) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 operator/ (const Vec4& v) const IMATH_NOEXCEPT;
 
     /// Component-wise division
-    IMATH_HOSTDEVICE constexpr Vec4 operator/ (T a) const noexcept;
+    IMATH_HOSTDEVICE constexpr Vec4 operator/ (T a) const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -739,14 +739,14 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec4
     /// @name Query and Manipulation
 
     /// Return the Euclidean norm
-    IMATH_HOSTDEVICE T length() const noexcept;
+    IMATH_HOSTDEVICE T length() const IMATH_NOEXCEPT;
 
     /// Return the square of the Euclidean norm, i.e. the dot product
     /// with itself.
-    IMATH_HOSTDEVICE constexpr T length2() const noexcept;
+    IMATH_HOSTDEVICE constexpr T length2() const IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, return a null vector.
-    IMATH_HOSTDEVICE const Vec4& normalize() noexcept; // modifies *this
+    IMATH_HOSTDEVICE const Vec4& normalize() IMATH_NOEXCEPT; // modifies *this
 
     /// Normalize in place. If length()==0, throw an exception.
     const Vec4& normalizeExc();
@@ -754,10 +754,10 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec4
     /// Normalize without any checks for length()==0. Slightly faster
     /// than the other normalization routines, but if v.length() is
     /// 0.0, the result is undefined.
-    IMATH_HOSTDEVICE const Vec4& normalizeNonNull() noexcept;
+    IMATH_HOSTDEVICE const Vec4& normalizeNonNull() IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this.
-    IMATH_HOSTDEVICE Vec4<T> normalized() const noexcept; // does not modify *this
+    IMATH_HOSTDEVICE Vec4<T> normalized() const IMATH_NOEXCEPT; // does not modify *this
 
     /// Return a normalized vector. Does not modify *this. Throw an
     /// exception if length()==0.
@@ -767,7 +767,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec4
     /// not check for length()==0. Slightly faster than the other
     /// normalization routines, but if v.length() is 0.0, the result
     /// is undefined.
-    IMATH_HOSTDEVICE Vec4<T> normalizedNonNull() const noexcept;
+    IMATH_HOSTDEVICE Vec4<T> normalizedNonNull() const IMATH_NOEXCEPT;
 
     /// @}
     
@@ -775,28 +775,28 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Vec4
     /// @name Numeric Limits
     
     /// Largest possible negative value
-    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() noexcept { return std::numeric_limits<T>::lowest(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeLowest() IMATH_NOEXCEPT { return std::numeric_limits<T>::lowest(); }
 
     /// Largest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeMax() noexcept { return std::numeric_limits<T>::max(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeMax() IMATH_NOEXCEPT { return std::numeric_limits<T>::max(); }
 
     /// Smallest possible positive value
-    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() noexcept { return std::numeric_limits<T>::min(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeSmallest() IMATH_NOEXCEPT { return std::numeric_limits<T>::min(); }
 
     /// Smallest possible e for which 1+e != 1
-    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() noexcept { return std::numeric_limits<T>::epsilon(); }
+    IMATH_HOSTDEVICE constexpr static T baseTypeEpsilon() IMATH_NOEXCEPT { return std::numeric_limits<T>::epsilon(); }
 
     /// @}
     
     /// Return the number of dimensions, i.e. 4
-    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() noexcept { return 4; }
+    IMATH_HOSTDEVICE constexpr static unsigned int dimensions() IMATH_NOEXCEPT { return 4; }
 
     /// The base type: In templates that accept a parameter `V`, you
     /// can refer to `T` as `V::BaseType`
     typedef T BaseType;
 
   private:
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T lengthTiny() const noexcept;
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T lengthTiny() const IMATH_NOEXCEPT;
 };
 
 /// Stream output
@@ -809,13 +809,13 @@ template <class T> std::ostream& operator<< (std::ostream& s, const Vec3<T>& v);
 template <class T> std::ostream& operator<< (std::ostream& s, const Vec4<T>& v);
 
 /// Reverse multiplication: S * Vec2<T>
-template <class T> IMATH_HOSTDEVICE constexpr Vec2<T> operator* (T a, const Vec2<T>& v) noexcept;
+template <class T> IMATH_HOSTDEVICE constexpr Vec2<T> operator* (T a, const Vec2<T>& v) IMATH_NOEXCEPT;
 
 /// Reverse multiplication: S * Vec3<T>
-template <class T> IMATH_HOSTDEVICE constexpr Vec3<T> operator* (T a, const Vec3<T>& v) noexcept;
+template <class T> IMATH_HOSTDEVICE constexpr Vec3<T> operator* (T a, const Vec3<T>& v) IMATH_NOEXCEPT;
 
 /// Reverse multiplication: S * Vec4<T>
-template <class T> IMATH_HOSTDEVICE constexpr Vec4<T> operator* (T a, const Vec4<T>& v) noexcept;
+template <class T> IMATH_HOSTDEVICE constexpr Vec4<T> operator* (T a, const Vec4<T>& v) IMATH_NOEXCEPT;
 
 //-------------------------
 // Typedefs for convenience
@@ -873,85 +873,85 @@ typedef Vec4<double> V4d;
 //----------------------------------------------------------------------------
 
 // Vec2<short>
-template <> short Vec2<short>::length() const noexcept = delete;
-template <> const Vec2<short>& Vec2<short>::normalize() noexcept = delete;
+template <> short Vec2<short>::length() const IMATH_NOEXCEPT = delete;
+template <> const Vec2<short>& Vec2<short>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec2<short>& Vec2<short>::normalizeExc() = delete;
-template <> const Vec2<short>& Vec2<short>::normalizeNonNull() noexcept = delete;
-template <> Vec2<short> Vec2<short>::normalized() const noexcept = delete;
+template <> const Vec2<short>& Vec2<short>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> Vec2<short> Vec2<short>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec2<short> Vec2<short>::normalizedExc() const = delete;
-template <> Vec2<short> Vec2<short>::normalizedNonNull() const noexcept = delete;
+template <> Vec2<short> Vec2<short>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec2<int>
-template <> int Vec2<int>::length() const noexcept = delete;
-template <> const Vec2<int>& Vec2<int>::normalize() noexcept = delete;
+template <> int Vec2<int>::length() const IMATH_NOEXCEPT = delete;
+template <> const Vec2<int>& Vec2<int>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec2<int>& Vec2<int>::normalizeExc() = delete;
-template <> const Vec2<int>& Vec2<int>::normalizeNonNull() noexcept = delete;
-template <> Vec2<int> Vec2<int>::normalized() const noexcept = delete;
+template <> const Vec2<int>& Vec2<int>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> Vec2<int> Vec2<int>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec2<int> Vec2<int>::normalizedExc() const = delete;
-template <> Vec2<int> Vec2<int>::normalizedNonNull() const noexcept = delete;
+template <> Vec2<int> Vec2<int>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec2<int64_t>
-template <> int64_t Vec2<int64_t>::length() const noexcept = delete;
-template <> const Vec2<int64_t>& Vec2<int64_t>::normalize() noexcept = delete;
+template <> int64_t Vec2<int64_t>::length() const IMATH_NOEXCEPT = delete;
+template <> const Vec2<int64_t>& Vec2<int64_t>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec2<int64_t>& Vec2<int64_t>::normalizeExc() = delete;
-template <> const Vec2<int64_t>& Vec2<int64_t>::normalizeNonNull() noexcept = delete;
-template <> Vec2<int64_t> Vec2<int64_t>::normalized() const noexcept = delete;
+template <> const Vec2<int64_t>& Vec2<int64_t>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> Vec2<int64_t> Vec2<int64_t>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec2<int64_t> Vec2<int64_t>::normalizedExc() const = delete;
-template <> Vec2<int64_t> Vec2<int64_t>::normalizedNonNull() const noexcept = delete;
+template <> Vec2<int64_t> Vec2<int64_t>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec3<short>
-template <> short Vec3<short>::length() const noexcept = delete;
-template <> const Vec3<short>& Vec3<short>::normalize() noexcept = delete;
+template <> short Vec3<short>::length() const IMATH_NOEXCEPT = delete;
+template <> const Vec3<short>& Vec3<short>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec3<short>& Vec3<short>::normalizeExc() = delete;
-template <> const Vec3<short>& Vec3<short>::normalizeNonNull() noexcept = delete;
-template <> Vec3<short> Vec3<short>::normalized() const noexcept = delete;
+template <> const Vec3<short>& Vec3<short>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> Vec3<short> Vec3<short>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec3<short> Vec3<short>::normalizedExc() const = delete;
-template <> Vec3<short> Vec3<short>::normalizedNonNull() const noexcept = delete;
+template <> Vec3<short> Vec3<short>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec3<int>
-template <> int Vec3<int>::length() const noexcept = delete;
-template <> const Vec3<int>& Vec3<int>::normalize() noexcept = delete;
+template <> int Vec3<int>::length() const IMATH_NOEXCEPT = delete;
+template <> const Vec3<int>& Vec3<int>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec3<int>& Vec3<int>::normalizeExc() = delete;
-template <> const Vec3<int>& Vec3<int>::normalizeNonNull() noexcept = delete;
-template <> Vec3<int> Vec3<int>::normalized() const noexcept = delete;
+template <> const Vec3<int>& Vec3<int>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> Vec3<int> Vec3<int>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec3<int> Vec3<int>::normalizedExc() const = delete;
-template <> Vec3<int> Vec3<int>::normalizedNonNull() const noexcept = delete;
+template <> Vec3<int> Vec3<int>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec3<int64_t>
-template <> int64_t Vec3<int64_t>::length() const noexcept = delete;
-template <> const Vec3<int64_t>& Vec3<int64_t>::normalize() noexcept = delete;
+template <> int64_t Vec3<int64_t>::length() const IMATH_NOEXCEPT = delete;
+template <> const Vec3<int64_t>& Vec3<int64_t>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec3<int64_t>& Vec3<int64_t>::normalizeExc() = delete;
-template <> const Vec3<int64_t>& Vec3<int64_t>::normalizeNonNull() noexcept = delete;
-template <> Vec3<int64_t> Vec3<int64_t>::normalized() const noexcept = delete;
+template <> const Vec3<int64_t>& Vec3<int64_t>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> Vec3<int64_t> Vec3<int64_t>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec3<int64_t> Vec3<int64_t>::normalizedExc() const = delete;
-template <> Vec3<int64_t> Vec3<int64_t>::normalizedNonNull() const noexcept = delete;
+template <> Vec3<int64_t> Vec3<int64_t>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec4<short>
-template <> short Vec4<short>::length() const noexcept = delete;
-template <> const Vec4<short>& Vec4<short>::normalize() noexcept = delete;
+template <> short Vec4<short>::length() const IMATH_NOEXCEPT = delete;
+template <> const Vec4<short>& Vec4<short>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec4<short>& Vec4<short>::normalizeExc() = delete;
-template <> const Vec4<short>& Vec4<short>::normalizeNonNull() noexcept = delete;
-template <> Vec4<short> Vec4<short>::normalized() const noexcept = delete;
+template <> const Vec4<short>& Vec4<short>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> Vec4<short> Vec4<short>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec4<short> Vec4<short>::normalizedExc() const = delete;
-template <> Vec4<short> Vec4<short>::normalizedNonNull() const noexcept = delete;
+template <> Vec4<short> Vec4<short>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec4<int>
-template <> int Vec4<int>::length() const noexcept = delete;
-template <> const Vec4<int>& Vec4<int>::normalize() noexcept = delete;
+template <> int Vec4<int>::length() const IMATH_NOEXCEPT = delete;
+template <> const Vec4<int>& Vec4<int>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec4<int>& Vec4<int>::normalizeExc() = delete;
-template <> const Vec4<int>& Vec4<int>::normalizeNonNull() noexcept = delete;
-template <> Vec4<int> Vec4<int>::normalized() const noexcept = delete;
+template <> const Vec4<int>& Vec4<int>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> Vec4<int> Vec4<int>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec4<int> Vec4<int>::normalizedExc() const = delete;
-template <> Vec4<int> Vec4<int>::normalizedNonNull() const noexcept = delete;
+template <> Vec4<int> Vec4<int>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec4<int64_t>
-template <> int64_t Vec4<int64_t>::length() const noexcept = delete;
-template <> const Vec4<int64_t>& Vec4<int64_t>::normalize() noexcept = delete;
+template <> int64_t Vec4<int64_t>::length() const IMATH_NOEXCEPT = delete;
+template <> const Vec4<int64_t>& Vec4<int64_t>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec4<int64_t>& Vec4<int64_t>::normalizeExc() = delete;
-template <> const Vec4<int64_t>& Vec4<int64_t>::normalizeNonNull() noexcept = delete;
-template <> Vec4<int64_t> Vec4<int64_t>::normalized() const noexcept = delete;
+template <> const Vec4<int64_t>& Vec4<int64_t>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> Vec4<int64_t> Vec4<int64_t>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec4<int64_t> Vec4<int64_t>::normalizedExc() const = delete;
-template <> Vec4<int64_t> Vec4<int64_t>::normalizedNonNull() const noexcept = delete;
+template <> Vec4<int64_t> Vec4<int64_t>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 //------------------------
 // Implementation of Vec2:
@@ -959,46 +959,46 @@ template <> Vec4<int64_t> Vec4<int64_t>::normalizedNonNull() const noexcept = de
 
 template <class T>
 IMATH_CONSTEXPR14 inline T&
-Vec2<T>::operator[] (int i) noexcept
+Vec2<T>::operator[] (int i) IMATH_NOEXCEPT
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>
 constexpr inline const T&
-Vec2<T>::operator[] (int i) const noexcept
+Vec2<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
-template <class T> inline Vec2<T>::Vec2() noexcept
+template <class T> inline Vec2<T>::Vec2() IMATH_NOEXCEPT
 {
     // empty, and not constexpr because data is uninitialized.
 }
 
-template <class T> constexpr inline Vec2<T>::Vec2 (T a) noexcept
+template <class T> constexpr inline Vec2<T>::Vec2 (T a) IMATH_NOEXCEPT
     : x(a), y(a)
 {
 }
 
-template <class T> constexpr inline Vec2<T>::Vec2 (T a, T b) noexcept
+template <class T> constexpr inline Vec2<T>::Vec2 (T a, T b) IMATH_NOEXCEPT
     : x(a), y(b)
 {
 }
 
-template <class T> constexpr inline Vec2<T>::Vec2 (const Vec2& v) noexcept
+template <class T> constexpr inline Vec2<T>::Vec2 (const Vec2& v) IMATH_NOEXCEPT
     : x(v.x), y(v.y)
 {
 }
 
-template <class T> template <class S> constexpr inline Vec2<T>::Vec2 (const Vec2<S>& v) noexcept
+template <class T> template <class S> constexpr inline Vec2<T>::Vec2 (const Vec2<S>& v) IMATH_NOEXCEPT
     : x(T(v.x)), y(T(v.y))
 {
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::operator= (const Vec2& v) noexcept
+Vec2<T>::operator= (const Vec2& v) IMATH_NOEXCEPT
 {
     x = v.x;
     y = v.y;
@@ -1008,7 +1008,7 @@ Vec2<T>::operator= (const Vec2& v) noexcept
 template <class T>
 template <class S>
 inline void
-Vec2<T>::setValue (S a, S b) noexcept
+Vec2<T>::setValue (S a, S b) IMATH_NOEXCEPT
 {
     x = T (a);
     y = T (b);
@@ -1017,7 +1017,7 @@ Vec2<T>::setValue (S a, S b) noexcept
 template <class T>
 template <class S>
 inline void
-Vec2<T>::setValue (const Vec2<S>& v) noexcept
+Vec2<T>::setValue (const Vec2<S>& v) IMATH_NOEXCEPT
 {
     x = T (v.x);
     y = T (v.y);
@@ -1026,7 +1026,7 @@ Vec2<T>::setValue (const Vec2<S>& v) noexcept
 template <class T>
 template <class S>
 inline void
-Vec2<T>::getValue (S& a, S& b) const noexcept
+Vec2<T>::getValue (S& a, S& b) const IMATH_NOEXCEPT
 {
     a = S (x);
     b = S (y);
@@ -1035,7 +1035,7 @@ Vec2<T>::getValue (S& a, S& b) const noexcept
 template <class T>
 template <class S>
 inline void
-Vec2<T>::getValue (Vec2<S>& v) const noexcept
+Vec2<T>::getValue (Vec2<S>& v) const IMATH_NOEXCEPT
 {
     v.x = S (x);
     v.y = S (y);
@@ -1043,14 +1043,14 @@ Vec2<T>::getValue (Vec2<S>& v) const noexcept
 
 template <class T>
 inline T*
-Vec2<T>::getValue() noexcept
+Vec2<T>::getValue() IMATH_NOEXCEPT
 {
     return (T*) &x;
 }
 
 template <class T>
 inline const T*
-Vec2<T>::getValue() const noexcept
+Vec2<T>::getValue() const IMATH_NOEXCEPT
 {
     return (const T*) &x;
 }
@@ -1058,7 +1058,7 @@ Vec2<T>::getValue() const noexcept
 template <class T>
 template <class S>
 constexpr inline bool
-Vec2<T>::operator== (const Vec2<S>& v) const noexcept
+Vec2<T>::operator== (const Vec2<S>& v) const IMATH_NOEXCEPT
 {
     return x == v.x && y == v.y;
 }
@@ -1066,14 +1066,14 @@ Vec2<T>::operator== (const Vec2<S>& v) const noexcept
 template <class T>
 template <class S>
 constexpr inline bool
-Vec2<T>::operator!= (const Vec2<S>& v) const noexcept
+Vec2<T>::operator!= (const Vec2<S>& v) const IMATH_NOEXCEPT
 {
     return x != v.x || y != v.y;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Vec2<T>::equalWithAbsError (const Vec2<T>& v, T e) const noexcept
+Vec2<T>::equalWithAbsError (const Vec2<T>& v, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 2; i++)
         if (!IMATH_INTERNAL_NAMESPACE::equalWithAbsError ((*this)[i], v[i], e))
@@ -1084,7 +1084,7 @@ Vec2<T>::equalWithAbsError (const Vec2<T>& v, T e) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Vec2<T>::equalWithRelError (const Vec2<T>& v, T e) const noexcept
+Vec2<T>::equalWithRelError (const Vec2<T>& v, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 2; i++)
         if (!IMATH_INTERNAL_NAMESPACE::equalWithRelError ((*this)[i], v[i], e))
@@ -1095,35 +1095,35 @@ Vec2<T>::equalWithRelError (const Vec2<T>& v, T e) const noexcept
 
 template <class T>
 constexpr inline T
-Vec2<T>::dot (const Vec2& v) const noexcept
+Vec2<T>::dot (const Vec2& v) const IMATH_NOEXCEPT
 {
     return x * v.x + y * v.y;
 }
 
 template <class T>
 constexpr inline T
-Vec2<T>::operator^ (const Vec2& v) const noexcept
+Vec2<T>::operator^ (const Vec2& v) const IMATH_NOEXCEPT
 {
     return dot (v);
 }
 
 template <class T>
 constexpr inline T
-Vec2<T>::cross (const Vec2& v) const noexcept
+Vec2<T>::cross (const Vec2& v) const IMATH_NOEXCEPT
 {
     return x * v.y - y * v.x;
 }
 
 template <class T>
 constexpr inline T
-Vec2<T>::operator% (const Vec2& v) const noexcept
+Vec2<T>::operator% (const Vec2& v) const IMATH_NOEXCEPT
 {
     return x * v.y - y * v.x;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::operator+= (const Vec2& v) noexcept
+Vec2<T>::operator+= (const Vec2& v) IMATH_NOEXCEPT
 {
     x += v.x;
     y += v.y;
@@ -1132,14 +1132,14 @@ Vec2<T>::operator+= (const Vec2& v) noexcept
 
 template <class T>
 constexpr inline Vec2<T>
-Vec2<T>::operator+ (const Vec2& v) const noexcept
+Vec2<T>::operator+ (const Vec2& v) const IMATH_NOEXCEPT
 {
     return Vec2 (x + v.x, y + v.y);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::operator-= (const Vec2& v) noexcept
+Vec2<T>::operator-= (const Vec2& v) IMATH_NOEXCEPT
 {
     x -= v.x;
     y -= v.y;
@@ -1148,21 +1148,21 @@ Vec2<T>::operator-= (const Vec2& v) noexcept
 
 template <class T>
 constexpr inline Vec2<T>
-Vec2<T>::operator- (const Vec2& v) const noexcept
+Vec2<T>::operator- (const Vec2& v) const IMATH_NOEXCEPT
 {
     return Vec2 (x - v.x, y - v.y);
 }
 
 template <class T>
 constexpr inline Vec2<T>
-Vec2<T>::operator-() const noexcept
+Vec2<T>::operator-() const IMATH_NOEXCEPT
 {
     return Vec2 (-x, -y);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::negate() noexcept
+Vec2<T>::negate() IMATH_NOEXCEPT
 {
     x = -x;
     y = -y;
@@ -1171,7 +1171,7 @@ Vec2<T>::negate() noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::operator*= (const Vec2& v) noexcept
+Vec2<T>::operator*= (const Vec2& v) IMATH_NOEXCEPT
 {
     x *= v.x;
     y *= v.y;
@@ -1180,7 +1180,7 @@ Vec2<T>::operator*= (const Vec2& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::operator*= (T a) noexcept
+Vec2<T>::operator*= (T a) IMATH_NOEXCEPT
 {
     x *= a;
     y *= a;
@@ -1189,21 +1189,21 @@ Vec2<T>::operator*= (T a) noexcept
 
 template <class T>
 constexpr inline Vec2<T>
-Vec2<T>::operator* (const Vec2& v) const noexcept
+Vec2<T>::operator* (const Vec2& v) const IMATH_NOEXCEPT
 {
     return Vec2 (x * v.x, y * v.y);
 }
 
 template <class T>
 constexpr inline Vec2<T>
-Vec2<T>::operator* (T a) const noexcept
+Vec2<T>::operator* (T a) const IMATH_NOEXCEPT
 {
     return Vec2 (x * a, y * a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::operator/= (const Vec2& v) noexcept
+Vec2<T>::operator/= (const Vec2& v) IMATH_NOEXCEPT
 {
     x /= v.x;
     y /= v.y;
@@ -1212,7 +1212,7 @@ Vec2<T>::operator/= (const Vec2& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec2<T>&
-Vec2<T>::operator/= (T a) noexcept
+Vec2<T>::operator/= (T a) IMATH_NOEXCEPT
 {
     x /= a;
     y /= a;
@@ -1221,21 +1221,21 @@ Vec2<T>::operator/= (T a) noexcept
 
 template <class T>
 constexpr inline Vec2<T>
-Vec2<T>::operator/ (const Vec2& v) const noexcept
+Vec2<T>::operator/ (const Vec2& v) const IMATH_NOEXCEPT
 {
     return Vec2 (x / v.x, y / v.y);
 }
 
 template <class T>
 constexpr inline Vec2<T>
-Vec2<T>::operator/ (T a) const noexcept
+Vec2<T>::operator/ (T a) const IMATH_NOEXCEPT
 {
     return Vec2 (x / a, y / a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Vec2<T>::lengthTiny() const noexcept
+Vec2<T>::lengthTiny() const IMATH_NOEXCEPT
 {
     T absX = std::abs(x);
     T absY = std::abs(y);
@@ -1262,7 +1262,7 @@ Vec2<T>::lengthTiny() const noexcept
 
 template <class T>
 inline T
-Vec2<T>::length() const noexcept
+Vec2<T>::length() const IMATH_NOEXCEPT
 {
     T length2 = dot (*this);
 
@@ -1274,14 +1274,14 @@ Vec2<T>::length() const noexcept
 
 template <class T>
 constexpr inline T
-Vec2<T>::length2() const noexcept
+Vec2<T>::length2() const IMATH_NOEXCEPT
 {
     return dot (*this);
 }
 
 template <class T>
 inline const Vec2<T>&
-Vec2<T>::normalize() noexcept
+Vec2<T>::normalize() IMATH_NOEXCEPT
 {
     T l = length();
 
@@ -1316,7 +1316,7 @@ Vec2<T>::normalizeExc()
 
 template <class T>
 inline const Vec2<T>&
-Vec2<T>::normalizeNonNull() noexcept
+Vec2<T>::normalizeNonNull() IMATH_NOEXCEPT
 {
     T l = length();
     x /= l;
@@ -1326,7 +1326,7 @@ Vec2<T>::normalizeNonNull() noexcept
 
 template <class T>
 inline Vec2<T>
-Vec2<T>::normalized() const noexcept
+Vec2<T>::normalized() const IMATH_NOEXCEPT
 {
     T l = length();
 
@@ -1350,7 +1350,7 @@ Vec2<T>::normalizedExc() const
 
 template <class T>
 inline Vec2<T>
-Vec2<T>::normalizedNonNull() const noexcept
+Vec2<T>::normalizedNonNull() const IMATH_NOEXCEPT
 {
     T l = length();
     return Vec2 (x / l, y / l);
@@ -1362,46 +1362,46 @@ Vec2<T>::normalizedNonNull() const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline T&
-Vec3<T>::operator[] (int i) noexcept
+Vec3<T>::operator[] (int i) IMATH_NOEXCEPT
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>
 constexpr inline const T&
-Vec3<T>::operator[] (int i) const noexcept
+Vec3<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
-template <class T> inline Vec3<T>::Vec3() noexcept
+template <class T> inline Vec3<T>::Vec3() IMATH_NOEXCEPT
 {
     // empty, and not constexpr because data is uninitialized.
 }
 
-template <class T> constexpr inline Vec3<T>::Vec3 (T a) noexcept
+template <class T> constexpr inline Vec3<T>::Vec3 (T a) IMATH_NOEXCEPT
     : x(a), y(a), z(a)
 {
 }
 
-template <class T> constexpr inline Vec3<T>::Vec3 (T a, T b, T c) noexcept
+template <class T> constexpr inline Vec3<T>::Vec3 (T a, T b, T c) IMATH_NOEXCEPT
     : x(a), y(b), z(c)
 {
 }
 
-template <class T> constexpr inline Vec3<T>::Vec3 (const Vec3& v) noexcept
+template <class T> constexpr inline Vec3<T>::Vec3 (const Vec3& v) IMATH_NOEXCEPT
     : x(v.x), y(v.y), z(v.z)
 {
 }
 
-template <class T> template <class S> constexpr inline Vec3<T>::Vec3 (const Vec3<S>& v) noexcept
+template <class T> template <class S> constexpr inline Vec3<T>::Vec3 (const Vec3<S>& v) IMATH_NOEXCEPT
     : x(T(v.x)), y(T(v.y)), z(T(v.z))
 {
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator= (const Vec3& v) noexcept
+Vec3<T>::operator= (const Vec3& v) IMATH_NOEXCEPT
 {
     x = v.x;
     y = v.y;
@@ -1409,7 +1409,7 @@ Vec3<T>::operator= (const Vec3& v) noexcept
     return *this;
 }
 
-template <class T> template <class S> constexpr inline Vec3<T>::Vec3 (const Vec4<S>& v) noexcept
+template <class T> template <class S> constexpr inline Vec3<T>::Vec3 (const Vec4<S>& v) IMATH_NOEXCEPT
     : x(T(v.x/v.w)), y(T(v.y/v.w)), z(T(v.z/v.w))
 {
 }
@@ -1441,7 +1441,7 @@ IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (const Vec4<S>& v, InfException)
 template <class T>
 template <class S>
 inline void
-Vec3<T>::setValue (S a, S b, S c) noexcept
+Vec3<T>::setValue (S a, S b, S c) IMATH_NOEXCEPT
 {
     x = T (a);
     y = T (b);
@@ -1451,7 +1451,7 @@ Vec3<T>::setValue (S a, S b, S c) noexcept
 template <class T>
 template <class S>
 inline void
-Vec3<T>::setValue (const Vec3<S>& v) noexcept
+Vec3<T>::setValue (const Vec3<S>& v) IMATH_NOEXCEPT
 {
     x = T (v.x);
     y = T (v.y);
@@ -1461,7 +1461,7 @@ Vec3<T>::setValue (const Vec3<S>& v) noexcept
 template <class T>
 template <class S>
 inline void
-Vec3<T>::getValue (S& a, S& b, S& c) const noexcept
+Vec3<T>::getValue (S& a, S& b, S& c) const IMATH_NOEXCEPT
 {
     a = S (x);
     b = S (y);
@@ -1471,7 +1471,7 @@ Vec3<T>::getValue (S& a, S& b, S& c) const noexcept
 template <class T>
 template <class S>
 inline void
-Vec3<T>::getValue (Vec3<S>& v) const noexcept
+Vec3<T>::getValue (Vec3<S>& v) const IMATH_NOEXCEPT
 {
     v.x = S (x);
     v.y = S (y);
@@ -1480,14 +1480,14 @@ Vec3<T>::getValue (Vec3<S>& v) const noexcept
 
 template <class T>
 inline T*
-Vec3<T>::getValue() noexcept
+Vec3<T>::getValue() IMATH_NOEXCEPT
 {
     return (T*) &x;
 }
 
 template <class T>
 inline const T*
-Vec3<T>::getValue() const noexcept
+Vec3<T>::getValue() const IMATH_NOEXCEPT
 {
     return (const T*) &x;
 }
@@ -1495,7 +1495,7 @@ Vec3<T>::getValue() const noexcept
 template <class T>
 template <class S>
 constexpr inline bool
-Vec3<T>::operator== (const Vec3<S>& v) const noexcept
+Vec3<T>::operator== (const Vec3<S>& v) const IMATH_NOEXCEPT
 {
     return x == v.x && y == v.y && z == v.z;
 }
@@ -1503,14 +1503,14 @@ Vec3<T>::operator== (const Vec3<S>& v) const noexcept
 template <class T>
 template <class S>
 constexpr inline bool
-Vec3<T>::operator!= (const Vec3<S>& v) const noexcept
+Vec3<T>::operator!= (const Vec3<S>& v) const IMATH_NOEXCEPT
 {
     return x != v.x || y != v.y || z != v.z;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Vec3<T>::equalWithAbsError (const Vec3<T>& v, T e) const noexcept
+Vec3<T>::equalWithAbsError (const Vec3<T>& v, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 3; i++)
         if (!IMATH_INTERNAL_NAMESPACE::equalWithAbsError ((*this)[i], v[i], e))
@@ -1521,7 +1521,7 @@ Vec3<T>::equalWithAbsError (const Vec3<T>& v, T e) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Vec3<T>::equalWithRelError (const Vec3<T>& v, T e) const noexcept
+Vec3<T>::equalWithRelError (const Vec3<T>& v, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 3; i++)
         if (!IMATH_INTERNAL_NAMESPACE::equalWithRelError ((*this)[i], v[i], e))
@@ -1532,28 +1532,28 @@ Vec3<T>::equalWithRelError (const Vec3<T>& v, T e) const noexcept
 
 template <class T>
 constexpr inline T
-Vec3<T>::dot (const Vec3& v) const noexcept
+Vec3<T>::dot (const Vec3& v) const IMATH_NOEXCEPT
 {
     return x * v.x + y * v.y + z * v.z;
 }
 
 template <class T>
 constexpr inline T
-Vec3<T>::operator^ (const Vec3& v) const noexcept
+Vec3<T>::operator^ (const Vec3& v) const IMATH_NOEXCEPT
 {
     return dot (v);
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::cross (const Vec3& v) const noexcept
+Vec3<T>::cross (const Vec3& v) const IMATH_NOEXCEPT
 {
     return Vec3 (y * v.z - z * v.y, z * v.x - x * v.z, x * v.y - y * v.x);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator%= (const Vec3& v) noexcept
+Vec3<T>::operator%= (const Vec3& v) IMATH_NOEXCEPT
 {
     T a = y * v.z - z * v.y;
     T b = z * v.x - x * v.z;
@@ -1566,14 +1566,14 @@ Vec3<T>::operator%= (const Vec3& v) noexcept
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator% (const Vec3& v) const noexcept
+Vec3<T>::operator% (const Vec3& v) const IMATH_NOEXCEPT
 {
     return Vec3 (y * v.z - z * v.y, z * v.x - x * v.z, x * v.y - y * v.x);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator+= (const Vec3& v) noexcept
+Vec3<T>::operator+= (const Vec3& v) IMATH_NOEXCEPT
 {
     x += v.x;
     y += v.y;
@@ -1583,14 +1583,14 @@ Vec3<T>::operator+= (const Vec3& v) noexcept
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator+ (const Vec3& v) const noexcept
+Vec3<T>::operator+ (const Vec3& v) const IMATH_NOEXCEPT
 {
     return Vec3 (x + v.x, y + v.y, z + v.z);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator-= (const Vec3& v) noexcept
+Vec3<T>::operator-= (const Vec3& v) IMATH_NOEXCEPT
 {
     x -= v.x;
     y -= v.y;
@@ -1600,21 +1600,21 @@ Vec3<T>::operator-= (const Vec3& v) noexcept
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator- (const Vec3& v) const noexcept
+Vec3<T>::operator- (const Vec3& v) const IMATH_NOEXCEPT
 {
     return Vec3 (x - v.x, y - v.y, z - v.z);
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator-() const noexcept
+Vec3<T>::operator-() const IMATH_NOEXCEPT
 {
     return Vec3 (-x, -y, -z);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::negate() noexcept
+Vec3<T>::negate() IMATH_NOEXCEPT
 {
     x = -x;
     y = -y;
@@ -1624,7 +1624,7 @@ Vec3<T>::negate() noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator*= (const Vec3& v) noexcept
+Vec3<T>::operator*= (const Vec3& v) IMATH_NOEXCEPT
 {
     x *= v.x;
     y *= v.y;
@@ -1634,7 +1634,7 @@ Vec3<T>::operator*= (const Vec3& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator*= (T a) noexcept
+Vec3<T>::operator*= (T a) IMATH_NOEXCEPT
 {
     x *= a;
     y *= a;
@@ -1644,21 +1644,21 @@ Vec3<T>::operator*= (T a) noexcept
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator* (const Vec3& v) const noexcept
+Vec3<T>::operator* (const Vec3& v) const IMATH_NOEXCEPT
 {
     return Vec3 (x * v.x, y * v.y, z * v.z);
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator* (T a) const noexcept
+Vec3<T>::operator* (T a) const IMATH_NOEXCEPT
 {
     return Vec3 (x * a, y * a, z * a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator/= (const Vec3& v) noexcept
+Vec3<T>::operator/= (const Vec3& v) IMATH_NOEXCEPT
 {
     x /= v.x;
     y /= v.y;
@@ -1668,7 +1668,7 @@ Vec3<T>::operator/= (const Vec3& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec3<T>&
-Vec3<T>::operator/= (T a) noexcept
+Vec3<T>::operator/= (T a) IMATH_NOEXCEPT
 {
     x /= a;
     y /= a;
@@ -1678,21 +1678,21 @@ Vec3<T>::operator/= (T a) noexcept
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator/ (const Vec3& v) const noexcept
+Vec3<T>::operator/ (const Vec3& v) const IMATH_NOEXCEPT
 {
     return Vec3 (x / v.x, y / v.y, z / v.z);
 }
 
 template <class T>
 constexpr inline Vec3<T>
-Vec3<T>::operator/ (T a) const noexcept
+Vec3<T>::operator/ (T a) const IMATH_NOEXCEPT
 {
     return Vec3 (x / a, y / a, z / a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Vec3<T>::lengthTiny() const noexcept
+Vec3<T>::lengthTiny() const IMATH_NOEXCEPT
 {
     T absX = (x >= T (0)) ? x : -x;
     T absY = (y >= T (0)) ? y : -y;
@@ -1724,7 +1724,7 @@ Vec3<T>::lengthTiny() const noexcept
 
 template <class T>
 inline T
-Vec3<T>::length() const noexcept
+Vec3<T>::length() const IMATH_NOEXCEPT
 {
     T length2 = dot (*this);
 
@@ -1736,14 +1736,14 @@ Vec3<T>::length() const noexcept
 
 template <class T>
 constexpr inline T
-Vec3<T>::length2() const noexcept
+Vec3<T>::length2() const IMATH_NOEXCEPT
 {
     return dot (*this);
 }
 
 template <class T>
 inline const Vec3<T>&
-Vec3<T>::normalize() noexcept
+Vec3<T>::normalize() IMATH_NOEXCEPT
 {
     T l = length();
 
@@ -1780,7 +1780,7 @@ Vec3<T>::normalizeExc()
 
 template <class T>
 inline const Vec3<T>&
-Vec3<T>::normalizeNonNull() noexcept
+Vec3<T>::normalizeNonNull() IMATH_NOEXCEPT
 {
     T l = length();
     x /= l;
@@ -1791,7 +1791,7 @@ Vec3<T>::normalizeNonNull() noexcept
 
 template <class T>
 inline Vec3<T>
-Vec3<T>::normalized() const noexcept
+Vec3<T>::normalized() const IMATH_NOEXCEPT
 {
     T l = length();
 
@@ -1815,7 +1815,7 @@ Vec3<T>::normalizedExc() const
 
 template <class T>
 inline Vec3<T>
-Vec3<T>::normalizedNonNull() const noexcept
+Vec3<T>::normalizedNonNull() const IMATH_NOEXCEPT
 {
     T l = length();
     return Vec3 (x / l, y / l, z / l);
@@ -1827,46 +1827,46 @@ Vec3<T>::normalizedNonNull() const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline T&
-Vec4<T>::operator[] (int i) noexcept
+Vec4<T>::operator[] (int i) IMATH_NOEXCEPT
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>
 constexpr inline const T&
-Vec4<T>::operator[] (int i) const noexcept
+Vec4<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
-template <class T> inline Vec4<T>::Vec4() noexcept
+template <class T> inline Vec4<T>::Vec4() IMATH_NOEXCEPT
 {
     // empty, and not constexpr because data is uninitialized.
 }
 
-template <class T> constexpr inline Vec4<T>::Vec4 (T a) noexcept
+template <class T> constexpr inline Vec4<T>::Vec4 (T a) IMATH_NOEXCEPT
     : x(a), y(a), z(a), w(a)
 {
 }
 
-template <class T> constexpr inline Vec4<T>::Vec4 (T a, T b, T c, T d) noexcept
+template <class T> constexpr inline Vec4<T>::Vec4 (T a, T b, T c, T d) IMATH_NOEXCEPT
     : x(a), y(b), z(c), w(d)
 {
 }
 
-template <class T> constexpr inline Vec4<T>::Vec4 (const Vec4& v) noexcept
+template <class T> constexpr inline Vec4<T>::Vec4 (const Vec4& v) IMATH_NOEXCEPT
     : x(v.x), y(v.y), z(v.z), w(v.w)
 {
 }
 
-template <class T> template <class S> constexpr inline Vec4<T>::Vec4 (const Vec4<S>& v) noexcept
+template <class T> template <class S> constexpr inline Vec4<T>::Vec4 (const Vec4<S>& v) IMATH_NOEXCEPT
     : x(T(v.x)), y(T(v.y)), z(T(v.z)), w(T(v.w))
 {
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::operator= (const Vec4& v) noexcept
+Vec4<T>::operator= (const Vec4& v) IMATH_NOEXCEPT
 {
     x = v.x;
     y = v.y;
@@ -1875,7 +1875,7 @@ Vec4<T>::operator= (const Vec4& v) noexcept
     return *this;
 }
 
-template <class T> template <class S> constexpr inline Vec4<T>::Vec4 (const Vec3<S>& v) noexcept
+template <class T> template <class S> constexpr inline Vec4<T>::Vec4 (const Vec3<S>& v) IMATH_NOEXCEPT
     : x(T(v.x)), y(T(v.y)), z(T(v.z)), w(T(1))
 {
 }
@@ -1883,7 +1883,7 @@ template <class T> template <class S> constexpr inline Vec4<T>::Vec4 (const Vec3
 template <class T>
 template <class S>
 constexpr inline bool
-Vec4<T>::operator== (const Vec4<S>& v) const noexcept
+Vec4<T>::operator== (const Vec4<S>& v) const IMATH_NOEXCEPT
 {
     return x == v.x && y == v.y && z == v.z && w == v.w;
 }
@@ -1891,14 +1891,14 @@ Vec4<T>::operator== (const Vec4<S>& v) const noexcept
 template <class T>
 template <class S>
 constexpr inline bool
-Vec4<T>::operator!= (const Vec4<S>& v) const noexcept
+Vec4<T>::operator!= (const Vec4<S>& v) const IMATH_NOEXCEPT
 {
     return x != v.x || y != v.y || z != v.z || w != v.w;
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Vec4<T>::equalWithAbsError (const Vec4<T>& v, T e) const noexcept
+Vec4<T>::equalWithAbsError (const Vec4<T>& v, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 4; i++)
         if (!IMATH_INTERNAL_NAMESPACE::equalWithAbsError ((*this)[i], v[i], e))
@@ -1909,7 +1909,7 @@ Vec4<T>::equalWithAbsError (const Vec4<T>& v, T e) const noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline bool
-Vec4<T>::equalWithRelError (const Vec4<T>& v, T e) const noexcept
+Vec4<T>::equalWithRelError (const Vec4<T>& v, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 4; i++)
         if (!IMATH_INTERNAL_NAMESPACE::equalWithRelError ((*this)[i], v[i], e))
@@ -1920,21 +1920,21 @@ Vec4<T>::equalWithRelError (const Vec4<T>& v, T e) const noexcept
 
 template <class T>
 constexpr inline T
-Vec4<T>::dot (const Vec4& v) const noexcept
+Vec4<T>::dot (const Vec4& v) const IMATH_NOEXCEPT
 {
     return x * v.x + y * v.y + z * v.z + w * v.w;
 }
 
 template <class T>
 constexpr inline T
-Vec4<T>::operator^ (const Vec4& v) const noexcept
+Vec4<T>::operator^ (const Vec4& v) const IMATH_NOEXCEPT
 {
     return dot (v);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::operator+= (const Vec4& v) noexcept
+Vec4<T>::operator+= (const Vec4& v) IMATH_NOEXCEPT
 {
     x += v.x;
     y += v.y;
@@ -1945,14 +1945,14 @@ Vec4<T>::operator+= (const Vec4& v) noexcept
 
 template <class T>
 constexpr inline Vec4<T>
-Vec4<T>::operator+ (const Vec4& v) const noexcept
+Vec4<T>::operator+ (const Vec4& v) const IMATH_NOEXCEPT
 {
     return Vec4 (x + v.x, y + v.y, z + v.z, w + v.w);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::operator-= (const Vec4& v) noexcept
+Vec4<T>::operator-= (const Vec4& v) IMATH_NOEXCEPT
 {
     x -= v.x;
     y -= v.y;
@@ -1963,21 +1963,21 @@ Vec4<T>::operator-= (const Vec4& v) noexcept
 
 template <class T>
 constexpr inline Vec4<T>
-Vec4<T>::operator- (const Vec4& v) const noexcept
+Vec4<T>::operator- (const Vec4& v) const IMATH_NOEXCEPT
 {
     return Vec4 (x - v.x, y - v.y, z - v.z, w - v.w);
 }
 
 template <class T>
 constexpr inline Vec4<T>
-Vec4<T>::operator-() const noexcept
+Vec4<T>::operator-() const IMATH_NOEXCEPT
 {
     return Vec4 (-x, -y, -z, -w);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::negate() noexcept
+Vec4<T>::negate() IMATH_NOEXCEPT
 {
     x = -x;
     y = -y;
@@ -1988,7 +1988,7 @@ Vec4<T>::negate() noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::operator*= (const Vec4& v) noexcept
+Vec4<T>::operator*= (const Vec4& v) IMATH_NOEXCEPT
 {
     x *= v.x;
     y *= v.y;
@@ -1999,7 +1999,7 @@ Vec4<T>::operator*= (const Vec4& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::operator*= (T a) noexcept
+Vec4<T>::operator*= (T a) IMATH_NOEXCEPT
 {
     x *= a;
     y *= a;
@@ -2010,21 +2010,21 @@ Vec4<T>::operator*= (T a) noexcept
 
 template <class T>
 constexpr inline Vec4<T>
-Vec4<T>::operator* (const Vec4& v) const noexcept
+Vec4<T>::operator* (const Vec4& v) const IMATH_NOEXCEPT
 {
     return Vec4 (x * v.x, y * v.y, z * v.z, w * v.w);
 }
 
 template <class T>
 constexpr inline Vec4<T>
-Vec4<T>::operator* (T a) const noexcept
+Vec4<T>::operator* (T a) const IMATH_NOEXCEPT
 {
     return Vec4 (x * a, y * a, z * a, w * a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::operator/= (const Vec4& v) noexcept
+Vec4<T>::operator/= (const Vec4& v) IMATH_NOEXCEPT
 {
     x /= v.x;
     y /= v.y;
@@ -2035,7 +2035,7 @@ Vec4<T>::operator/= (const Vec4& v) noexcept
 
 template <class T>
 IMATH_CONSTEXPR14 inline const Vec4<T>&
-Vec4<T>::operator/= (T a) noexcept
+Vec4<T>::operator/= (T a) IMATH_NOEXCEPT
 {
     x /= a;
     y /= a;
@@ -2046,21 +2046,21 @@ Vec4<T>::operator/= (T a) noexcept
 
 template <class T>
 constexpr inline Vec4<T>
-Vec4<T>::operator/ (const Vec4& v) const noexcept
+Vec4<T>::operator/ (const Vec4& v) const IMATH_NOEXCEPT
 {
     return Vec4 (x / v.x, y / v.y, z / v.z, w / v.w);
 }
 
 template <class T>
 constexpr inline Vec4<T>
-Vec4<T>::operator/ (T a) const noexcept
+Vec4<T>::operator/ (T a) const IMATH_NOEXCEPT
 {
     return Vec4 (x / a, y / a, z / a, w / a);
 }
 
 template <class T>
 IMATH_CONSTEXPR14 inline T
-Vec4<T>::lengthTiny() const noexcept
+Vec4<T>::lengthTiny() const IMATH_NOEXCEPT
 {
     T absX = (x >= T (0)) ? x : -x;
     T absY = (y >= T (0)) ? y : -y;
@@ -2097,7 +2097,7 @@ Vec4<T>::lengthTiny() const noexcept
 
 template <class T>
 inline T
-Vec4<T>::length() const noexcept
+Vec4<T>::length() const IMATH_NOEXCEPT
 {
     T length2 = dot (*this);
 
@@ -2109,14 +2109,14 @@ Vec4<T>::length() const noexcept
 
 template <class T>
 constexpr inline T
-Vec4<T>::length2() const noexcept
+Vec4<T>::length2() const IMATH_NOEXCEPT
 {
     return dot (*this);
 }
 
 template <class T>
 const inline Vec4<T>&
-Vec4<T>::normalize() noexcept
+Vec4<T>::normalize() IMATH_NOEXCEPT
 {
     T l = length();
 
@@ -2155,7 +2155,7 @@ Vec4<T>::normalizeExc()
 
 template <class T>
 inline const Vec4<T>&
-Vec4<T>::normalizeNonNull() noexcept
+Vec4<T>::normalizeNonNull() IMATH_NOEXCEPT
 {
     T l = length();
     x /= l;
@@ -2167,7 +2167,7 @@ Vec4<T>::normalizeNonNull() noexcept
 
 template <class T>
 inline Vec4<T>
-Vec4<T>::normalized() const noexcept
+Vec4<T>::normalized() const IMATH_NOEXCEPT
 {
     T l = length();
 
@@ -2191,7 +2191,7 @@ Vec4<T>::normalizedExc() const
 
 template <class T>
 inline Vec4<T>
-Vec4<T>::normalizedNonNull() const noexcept
+Vec4<T>::normalizedNonNull() const IMATH_NOEXCEPT
 {
     T l = length();
     return Vec4 (x / l, y / l, z / l, w / l);
@@ -2228,21 +2228,21 @@ operator<< (std::ostream& s, const Vec4<T>& v)
 
 template <class T>
 constexpr inline Vec2<T>
-operator* (T a, const Vec2<T>& v) noexcept
+operator* (T a, const Vec2<T>& v) IMATH_NOEXCEPT
 {
     return Vec2<T> (a * v.x, a * v.y);
 }
 
 template <class T>
 constexpr inline Vec3<T>
-operator* (T a, const Vec3<T>& v) noexcept
+operator* (T a, const Vec3<T>& v) IMATH_NOEXCEPT
 {
     return Vec3<T> (a * v.x, a * v.y, a * v.z);
 }
 
 template <class T>
 constexpr inline Vec4<T>
-operator* (T a, const Vec4<T>& v) noexcept
+operator* (T a, const Vec4<T>& v) IMATH_NOEXCEPT
 {
     return Vec4<T> (a * v.x, a * v.y, a * v.z, a * v.w);
 }

--- a/src/Imath/ImathVecAlgo.h
+++ b/src/Imath/ImathVecAlgo.h
@@ -32,7 +32,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 template <class Vec,
           IMATH_ENABLE_IF(!std::is_integral<typename Vec::BaseType>::value)>
 IMATH_CONSTEXPR14 inline Vec
-project (const Vec& s, const Vec& t) noexcept
+project (const Vec& s, const Vec& t) IMATH_NOEXCEPT
 {
     Vec sNormalized = s.normalized();
     return sNormalized * (sNormalized ^ t);
@@ -45,7 +45,7 @@ project (const Vec& s, const Vec& t) noexcept
 template <class Vec,
           IMATH_ENABLE_IF(!std::is_integral<typename Vec::BaseType>::value)>
 constexpr inline Vec
-orthogonal (const Vec& s, const Vec& t) noexcept
+orthogonal (const Vec& s, const Vec& t) IMATH_NOEXCEPT
 {
     return t - project (s, t);
 }
@@ -57,7 +57,7 @@ orthogonal (const Vec& s, const Vec& t) noexcept
 template <class Vec,
           IMATH_ENABLE_IF(!std::is_integral<typename Vec::BaseType>::value)>
 constexpr inline Vec
-reflect (const Vec& s, const Vec& t) noexcept
+reflect (const Vec& s, const Vec& t) IMATH_NOEXCEPT
 {
     return s - typename Vec::BaseType (2) * (s - project (t, s));
 }
@@ -68,7 +68,7 @@ reflect (const Vec& s, const Vec& t) noexcept
 /// (`Vec2`, `Vec3`, `Vec4`)
 template <class Vec>
 IMATH_CONSTEXPR14 Vec
-closestVertex (const Vec& v0, const Vec& v1, const Vec& v2, const Vec& p) noexcept
+closestVertex (const Vec& v0, const Vec& v1, const Vec& v2, const Vec& p) IMATH_NOEXCEPT
 {
     Vec nearest                    = v0;
     typename Vec::BaseType neardot = (v0 - p).length2();

--- a/src/Imath/half.cpp
+++ b/src/Imath/half.cpp
@@ -57,7 +57,7 @@ EXPORT_CONST const uint16_t *imath_float_half_exp_table = imath_float_half_exp_t
 //-----------------------------------------------
 
 static float
-half_overflow() noexcept
+half_overflow() IMATH_NOEXCEPT
 {
     float f = 1e10;
 
@@ -73,7 +73,7 @@ half_overflow() noexcept
 //-----------------------------------------------------
 
 IMATH_EXPORT uint16_t
-half::long_convert (int i) noexcept
+half::long_convert (int i) IMATH_NOEXCEPT
 {
     //
     // Our floating point number, f, is represented by the bit

--- a/src/Imath/half.h
+++ b/src/Imath/half.h
@@ -377,98 +377,98 @@ class IMATH_EXPORT_TYPE half
 
     /// Default construction provides no initialization (hence it is
     /// not constexpr).
-    half() noexcept = default;
+    half() IMATH_NOEXCEPT = default;
 
     /// Construct from float
-    half (float f) noexcept;
+    half (float f) IMATH_NOEXCEPT;
 
     /// Construct from bit-vector
-    constexpr half (FromBitsTag, uint16_t bits) noexcept;
+    constexpr half (FromBitsTag, uint16_t bits) IMATH_NOEXCEPT;
 
     /// Copy constructor
-    constexpr half (const half&) noexcept = default;
+    constexpr half (const half&) IMATH_NOEXCEPT = default;
 
     /// Move constructor
-    constexpr half (half&&) noexcept = default;
+    constexpr half (half&&) IMATH_NOEXCEPT = default;
 
     /// Destructor
-    ~half() noexcept = default;
+    ~half() IMATH_NOEXCEPT = default;
 
     /// @}
 
     /// Conversion to float
-    operator float() const noexcept;
+    operator float() const IMATH_NOEXCEPT;
 
     /// @{
     /// @name Basic Algebra
 
     /// Unary minus
-    constexpr half operator-() const noexcept;
+    constexpr half operator-() const IMATH_NOEXCEPT;
 
     /// Assignment
-    half& operator= (const half& h) noexcept = default;
+    half& operator= (const half& h) IMATH_NOEXCEPT = default;
 
     /// Move assignment
-    half& operator= (half&& h) noexcept = default;
+    half& operator= (half&& h) IMATH_NOEXCEPT = default;
 
     /// Assignment from float
-    half& operator= (float f) noexcept;
+    half& operator= (float f) IMATH_NOEXCEPT;
 
     /// Addition assignment
-    half& operator+= (half h) noexcept;
+    half& operator+= (half h) IMATH_NOEXCEPT;
 
     /// Addition assignment from float
-    half& operator+= (float f) noexcept;
+    half& operator+= (float f) IMATH_NOEXCEPT;
 
     /// Subtraction assignment
-    half& operator-= (half h) noexcept;
+    half& operator-= (half h) IMATH_NOEXCEPT;
 
     /// Subtraction assignment from float
-    half& operator-= (float f) noexcept;
+    half& operator-= (float f) IMATH_NOEXCEPT;
 
     /// Multiplication assignment
-    half& operator*= (half h) noexcept;
+    half& operator*= (half h) IMATH_NOEXCEPT;
 
     /// Multiplication assignment from float
-    half& operator*= (float f) noexcept;
+    half& operator*= (float f) IMATH_NOEXCEPT;
 
     /// Division assignment
-    half& operator/= (half h) noexcept;
+    half& operator/= (half h) IMATH_NOEXCEPT;
 
     /// Division assignment from float
-    half& operator/= (float f) noexcept;
+    half& operator/= (float f) IMATH_NOEXCEPT;
 
     /// @}
 
     /// Round to n-bit precision (n should be between 0 and 10).
     /// After rounding, the significand's 10-n least significant
     /// bits will be zero.
-    IMATH_CONSTEXPR14 half round (unsigned int n) const noexcept;
+    IMATH_CONSTEXPR14 half round (unsigned int n) const IMATH_NOEXCEPT;
 
     /// @{
     /// @name Classification
 
     /// Return true if a normalized number, a denormalized number, or
     /// zero.
-    constexpr bool isFinite() const noexcept;
+    constexpr bool isFinite() const IMATH_NOEXCEPT;
 
     /// Return true if a normalized number.
-    constexpr bool isNormalized() const noexcept;
+    constexpr bool isNormalized() const IMATH_NOEXCEPT;
 
     /// Return true if a denormalized number.
-    constexpr bool isDenormalized() const noexcept;
+    constexpr bool isDenormalized() const IMATH_NOEXCEPT;
 
     /// Return true if zero.
-    constexpr bool isZero() const noexcept;
+    constexpr bool isZero() const IMATH_NOEXCEPT;
 
     /// Return true if NAN.
-    constexpr bool isNan() const noexcept;
+    constexpr bool isNan() const IMATH_NOEXCEPT;
 
     /// Return true if a positive or a negative infinity
-    constexpr bool isInfinity() const noexcept;
+    constexpr bool isInfinity() const IMATH_NOEXCEPT;
 
     /// Return true if the sign bit is set (negative)
-    constexpr bool isNegative() const noexcept;
+    constexpr bool isNegative() const IMATH_NOEXCEPT;
 
     /// @}
 
@@ -476,16 +476,16 @@ class IMATH_EXPORT_TYPE half
     /// @name Special values
 
     /// Return +infinity
-    static constexpr half posInf() noexcept;
+    static constexpr half posInf() IMATH_NOEXCEPT;
 
     /// Return -infinity
-    static constexpr half negInf() noexcept;
+    static constexpr half negInf() IMATH_NOEXCEPT;
 
     /// Returns a NAN with the bit pattern 0111111111111111
-    static constexpr half qNan() noexcept;
+    static constexpr half qNan() IMATH_NOEXCEPT;
 
     /// Return a NAN with the bit pattern 0111110111111111
-    static constexpr half sNan() noexcept;
+    static constexpr half sNan() IMATH_NOEXCEPT;
 
     /// @}
 
@@ -493,10 +493,10 @@ class IMATH_EXPORT_TYPE half
     /// @name Access to the internal representation
 
     /// Return the bit pattern
-    IMATH_EXPORT constexpr uint16_t bits() const noexcept;
+    IMATH_EXPORT constexpr uint16_t bits() const IMATH_NOEXCEPT;
 
     /// Set the bit pattern
-    IMATH_EXPORT IMATH_CONSTEXPR14 void setBits (uint16_t bits) noexcept;
+    IMATH_EXPORT IMATH_CONSTEXPR14 void setBits (uint16_t bits) IMATH_NOEXCEPT;
 
     /// @}
 
@@ -506,11 +506,11 @@ class IMATH_EXPORT_TYPE half
     using uif = imath_half_uif;
 
     // preserved for legacy conversion
-    IMATH_EXPORT static uint16_t long_convert ( int i ) noexcept;
+    IMATH_EXPORT static uint16_t long_convert ( int i ) IMATH_NOEXCEPT;
   private:
 
-    constexpr uint16_t mantissa() const noexcept;
-    constexpr uint16_t exponent() const noexcept;
+    constexpr uint16_t mantissa() const IMATH_NOEXCEPT;
+    constexpr uint16_t exponent() const IMATH_NOEXCEPT;
 
     uint16_t _h;
 };
@@ -631,7 +631,7 @@ class IMATH_EXPORT_TYPE half
 // Half-from-float constructor
 //----------------------------
 
-inline half::half (float f) noexcept
+inline half::half (float f) IMATH_NOEXCEPT
     : _h (imath_float_to_half (f))
 {
 }
@@ -640,14 +640,14 @@ inline half::half (float f) noexcept
 // Half from raw bits constructor
 //------------------------------------------
 
-inline constexpr half::half (FromBitsTag, uint16_t bits) noexcept : _h (bits)
+inline constexpr half::half (FromBitsTag, uint16_t bits) IMATH_NOEXCEPT : _h (bits)
 {}
 
 //------------------------------------------
 // Half-to-float conversion via table lookup
 //------------------------------------------
 
-inline half::operator float() const noexcept
+inline half::operator float() const IMATH_NOEXCEPT
 {
     return imath_half_to_float (_h);
 }
@@ -657,7 +657,7 @@ inline half::operator float() const noexcept
 //-------------------------
 
 inline IMATH_CONSTEXPR14 half
-half::round (unsigned int n) const noexcept
+half::round (unsigned int n) const IMATH_NOEXCEPT
 {
     //
     // Parameter check.
@@ -714,160 +714,160 @@ half::round (unsigned int n) const noexcept
 //-----------------------
 
 inline constexpr half
-half::operator-() const noexcept
+half::operator-() const IMATH_NOEXCEPT
 {
     return half (FromBits, bits() ^ 0x8000);
 }
 
 inline half&
-half::operator= (float f) noexcept
+half::operator= (float f) IMATH_NOEXCEPT
 {
     *this = half (f);
     return *this;
 }
 
 inline half&
-half::operator+= (half h) noexcept
+half::operator+= (half h) IMATH_NOEXCEPT
 {
     *this = half (float (*this) + float (h));
     return *this;
 }
 
 inline half&
-half::operator+= (float f) noexcept
+half::operator+= (float f) IMATH_NOEXCEPT
 {
     *this = half (float (*this) + f);
     return *this;
 }
 
 inline half&
-half::operator-= (half h) noexcept
+half::operator-= (half h) IMATH_NOEXCEPT
 {
     *this = half (float (*this) - float (h));
     return *this;
 }
 
 inline half&
-half::operator-= (float f) noexcept
+half::operator-= (float f) IMATH_NOEXCEPT
 {
     *this = half (float (*this) - f);
     return *this;
 }
 
 inline half&
-half::operator*= (half h) noexcept
+half::operator*= (half h) IMATH_NOEXCEPT
 {
     *this = half (float (*this) * float (h));
     return *this;
 }
 
 inline half&
-half::operator*= (float f) noexcept
+half::operator*= (float f) IMATH_NOEXCEPT
 {
     *this = half (float (*this) * f);
     return *this;
 }
 
 inline half&
-half::operator/= (half h) noexcept
+half::operator/= (half h) IMATH_NOEXCEPT
 {
     *this = half (float (*this) / float (h));
     return *this;
 }
 
 inline half&
-half::operator/= (float f) noexcept
+half::operator/= (float f) IMATH_NOEXCEPT
 {
     *this = half (float (*this) / f);
     return *this;
 }
 
 inline constexpr uint16_t
-half::mantissa() const noexcept
+half::mantissa() const IMATH_NOEXCEPT
 {
     return _h & 0x3ff;
 }
 
 inline constexpr uint16_t
-half::exponent() const noexcept
+half::exponent() const IMATH_NOEXCEPT
 {
     return (_h >> 10) & 0x001f;
 }
 
 inline constexpr bool
-half::isFinite() const noexcept
+half::isFinite() const IMATH_NOEXCEPT
 {
     return exponent() < 31;
 }
 
 inline constexpr bool
-half::isNormalized() const noexcept
+half::isNormalized() const IMATH_NOEXCEPT
 {
     return exponent() > 0 && exponent() < 31;
 }
 
 inline constexpr bool
-half::isDenormalized() const noexcept
+half::isDenormalized() const IMATH_NOEXCEPT
 {
     return exponent() == 0 && mantissa() != 0;
 }
 
 inline constexpr bool
-half::isZero() const noexcept
+half::isZero() const IMATH_NOEXCEPT
 {
     return (_h & 0x7fff) == 0;
 }
 
 inline constexpr bool
-half::isNan() const noexcept
+half::isNan() const IMATH_NOEXCEPT
 {
     return exponent() == 31 && mantissa() != 0;
 }
 
 inline constexpr bool
-half::isInfinity() const noexcept
+half::isInfinity() const IMATH_NOEXCEPT
 {
     return exponent() == 31 && mantissa() == 0;
 }
 
 inline constexpr bool
-half::isNegative() const noexcept
+half::isNegative() const IMATH_NOEXCEPT
 {
     return (_h & 0x8000) != 0;
 }
 
 inline constexpr half
-half::posInf() noexcept
+half::posInf() IMATH_NOEXCEPT
 {
     return half (FromBits, 0x7c00);
 }
 
 inline constexpr half
-half::negInf() noexcept
+half::negInf() IMATH_NOEXCEPT
 {
     return half (FromBits, 0xfc00);
 }
 
 inline constexpr half
-half::qNan() noexcept
+half::qNan() IMATH_NOEXCEPT
 {
     return half (FromBits, 0x7fff);
 }
 
 inline constexpr half
-half::sNan() noexcept
+half::sNan() IMATH_NOEXCEPT
 {
     return half (FromBits, 0x7dff);
 }
 
 inline constexpr uint16_t
-half::bits() const noexcept
+half::bits() const IMATH_NOEXCEPT
 {
     return _h;
 }
 
 inline IMATH_CONSTEXPR14 void
-half::setBits (uint16_t bits) noexcept
+half::setBits (uint16_t bits) IMATH_NOEXCEPT
 {
     _h = bits;
 }

--- a/src/Imath/halfLimits.h
+++ b/src/Imath/halfLimits.h
@@ -31,8 +31,8 @@ template <> class numeric_limits<half>
   public:
     static const bool is_specialized = true;
 
-    static constexpr half min() noexcept { return half(half::FromBits, 0x0400); /*HALF_MIN*/ }
-    static constexpr half max() noexcept { return half(half::FromBits, 0x7bff); /*HALF_MAX*/ }
+    static constexpr half min() IMATH_NOEXCEPT { return half(half::FromBits, 0x0400); /*HALF_MIN*/ }
+    static constexpr half max() IMATH_NOEXCEPT { return half(half::FromBits, 0x7bff); /*HALF_MAX*/ }
     static constexpr half lowest() { return half(half::FromBits, 0xfbff); /* -HALF_MAX */ }
 
     static constexpr int digits       = HALF_MANT_DIG;
@@ -42,8 +42,8 @@ template <> class numeric_limits<half>
     static constexpr bool is_integer  = false;
     static constexpr bool is_exact    = false;
     static constexpr int radix        = HALF_RADIX;
-    static constexpr half epsilon() noexcept { return half(half::FromBits, 0x1400); /*HALF_EPSILON*/ }
-    static constexpr half round_error() noexcept { return half(half::FromBits, 0x3800); /*0.5*/ }
+    static constexpr half epsilon() IMATH_NOEXCEPT { return half(half::FromBits, 0x1400); /*HALF_EPSILON*/ }
+    static constexpr half round_error() IMATH_NOEXCEPT { return half(half::FromBits, 0x3800); /*0.5*/ }
 
     static constexpr int min_exponent   = HALF_DENORM_MIN_EXP;
     static constexpr int min_exponent10 = HALF_DENORM_MIN_10_EXP;
@@ -55,10 +55,10 @@ template <> class numeric_limits<half>
     static constexpr bool has_signaling_NaN        = true;
     static constexpr float_denorm_style has_denorm = denorm_present;
     static constexpr bool has_denorm_loss          = false;
-    static constexpr half infinity() noexcept { return half(half::FromBits, 0x7c00); /*half::posInf()*/ }
-    static constexpr half quiet_NaN() noexcept { return half(half::FromBits, 0x7fff); /*half::qNan()*/ }
-    static constexpr half signaling_NaN() noexcept { return half(half::FromBits, 0x7dff); /*half::sNan()*/ }
-    static constexpr half denorm_min() noexcept { return half(half::FromBits, 0x0001); /*HALF_DENORM_MIN*/ }
+    static constexpr half infinity() IMATH_NOEXCEPT { return half(half::FromBits, 0x7c00); /*half::posInf()*/ }
+    static constexpr half quiet_NaN() IMATH_NOEXCEPT { return half(half::FromBits, 0x7fff); /*half::qNan()*/ }
+    static constexpr half signaling_NaN() IMATH_NOEXCEPT { return half(half::FromBits, 0x7dff); /*half::sNan()*/ }
+    static constexpr half denorm_min() IMATH_NOEXCEPT { return half(half::FromBits, 0x0001); /*HALF_DENORM_MIN*/ }
 
     static constexpr bool is_iec559  = false;
     static constexpr bool is_bounded = false;


### PR DESCRIPTION
Legacy code that depends on the IlmBase v2 ExcMath mechanism of signal
handlers that throw exceptions is incompatible with noexcept, since
floating-point overflow and underflow can occur in computations within
Imath functions now marked with noexcept. Legacy code that needs to
accomodate the exception-handling behavior can disable the noexcept
specifier by defining the IMATH_NOEXCEPT macro to be empty. Otherwise,
IMATH_NOEXEPT defaults to "noexcept".

Signed-off-by: Cary Phillips <cary@ilm.com>