### PR TITLE
Add testInterop to test list in define_imath_test()

### DIFF
--- a/src/ImathTest/CMakeLists.txt
+++ b/src/ImathTest/CMakeLists.txt
@@ -117,5 +117,6 @@ define_imath_tests(
   testTinySVD
   testJacobiEigenSolver
   testFrustumTest
+  testInterop
 )
 


### PR DESCRIPTION
Otherwise it doesn't get executed.

Signed-off-by: Cary Phillips <cary@ilm.com>