### PR TITLE
Clean up library VERSION and SOVERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,28 @@ set(IMATH_VERSION_RELEASE_TYPE "-dev" CACHE STRING "Extra version tag string for
 set(IMATH_VERSION ${Imath_VERSION})
 set(IMATH_VERSION_API "${Imath_VERSION_MAJOR}_${Imath_VERSION_MINOR}")
 
+# Library/shared-object version using libtool versioning policy.
 # See https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
-set(IMATH_SOVERSION 29)
-set(IMATH_SOREVISION 0) 
-set(IMATH_SOAGE 0) 
-set(IMATH_LIB_VERSION "${IMATH_SOVERSION}.${IMATH_SOREVISION}.${IMATH_SOAGE}")
+#
+# Library API version (CMake's library VERSION attribute) is of the
+# form CURRENT.REVISION.AGE; the CMake SOVERSION attribute corresonds
+# to just CURRENT. These produce a .so and a symlink symlink, e.g.:
+# libImath-3_1.so.29 -> libImath-3_1.so.29.0.0
+#                 ^                     ^  ^ ^
+#                 |                     |  | |
+#                 CURRENT               |  | AGE
+#                                       |  REVISION 
+#                                       CURRENT
+# When updating:
+#   1. no API change: CURRENT.REVISION+1.AGE
+#   2. API added:     CURRENT+1.0.AGE+1
+#   3. API changed:   CURRENT+1.0.0
+#
+set(IMATH_LIBTOOL_CURRENT 29)
+set(IMATH_LIBTOOL_REVISION 0)
+set(IMATH_LIBTOOL_AGE 0)
+set(IMATH_LIB_VERSION "${IMATH_LIBTOOL_CURRENT}.${IMATH_LIBTOOL_REVISION}.${IMATH_LIBTOOL_AGE}")
+set(IMATH_LIB_SOVERSION ${IMATH_LIBTOOL_CURRENT})
 
 # ImathSetup.cmake declares all the configuration variables visible
 # in cmake-gui or similar and the rest of the global

--- a/config/LibraryDefine.cmake
+++ b/config/LibraryDefine.cmake
@@ -70,7 +70,7 @@ function(IMATH_DEFINE_LIBRARY libname)
 
   if(BUILD_SHARED_LIBS)
     set_target_properties(${libname} PROPERTIES
-      SOVERSION ${IMATH_SOVERSION}
+      SOVERSION ${IMATH_LIB_SOVERSION}
       VERSION ${IMATH_LIB_VERSION}
     )
   endif()

--- a/src/python/config/ModuleDefine.cmake
+++ b/src/python/config/ModuleDefine.cmake
@@ -15,7 +15,7 @@ function(PYIMATH_ADD_LIBRARY_PRIV libname)
   add_library(${libname} SHARED ${PYIMATH_CURLIB_SOURCE})
   #if(BUILD_SHARED_LIBS)
   set_target_properties(${libname} PROPERTIES
-  SOVERSION ${IMATH_SOVERSION}
+  SOVERSION ${IMATH_LIB_SOVERSION}
   VERSION ${IMATH_LIB_VERSION}
   )
   #endif()


### PR DESCRIPTION
Reduce confusion between "VERSION", "REVISION", and "SOVERSION":
* Label the internal variable IMATH_LIBTOOL_* to indicate their purpose.
* Use terminology closer to the libtool description
* Add comment documenting the library update process

Signed-off-by: Cary Phillips <cary@ilm.com>