### PR TITLE
Add new macros to Doxyfile PREDEFINED

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -19,5 +19,10 @@ PREDEFINED = IMATH_CONSTEXPR14=constexpr \
              IMATH_INTERNAL_NAMESPACE_SOURCE_ENTER="namespace Imath {" \
              IMATH_INTERNAL_NAMESPACE_SOURCE_EXIT="}" \
              IMATH_INTERNAL_NAMESPACE_HEADER_ENTER="namespace Imath {" \
-             IMATH_INTERNAL_NAMESPACE_HEADER_EXIT="}" 
+             IMATH_INTERNAL_NAMESPACE_HEADER_EXIT="}" \
+             IMATH_EXPORT= \
+             IMATH_EXPORT_ENUM= \
+             IMATH_EXPORT_TYPE= \
+             IMATH_EXPORT_TEMPLATE_TYPE= \
+             __cplusplus=1 
              


### PR DESCRIPTION
This gets the docs back functioning after recent changes (__cplusplus is necessary for the half changes). Preview of the updated docs is here:

https://cary-ilm-imath.readthedocs.io/en/latest/classes/half.html

The .rst setup doesn't currently pull in any of the overview doxygen coments (e.g. @file) from the headers such, that should be fleshed out.

Signed-off-by: Cary Phillips <cary@ilm.com>