### PR TITLE
Add validate_imath_libs.sh to validate .so symlinks

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -257,6 +257,9 @@ jobs:
                 --target install \
                 --config ${{ matrix.build-type }}
         working-directory: _build
+      - name: Validate
+        run: |
+          share/ci/scripts/linux/validate_imath_libs.sh _install 
       - name: Examples
         run: |
           # Make sure we can build the tests when configured as a

--- a/share/ci/scripts/linux/validate_imath_libs.sh
+++ b/share/ci/scripts/linux/validate_imath_libs.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+#
+# Validate the libary symlinks:
+#   * The actual elf binary is, e.g. libImath-3_1.so.29.0.0
+#   * The symlinks are:
+#       libImath.so -> libImath-3_1.so
+#       libImath-3_1.so -> libImath-3_1.so.29
+#       libImath-3_1.so.29 -> libImath-3_1.so.29.0.0
+#
+# Extract the lib version by compiling a program that prints the
+# IMATH_LIB_VERSION_STRING. This also validates that the program
+# compiles and executes with the info from pkg-config.
+#
+
+if [[ $# == "0" ]]; then
+    echo "usage: $0 BUILD_ROOT [SRC_ROOT]"
+    exit -1
+fi
+
+BUILD_ROOT=$1
+SRC_ROOT=$2
+
+# Locate Imath.pc and set PKG_CONFIG_PATH accordingly
+
+pkgconfig=$(find $BUILD_ROOT -name Imath.pc)
+if [[ "$pkgconfig" == "" ]]; then
+    echo "Can't find Imath.pc"
+    exit -1
+fi    
+export PKG_CONFIG_PATH=$(dirname $pkgconfig)
+
+CXX_FLAGS=$(pkg-config Imath --cflags)
+LD_FLAGS=$(pkg-config Imath --libs --static)
+
+VALIDATE_CPP=$(mktemp --tmpdir "validate_XXX.cpp")
+VALIDATE_BIN=$(mktemp --tmpdir "validate_XXX")
+trap "rm -rf $VALIDATE_CPP $VALIDATE_BIN" exit
+
+# Invoke succf (which is not inline) in the program so it links against the library, to validate the link phase.
+
+echo -e '#include <ImathFun.h>\n#include <stdio.h>\nint main() { printf("%s %s\\n", IMATH_PACKAGE_STRING, IMATH_LIB_VERSION_STRING); Imath::succf(0.0f); return 0; }' > $VALIDATE_CPP
+
+g++ $CXX_FLAGS $VALIDATE_CPP -o $VALIDATE_BIN $LD_FLAGS
+
+# Execute the program
+
+LIB_DIR=$(pkg-config Imath --variable=libdir)
+export LD_LIBRARY_PATH=$LIB_DIR
+
+validate=`$VALIDATE_BIN`
+status=$?
+
+echo $validate
+
+if [[ "$status" != "0" ]]; then
+   echo "validate failed: $validate"
+   exit -1
+fi
+
+# Get the suffix, e.g. -2_5_d, and determine if there's also a _d
+libsuffix=$(pkg-config Imath --variable=libsuffix)
+if [[ $libsuffix != $(basename ./$libsuffix _d) ]]; then
+    _d="_d"
+else
+    _d=""
+fi
+
+# Validate each of the libs
+libs=$(pkg-config Imath --libs-only-l | sed -e s/-l//g)
+for lib in $libs; do
+
+    base=`echo $lib | cut -d- -f1`
+    suffix=`echo $lib | cut -d- -f2`
+
+    if [[ -f $LIB_DIR/lib$base$_d.so ]]; then 
+        libbase=`readlink $LIB_DIR/lib$base$_d.so`
+        echo libbase=$libbase
+        libcurrent=`readlink $LIB_DIR/$libbase`
+        echo libcurrent=$libcurrent
+        libversion=`readlink $LIB_DIR/$libcurrent`
+        echo libversion=$libversion
+        file $LIB_DIR/$libversion | grep -q "ELF"
+
+        if [[ "$?" != 0 ]]; then
+            echo "Broken libs: lib$base.so -> $libbase -> $libcurrent -> $libversion"
+            exit -1
+        fi
+
+        echo "lib$base.so -> $libbase -> $libcurrent -> $libversion"
+
+    elif [[ ! -f $LIB_DIR/lib$lib.a ]]; then
+        echo "No static lib: $LIB_DIR/lib$lib.a"
+    else
+        echo "Static lib lib$lib.a"
+    fi
+
+done
+
+pkg-config --validate --silence-errors PyImath
+if [[ $? == 1 ]]; then
+    echo "No PyImath pkg-config"
+else
+
+    pylibs=`pkg-config PyImath --libs-only-l | sed -e s/-l//g`
+    for lib in $pylibs; do
+
+        base=`echo $lib | cut -d- -f1`
+        suffix=`echo $lib | cut -d- -f2`
+
+        if [[ -f $LIB_DIR/lib$lib.so ]]; then 
+            libcurrent=`readlink $LIB_DIR/lib$lib.so`
+            libversion=`readlink $LIB_DIR/$libcurrent`
+            file $LIB_DIR/$libversion | grep -q "ELF"
+
+            if [[ "$?" != 0 ]]; then
+                echo "Broken libs: lib$base.so -> $libbase -> $libcurrent -> $libversion"
+                exit -1
+            fi
+
+            echo "lib$lib.so -> $libcurrent -> $libversion"
+
+        elif [[ ! -f $LIB_DIR/lib$lib.a ]]; then
+            echo "No static lib: $LIB_DIR/lib$lib.a"
+        else
+            echo "Static lib lib$lib.a"
+        fi
+    done
+fi
+
+# Confirm no broken .so symlinks 
+file $LIB_DIR/lib* | grep -q broken 
+if [[ "$?" == "0" ]]; then
+  echo "Broken symbolic link."
+  exit -1
+fi
+
+if [[ "$SRC_ROOT" != "" ]]; then
+    version=$(pkg-config Imath --modversion)
+    notes=$(grep "\* \[Version $version\]" $SRC_ROOT/CHANGES.md | head -1)
+    if [[ "$notes" == "" ]]; then
+        echo "No release notes."
+    else
+        echo "Release notes: $notes"
+    fi
+fi
+   
+echo "ok."
+

--- a/share/ci/scripts/linux/validate_imath_libs.sh
+++ b/share/ci/scripts/linux/validate_imath_libs.sh
@@ -66,20 +66,22 @@ else
     _d=""
 fi
 
-# Validate each of the libs
+#
+# Validate each of the symlinks, which should be changed together like:
+#
+# libImath.so -> libImath-3_1.so -> libImath-3_1.so.29 -> libImath-3_1.so.29.0.0
+#
+
 libs=$(pkg-config Imath --libs-only-l | sed -e s/-l//g)
 for lib in $libs; do
 
-    base=`echo $lib | cut -d- -f1`
-    suffix=`echo $lib | cut -d- -f2`
-
-    if [[ -f $LIB_DIR/lib$base$_d.so ]]; then 
-        libbase=`readlink $LIB_DIR/lib$base$_d.so`
-        echo libbase=$libbase
-        libcurrent=`readlink $LIB_DIR/$libbase`
-        echo libcurrent=$libcurrent
-        libversion=`readlink $LIB_DIR/$libcurrent`
-        echo libversion=$libversion
+    base=`echo $lib | cut -d- -f1` # Imath
+    suffix=`echo $lib | cut -d- -f2` # 3_1
+    
+    if [[ -f $LIB_DIR/lib$base$_d.so ]]; then       # libImath.so
+        libbase=`readlink $LIB_DIR/lib$base$_d.so`  # libImath-3.1.so
+        libcurrent=`readlink $LIB_DIR/$libbase`     # libImath-3.1.so.29
+        libversion=`readlink $LIB_DIR/$libcurrent`  # libImath-3.1.so.29.0.0
         file $LIB_DIR/$libversion | grep -q "ELF"
 
         if [[ "$?" != 0 ]]; then
@@ -135,6 +137,7 @@ if [[ "$?" == "0" ]]; then
   exit -1
 fi
 
+# If the SRC_ROOT is specified, check if there are release notes.
 if [[ "$SRC_ROOT" != "" ]]; then
     version=$(pkg-config Imath --modversion)
     notes=$(grep "\* \[Version $version\]" $SRC_ROOT/CHANGES.md | head -1)


### PR DESCRIPTION
Invoked by the ci, but also helpful as a standalone in validating new releases. Validates the pkg-config and library symlinks.
