### PR TITLE
Clean up half lookup-table options and related docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -207,7 +207,7 @@ ways:
 
 ``IMATH_HALF_USE_LOOKUP_TABLE``
   Use the half-to-float conversion lookup table. Default is ``ON`` for
-  backwards compatibility. With the value of ``OFF``, use a bit-shif
+  backwards compatibility. With the value of ``OFF``, use a bit-shift
   conversion algorithm. Note that this setting is overriden when
   compiler flags enable the F16C SSE instruction set.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -201,59 +201,68 @@ ways:
 
 ### Imath Configuration Settings:
 
-* ``IMATH_CXX_STANDARD`` - C++ standard to compile against. Default is
-  ``14``.
+``IMATH_CXX_STANDARD``
+  C++ standard to compile against. Default is ``14``.
 
-* ``IMATH_USE_HALF_LOOKUP_TABLES`` - Use the hard-coded half-to-float
-  conversion lookup tables. Default is ``ON`` for backwards
-  compatibility. With the value of ``OFF``, half-to-float and
-  float-to-half conversion is performed using Intel intrinsic
-  instructions if available, or if not, via a newer, optimized bit
-  manpulation algorithm.
+``IMATH_HALF_USE_LOOKUP_TABLE``
+  Use the half-to-float conversion lookup table. Default is ``ON`` for
+  backwards compatibility. With the value of ``OFF``, use a bit-shif
+  conversion algorithm. Note that this setting is overriden when
+  compiler flags enable the F16C SSE instruction set.
 
-* ``IMATH_HALF_NO_TABLES_AT_ALL`` - force elimination of all
-  half-conversion lookup tables. This forces either the SSE extension
-  instructions or the bit-manipulation conversion.
+``IMATH_USE_DEFAULT_VISIBILITY``
+  Use default visibility, which makes all symbols visible in compiled
+  objects.  Default is ``OFF``, in which case only designated
+  necessary symbols are marked for export.
 
-* ``IMATH_ENABLE_LARGE_STACK`` - Enables the ``halfFunction`` object
-  to place the lookup tables on the stack rather than allocating heap
-  memory. Default is ``OFF``.
+``IMATH_USE_NOEXCEPT``
+  Use the ``noexcept`` specifier of appropriate methods. Default is
+  ``ON``.  With the value of ``OFF``, the ``noexcept`` specifier is
+  omitted, for situations in which it is not desireable.
 
-* ``IMATH_USE_NOEXCEPT`` - Use the ``noexcept`` specifier of
-  appropriate methods. Default is ``ON``.  With the value of ``OFF``,
-  the ``noexcept`` specifier is omitted, for situations in which it is
-  not desireable.
+``IMATH_ENABLE_LARGE_STACK``
+  Enables the ``halfFunction`` object to place the lookup tables on
+  the stack rather than allocating heap memory. Default is ``OFF``.
 
-* ``IMATH_USE_DEFAULT_VISIBILITY`` - Use default visibility, which
-  makes all symbols visible in compiled objects.  Default is ``OFF``,
-  in which case only designated necessary symbols are marked for
-  export.
-
-* ``IMATH_VERSION_RELEASE_TYPE`` a string to append to the version
+``IMATH_VERSION_RELEASE_TYPE``
+  A string to append to the version
   number in the internal package name macro
   IMATH_PACKAGE_STRING. Default is the empty string, but can be set
   to, for example, "-dev" during development (e.g. "3.1.0-dev").
 
-* ``IMATH_INSTALL_SYM_LINK`` - Install an unversioned symbolic link
-  (i.e. libImath.so) to the versioned library.
+``IMATH_INSTALL_SYM_LINK``
+  Install an unversioned symbolic link (i.e. libImath.so) to the
+  versioned library.
 
-* ``IMATH_INSTALL_PKG_CONFIG`` - Install Imath.pc file. Default is
-  ``ON``.
+``IMATH_INSTALL_PKG_CONFIG``
+  Install Imath.pc file. Default is ``ON``.
 
-* ``IMATH_NAMESPACE`` - Public namespace alias for
-  Imath. Default is ``Imath``.
+``IMATH_NAMESPACE``
+  Public namespace alias for Imath. Default is ``Imath``.
 
-* ``IMATH_INTERNAL_NAMESPACE`` - Real namespace for Imath that
-  will end up in compiled symbols. Default is ``Imath_<major>_<minor>``.
+``IMATH_INTERNAL_NAMESPACE``
+  Real namespace for Imath that will end up in compiled
+  symbols. Default is ``Imath_<major>_<minor>``.
 
-* ``IMATH_NAMESPACE_CUSTOM`` - Whether the namespace has been
-  customized (so external users know). Default is ``NO``.
+``IMATH_NAMESPACE_CUSTOM``
+  Whether the namespace has been customized (so external users
+  know). Default is ``NO``.
 
-* ``IMATH_LIB_SUFFIX`` - String added to the end of all the versioned
-  libraries. Default is ``-<major>_<minor>``
+``IMATH_LIB_SUFFIX``
+  String added to the end of all the versioned libraries. Default is
+  ``-<major>_<minor>``
 
-* ``IMATH_OUTPUT_SUBDIR`` - Destination sub-folder of the include path
-  for install. Default is ``Imath``.
+``IMATH_OUTPUT_SUBDIR``
+  Destination sub-folder of the include path for install. Default is ``Imath``.
+
+To enable half-to-float conversion using the F16C SSE instruction set
+for g++ and clang when installing Imath, add the ``-mf16c`` compiler
+option:
+
+      % cmake <Imath source directory> -DCMAKE_CXX_FLAGS="-mf16c"
+
+See `half-float Conversion Configuration Options`_ for more
+information about the half-float conversion process.
 
 ### Common CMake Settings:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,11 +49,12 @@ tree, hence the ``$build_directory`` noted above, referred to in CMake
 parlance as the *build directory*. You can place this directory
 wherever you like.
 
-See the CMake Configuration Options section below for the most common
-configuration options especially the install directory. Note that with
-no arguments, as above, ``make install`` installs the header files in
-``/usr/local/include``, the object libraries in ``/usr/local/lib``, and the
-executable programs in ``/usr/local/bin``.
+See the [CMake Configuration Options](#CMake-Configuration-Options)
+section below for the most common configuration options especially the
+install directory. Note that with no arguments, as above, ``make
+install`` installs the header files in ``/usr/local/include``, the
+object libraries in ``/usr/local/lib``, and the executable programs in
+``/usr/local/bin``.
 
 ## Python Bindings
 
@@ -261,7 +262,8 @@ option:
 
       % cmake <Imath source directory> -DCMAKE_CXX_FLAGS="-mf16c"
 
-See `half-float Conversion Configuration Options`_ for more
+See the [Imath Technical
+Documentation](https://imath.readthedocs.io/en/latest) for more
 information about the half-float conversion process.
 
 ### Common CMake Settings:

--- a/README.md
+++ b/README.md
@@ -41,19 +41,24 @@ or numerical analysis package.
 ### New Features in 3.1
 
 The 3.1 release of Imath introduces optimized half-to-float and
-float-to-half conversion, using the F16C SSE extension if available,
-or otherwise using an optimized bit-manipulation algorithm that does
-not require lookup tables. Performance of both options is generally
-significantly faster than the lookup-table based conversions that
-Imath has traditionally used, although performance may vary depending
-on the nature of the data. The new optimized conversions generate the
-same values as the tranditional methods.
+float-to-half conversion using the F16C SSE instruction set extension,
+if available. These single-instruction conversions offer a 5-10x
+speedup for float-to-half and 2x speedup for half-to-float over
+Imath/half's traditional table-based conversion (timings depend on the
+data).
 
-For backwards compatibility and ensured stability in the 3.1 release,
-the optimized conversion is off by default, but it can be enabled at
-compile-time by disabling the ``IMATH_USE_HALF_LOOKUP_TABLES`` CMake
-option. See [INSTALL.md](INSTALL.md#imath-configuration-settings) for
-more installation options.
+In the absence of the F16C instruction set, the lookup-table-based
+conversion from half to float is still the default, but Imath 3.1 also
+introduces an optimized bit-shift conversion algorithm as a
+compile-time option that does not require lookup tables, for
+architectures where memory is limited. The float-to-half conversion
+also no longer requires an exponent lookup table, further reducing
+memory requirements.
+
+These new conversions generate the same values as the tranditional
+methods, which ensures backwards compatibility.  See
+[INSTALL.md](INSTALL.md#imath-configuration-settings) for more
+installation and configuation options.
 
 Also, ``half.h`` can now be included in pure C code for a definition
 of the type and for conversions between half and float.

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,10 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenEXR Project.
 
-if (IMATH_USE_HALF_LOOKUP_TABLES)
-  set(IMATH_ENABLE_HALF_LOOKUP_TABLES ON)
-endif()
-
 if (IMATH_ENABLE_LARGE_STACK)
   set(IMATH_HAVE_LARGE_STACK ON)
 endif()

--- a/config/ImathConfig.h.in
+++ b/config/ImathConfig.h.in
@@ -10,12 +10,15 @@
 
 //
 // Options / configuration based on O.S. / compiler
-/////////////////////
+//
 
 //
-// Define if the half implementation should compile / enable the half lookup tables
+// Define whether the half-to-float conversion should use the lookup
+// table method. Note that this is overriden by F16C compiler
+// flags. It is also overrided by the IMATH_HALF_NO_LOOKUP_TABLE
+// macro, if defined.
 //
-#cmakedefine IMATH_ENABLE_HALF_LOOKUP_TABLES
+#cmakedefine IMATH_HALF_USE_LOOKUP_TABLE
 
 //
 // Define if the target system has support for large

--- a/config/ImathSetup.cmake
+++ b/config/ImathSetup.cmake
@@ -9,7 +9,7 @@ if(NOT "${CMAKE_PROJECT_NAME}" STREQUAL "${PROJECT_NAME}")
   message(STATUS "Imath is configuring as a cmake sub project")
 endif()
 
-option(IMATH_USE_HALF_LOOKUP_TABLES "Restores use of lookup tables for systems where that is still faster (on by default)" ON)
+option(IMATH_HALF_USE_LOOKUP_TABLE "Convert half-to-float using a lookup table (on by default)" ON)
 
 option(IMATH_USE_DEFAULT_VISIBILITY "Makes the compile use default visibility (by default compiles tidy, hidden-by-default)"     OFF)
 

--- a/docs/classes/half.rst
+++ b/docs/classes/half.rst
@@ -1,5 +1,5 @@
-The ``half`` Class
-##################
+The half Class
+##############
 
 .. code-block::
 

--- a/docs/half_conversion.rst
+++ b/docs/half_conversion.rst
@@ -1,3 +1,5 @@
+.. _half-float-conversion-configuration-options:
+
 half-float Conversion Configuration Options
 ###########################################
 
@@ -14,27 +16,30 @@ half and 32-bit float:
 3. Bit-shift conversion algorithm.
 
 To use the F16C SSE instruction set on an architecture that supports
-it, simply provide the appropriate compiler flags. For g++ and clang,
+it, simply provide the appropriate compiler flags when building an
+application that includes ``half.h``. For g++ and clang,
 for example:
+::
 
     % cmake -DCMAKE_CXX_FLAGS="-m16fc" <source directory> 
-
+    
 When code including ``half.h`` is compiled with F16C enabled, it will
 automatically perform conversions using the instruction set. F16C
-compiler flags take precedence over other lookup-table-related CMake
-settings.
+compiler flags take precedence over other lookup-table-related Imath
+CMake settings.
 
 On architectures that do not support F16C, you may choose at
 compile-time between the bit-shift conversion and lookup table
 conversion via the ``IMATH_HALF_USE_LOOKUP_TABLE`` CMake option:
+::
 
-    % cmake -DIMATH_HALF_USE_LOOKUP_TABLE=OFF
+    % cmake -DIMATH_HALF_USE_LOOKUP_TABLE=OFF <source directory>
 
-Note that when building the Imath library itself, the 65,536-entry
-lookup table symbol will be compiled into the library regardless of
-the ``IMATH_HALF_USE_LOOKUP_TABLE`` setting. This subsequently allows
-programs using Imath to choose at compile time which conversion method
-to use.
+Note that when building and installing the Imath library itself, the
+65,536-entry lookup table symbol will be compiled into the library
+even if the ``IMATH_HALF_USE_LOOKUP_TABLE`` setting is false. This
+allows applications using that installed Imath library downstream to
+choose at compile time which conversion method to use.
 
 Applications with memory limitations that cannot accomodate the
 conversion lookup table can eliminate it from the library by building
@@ -42,6 +47,7 @@ Imath with the C preprocessor define ``IMATH_HALF_NO_LOOKUP_TABLE``
 defined. Note that this is a compile-time option, not a CMake setting
 (making it possible for application code to choose the desired
 behavior). Simply add:
+::
 
     #define IMATH_HALF_NO_LOOKUP_TABLE
 
@@ -52,7 +58,8 @@ Furthermore, an implementation wishing to receive ``FE_OVERFLOW`` and
 ``FE_UNDERFLOW`` floating point exceptions when converting float to
 half by the bit-shift algorithm can define the preprocessor symbol
 ``IMATH_HALF_ENABLE_FP_EXCEPTIONS`` prior to including ``half.h``:
-
+::
+   
     #define IMATH_HALF_ENABLE_FP_EXCEPTIONS
 
 By default, no exceptions are raised on overflow and underflow.

--- a/docs/half_conversion.rst
+++ b/docs/half_conversion.rst
@@ -4,45 +4,58 @@ half-float Conversion Configuration Options
 The Imath library supports three options for conversion between 16-bit
 half and 32-bit float:
 
-1. F16C SSE instructions - single-instruction conversion for machine
-   architectures that support it. When available, this is the fastest
-   option by far.
-
-2. Bit-shift conversion algorithm.
-
-3. Conversion from half to float via a 16-bit lookup table. Prior to
+1. Conversion from half to float via a 16-bit lookup table. Prior to
    Imath v3.1, this was the only method supported.
 
-To use the F16C instruction set on an architecture that supports it,
-simply provide the appropriate compiler flags. For g++ and clang, for example:
+2. F16C SSE instructions: single-instruction conversion for machine
+   architectures that support it. When available, this is the fastest
+   option, by far.
 
-    % cmake -dCMAKE_CXX_FLAGS="-m16fc"
+3. Bit-shift conversion algorithm.
+
+To use the F16C SSE instruction set on an architecture that supports
+it, simply provide the appropriate compiler flags. For g++ and clang,
+for example:
+
+    % cmake -DCMAKE_CXX_FLAGS="-m16fc" <source directory> 
 
 When code including ``half.h`` is compiled with F16C enabled, it will
-automatically perform conversions using the instruction set, no
-additional settings required.
+automatically perform conversions using the instruction set. F16C
+compiler flags take precedence over other lookup-table-related CMake
+settings.
 
 On architectures that do not support F16C, you may choose at
 compile-time between the bit-shift conversion and lookup table
-conversion via the ``IMATH_ENABLE_HALF_LOOKUP_TABLES`` CMake option:
+conversion via the ``IMATH_HALF_USE_LOOKUP_TABLE`` CMake option:
 
-    % cmake -d IMATH_ENABLE_HALF_LOOKUP_TABLES=OFF
+    % cmake -DIMATH_HALF_USE_LOOKUP_TABLE=OFF
 
-Note that when building the Imath library itself, the lookup table
-will be compiled into the library regardless of the
-``IMATH_ENABLE_HALF_LOOKUP_TABLES`` setting. This subsequently allows
-programs using Imath to choose at compile time which conversion to
-use.
+Note that when building the Imath library itself, the 65,536-entry
+lookup table symbol will be compiled into the library regardless of
+the ``IMATH_HALF_USE_LOOKUP_TABLE`` setting. This subsequently allows
+programs using Imath to choose at compile time which conversion method
+to use.
 
 Applications with memory limitations that cannot accomodate the
-conversion lookup tables can eliminate them from the library by
-building Imath and with the C macro ``IMATH_HALF_TABLES_AT_ALL``
-defined. Note that this is a compile-time option, not a CMake setting.
+conversion lookup table can eliminate it from the library by building
+Imath with the C preprocessor define ``IMATH_HALF_NO_LOOKUP_TABLE``
+defined. Note that this is a compile-time option, not a CMake setting
+(making it possible for application code to choose the desired
+behavior). Simply add:
 
-Furthermore, an implementation wishing to receive floating point
-exceptions on underflow / overflow when converting float to half can
-include ``half.h`` with ``IMATH_HALF_EXCEPTIONS_ENABLED``
-defined. This setting is off by default.
+    #define IMATH_HALF_NO_LOOKUP_TABLE
+
+before including ``half.h``, or define the symbol on the compile
+command line.
+
+Furthermore, an implementation wishing to receive ``FE_OVERFLOW`` and
+``FE_UNDERFLOW`` floating point exceptions when converting float to
+half by the bit-shift algorithm can define the preprocessor symbol
+``IMATH_HALF_ENABLE_FP_EXCEPTIONS`` prior to including ``half.h``:
+
+    #define IMATH_HALF_ENABLE_FP_EXCEPTIONS
+
+By default, no exceptions are raised on overflow and underflow.
 
 
 

--- a/docs/half_limits.rst
+++ b/docs/half_limits.rst
@@ -1,5 +1,5 @@
-``half`` Limits
-###############
+half Limits
+###########
 
 .. doxygenfile:: half.h
    :sections: define

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,13 +1,18 @@
 .. Imath documentation master file, created by
    sphinx-quickstart on Wed Apr 24 15:19:01 2019.
 
-Imath Documentation
-===================
+Imath Technical Documentation
+=============================
 
 Imath is a basic, light-weight, and efficient C++ representation of 2D
 and 3D vectors and matrices and other simple but useful mathematical
 objects, functions, and data types common in computer graphics
 applications, including the ``half`` 16-bit floating-point type.
+
+- Download: https://github.com/AcademySoftwareFoundation/Imath
+- Install Help: `INSTALL.md <https://github.com/AcademySoftwareFoundation/Imath/blob/master/INSTALL>`_
+- Porting Help: `Imath/OpenEXR Version 2->3 Porting Guide <https://github.com/AcademySoftwareFoundation/Imath/blob/master/docs/PortingGuide2-3.md>`_
+- License: `BSD License <https://github.com/AcademySoftwareFoundation/Imath/blob/master/LICENSE.md>`_
 
 Introduction
 ############
@@ -17,6 +22,8 @@ Introduction
 
    intro
    
+   install
+
 The half Type
 #############
 
@@ -24,8 +31,8 @@ The half Type
    :maxdepth: 3
 
    classes/half
-   functions/half_c
    half_limits
+   functions/half_c
    half_conversion
    float
               

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -8,7 +8,7 @@ When installing Imath from source, take note of the following CMake options:
 
 ``IMATH_HALF_USE_LOOKUP_TABLE``
   Use the half-to-float conversion lookup table. Default is ``ON`` for
-  backwards compatibility. With the value of ``OFF``, use a bit-shif
+  backwards compatibility. With the value of ``OFF``, use a bit-shift
   conversion algorithm. Note that this setting is overriden when
   compiler flags enable the F16C SSE instruction set.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,0 +1,69 @@
+Install Options
+###############
+
+When installing Imath from source, take note of the following CMake options:
+
+``IMATH_CXX_STANDARD``
+  C++ standard to compile against. Default is ``14``.
+
+``IMATH_HALF_USE_LOOKUP_TABLE``
+  Use the half-to-float conversion lookup table. Default is ``ON`` for
+  backwards compatibility. With the value of ``OFF``, use a bit-shif
+  conversion algorithm. Note that this setting is overriden when
+  compiler flags enable the F16C SSE instruction set.
+
+``IMATH_USE_DEFAULT_VISIBILITY``
+  Use default visibility, which makes all symbols visible in compiled
+  objects.  Default is ``OFF``, in which case only designated
+  necessary symbols are marked for export.
+
+``IMATH_USE_NOEXCEPT``
+  Use the ``noexcept`` specifier of appropriate methods. Default is
+  ``ON``.  With the value of ``OFF``, the ``noexcept`` specifier is
+  omitted, for situations in which it is not desireable.
+
+``IMATH_ENABLE_LARGE_STACK``
+  Enables the ``halfFunction`` object to place the lookup tables on
+  the stack rather than allocating heap memory. Default is ``OFF``.
+
+``IMATH_VERSION_RELEASE_TYPE``
+  A string to append to the version
+  number in the internal package name macro
+  IMATH_PACKAGE_STRING. Default is the empty string, but can be set
+  to, for example, "-dev" during development (e.g. "3.1.0-dev").
+
+``IMATH_INSTALL_SYM_LINK``
+  Install an unversioned symbolic link (i.e. libImath.so) to the
+  versioned library.
+
+``IMATH_INSTALL_PKG_CONFIG``
+  Install Imath.pc file. Default is ``ON``.
+
+``IMATH_NAMESPACE``
+  Public namespace alias for Imath. Default is ``Imath``.
+
+``IMATH_INTERNAL_NAMESPACE``
+  Real namespace for Imath that will end up in compiled
+  symbols. Default is ``Imath_<major>_<minor>``.
+
+``IMATH_NAMESPACE_CUSTOM``
+  Whether the namespace has been customized (so external users
+  know). Default is ``NO``.
+
+``IMATH_LIB_SUFFIX``
+  String added to the end of all the versioned libraries. Default is
+  ``-<major>_<minor>``
+
+``IMATH_OUTPUT_SUBDIR``
+  Destination sub-folder of the include path for install. Default is ``Imath``.
+
+To enable half-to-float conversion using the F16C SSE instruction set
+for g++ and clang when installing Imath, add the ``-mf16c`` compiler
+option:
+::
+   
+    % cmake <Imath source directory> -DCMAKE_CXX_FLAGS="-mf16c"
+
+See :ref:`half-float Conversion Configuration Options <half-float-conversion-configuration-options>` for more
+information about the half-float conversion process.
+

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -1,5 +1,5 @@
 Overview
---------
+########
 
 Imath is a basic, light-weight, and efficient C++ representation of 2D
 and 3D vectors and matrices and other simple but useful mathematical
@@ -21,93 +21,6 @@ and matrices of arbitrary dimension. Its greatest utility is as a
 geometric data representation, primarily for 2D images and 3D scenes
 and coordinate transformations, along with an accompanying set of
 utility methods and functions.
-
-Quick Links
------------
-
-- Download: https://github.com/AcademySoftwareFoundation/Imath
-- Install Help: `INSTALL.md <https://github.com/AcademySoftwareFoundation/Imath/blob/master/INSTALL.md>`_
-- Porting Help: `Imath/OpenEXR Version 2->3 Porting Guide <https://github.com/AcademySoftwareFoundation/Imath/blob/master/docs/PortingGuide2-3.md>`_
-- License: `BSD License <https://github.com/AcademySoftwareFoundation/Imath/blob/master/LICENSE.md>`_
-
-Install Options
----------------
-
-When installing Imath from source, take note of the following CMake options:
-
-``IMATH_CXX_STANDARD``
-  C++ standard to compile against. Default is ``14``.
-
-``IMATH_HALF_USE_LOOKUP_TABLE``
-  Use the half-to-float conversion lookup table. Default is ``ON`` for
-  backwards compatibility. With the value of ``OFF``, use a bit-shif
-  conversion algorithm. Note that this setting is overriden when
-  compiler flags enable the F16C SSE instruction set.
-
-``IMATH_USE_DEFAULT_VISIBILITY``
-  Use default visibility, which makes all symbols visible in compiled
-  objects.  Default is ``OFF``, in which case only designated
-  necessary symbols are marked for export.
-
-``IMATH_USE_NOEXCEPT``
-  Use the ``noexcept`` specifier of appropriate methods. Default is
-  ``ON``.  With the value of ``OFF``, the ``noexcept`` specifier is
-  omitted, for situations in which it is not desireable.
-
-``IMATH_ENABLE_LARGE_STACK``
-  Enables the ``halfFunction`` object to place the lookup tables on
-  the stack rather than allocating heap memory. Default is ``OFF``.
-
-``IMATH_VERSION_RELEASE_TYPE``
-  A string to append to the version
-  number in the internal package name macro
-  IMATH_PACKAGE_STRING. Default is the empty string, but can be set
-  to, for example, "-dev" during development (e.g. "3.1.0-dev").
-
-``IMATH_INSTALL_SYM_LINK``
-  Install an unversioned symbolic link (i.e. libImath.so) to the
-  versioned library.
-
-``IMATH_INSTALL_PKG_CONFIG``
-  Install Imath.pc file. Default is ``ON``.
-
-``IMATH_NAMESPACE``
-  Public namespace alias for Imath. Default is ``Imath``.
-
-``IMATH_INTERNAL_NAMESPACE``
-  Real namespace for Imath that will end up in compiled
-  symbols. Default is ``Imath_<major>_<minor>``.
-
-``IMATH_NAMESPACE_CUSTOM``
-  Whether the namespace has been customized (so external users
-  know). Default is ``NO``.
-
-``IMATH_LIB_SUFFIX``
-  String added to the end of all the versioned libraries. Default is
-  ``-<major>_<minor>``
-
-``IMATH_OUTPUT_SUBDIR``
-  Destination sub-folder of the include path for install. Default is ``Imath``.
-
-To enable half-to-float conversion using the F16C SSE instruction set
-for g++ and clang when installing Imath, add the ``-mf16c`` compiler
-option:
-
-      % cmake <Imath source directory> -DCMAKE_CXX_FLAGS="-mf16c"
-
-See `half-float Conversion Configuration Options`_ for more
-information about the half-float conversion process.
-
-History
--------
-
-Imath originated at Industrial Light & Magic in the late 1990's and
-early 2000's, and it was originally distributed publicly as a
-component of
-`OpenEXR <https:://github.com/AcademySoftwareFoundation/openexr>`_.
-
-Imath is Version 3 because it was previously distributed as a
-component of OpenEXR v1 and v2.
 
 Example
 -------
@@ -245,3 +158,19 @@ as pre-multiplication:
   tx & ty & tz & 1 \\
   \end{bmatrix}
 
+
+About
+-----
+
+Imath originated at Industrial Light & Magic in the late 1990's and
+early 2000's, and it was originally distributed publicly as a
+component of `OpenEXR
+<https:://github.com/AcademySoftwareFoundation/openexr>`_.  Imath is
+now a project of the `Academy Software Foundation
+<https://www.aswf.io>`_ and is still maintained by the OpenEXR
+project.
+
+Imath is Version 3 because it was previously distributed as a
+component of OpenEXR v1 and v2.
+
+  

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -33,39 +33,70 @@ Quick Links
 Install Options
 ---------------
 
-``IMATH_USE_HALF_LOOKUP_TABLES``
-  The 3.1 release of Imath introduces optimized half-to-float and
-  float-to-half conversion, using the F16C SSE extension if available,
-  or otherwise using an optimized bit-manipulation algorithm that does
-  not require lookup tables. Performance of both options is generally
-  significantly faster than the lookup-table based conversions that
-  Imath has traditionally used, although performance may vary
-  depending on the nature of your data. The new optimized conversions
-  generate the same values as the tranditional methods.
+When installing Imath from source, take note of the following CMake options:
 
-  For backwards compatibility and ensured stability in the 3.1
-  release, the optimized conversion is off by default, but it can be
-  enabled at compile-time by disabling the
-  ``IMATH_USE_HALF_LOOKUP_TABLES`` CMake option:
+``IMATH_CXX_STANDARD``
+  C++ standard to compile against. Default is ``14``.
 
-      % cmake <source directory> -DIMATH_USE_HALF_LOOKUP_TABLES=OFF
+``IMATH_HALF_USE_LOOKUP_TABLE``
+  Use the half-to-float conversion lookup table. Default is ``ON`` for
+  backwards compatibility. With the value of ``OFF``, use a bit-shif
+  conversion algorithm. Note that this setting is overriden when
+  compiler flags enable the F16C SSE instruction set.
 
-``IMATH_HALF_NO_TABLES_AT_ALL``
-  Furthermore, the ``IMATH_HALF_NO_TABLES_AT_ALL`` CMake option forces
-  elimination of all half-conversion lookup tables. This forces either
-  the SSE extension instructions or the bit-manipulation conversion.
-
-``IMATH_HALF_EXCEPTIONS_ENABLED``
-  An implementation wishing to receive floating point exceptions on
-  underflow / overflow when converting float to half can include
-  ``half.h`` with ``IMATH_HALF_EXCEPTIONS_ENABLED`` defined.
+``IMATH_USE_DEFAULT_VISIBILITY``
+  Use default visibility, which makes all symbols visible in compiled
+  objects.  Default is ``OFF``, in which case only designated
+  necessary symbols are marked for export.
 
 ``IMATH_USE_NOEXCEPT``
-  Also, the ``IMATH_USE_NOEXCEPT`` CMake option disables the use of
-  the ``noexcept`` specifier. Earlier versions of the OpenEXR library
-  provided the ability to catch floating point errors through signal
-  handlers and throw corresponding C++ exceptions.  Code using this
-  mechanism is incompatible with the ``noexcept`` specifier.
+  Use the ``noexcept`` specifier of appropriate methods. Default is
+  ``ON``.  With the value of ``OFF``, the ``noexcept`` specifier is
+  omitted, for situations in which it is not desireable.
+
+``IMATH_ENABLE_LARGE_STACK``
+  Enables the ``halfFunction`` object to place the lookup tables on
+  the stack rather than allocating heap memory. Default is ``OFF``.
+
+``IMATH_VERSION_RELEASE_TYPE``
+  A string to append to the version
+  number in the internal package name macro
+  IMATH_PACKAGE_STRING. Default is the empty string, but can be set
+  to, for example, "-dev" during development (e.g. "3.1.0-dev").
+
+``IMATH_INSTALL_SYM_LINK``
+  Install an unversioned symbolic link (i.e. libImath.so) to the
+  versioned library.
+
+``IMATH_INSTALL_PKG_CONFIG``
+  Install Imath.pc file. Default is ``ON``.
+
+``IMATH_NAMESPACE``
+  Public namespace alias for Imath. Default is ``Imath``.
+
+``IMATH_INTERNAL_NAMESPACE``
+  Real namespace for Imath that will end up in compiled
+  symbols. Default is ``Imath_<major>_<minor>``.
+
+``IMATH_NAMESPACE_CUSTOM``
+  Whether the namespace has been customized (so external users
+  know). Default is ``NO``.
+
+``IMATH_LIB_SUFFIX``
+  String added to the end of all the versioned libraries. Default is
+  ``-<major>_<minor>``
+
+``IMATH_OUTPUT_SUBDIR``
+  Destination sub-folder of the include path for install. Default is ``Imath``.
+
+To enable half-to-float conversion using the F16C SSE instruction set
+for g++ and clang when installing Imath, add the ``-mf16c`` compiler
+option:
+
+      % cmake <Imath source directory> -DCMAKE_CXX_FLAGS="-mf16c"
+
+See `half-float Conversion Configuration Options`_ for more
+information about the half-float conversion process.
 
 History
 -------

--- a/src/Imath/half.cpp
+++ b/src/Imath/half.cpp
@@ -33,7 +33,10 @@ using namespace std;
 
 // clang-format off
 
-#ifdef IMATH_ENABLE_HALF_LOOKUP_TABLES
+#if !defined(IMATH_HALF_NO_LOOKUP_TABLE)
+// Omit the table entirely if IMATH_HALF_NO_LOOKUP_TABLE is
+// defined. Half-to-float conversion must be accomplished either by
+// F16C instructions or the bit-shift algorithm.
 const imath_half_uif_t imath_half_to_float_table_data[1 << 16] =
 #include "toFloat.h"
 

--- a/src/ImathTest/CMakeLists.txt
+++ b/src/ImathTest/CMakeLists.txt
@@ -59,7 +59,7 @@ if(NOT "${CMAKE_PROJECT_NAME}" STREQUAL "ImathTest")
   target_link_libraries(ImathHalfCTest Imath::Config)
   target_include_directories(ImathHalfCTest PRIVATE "../Imath")
   #target_compile_options(ImathHalfCTest PRIVATE -mavx2 -mf16c)
-  if (IMATH_USE_HALF_LOOKUP_TABLES)
+  if (IMATH_USE_HALF_LOOKUP_TABLE)
     target_link_libraries(ImathHalfCTest Imath::Imath)
   endif()
 

--- a/src/ImathTest/half_c_main.c
+++ b/src/ImathTest/half_c_main.c
@@ -3,8 +3,11 @@
 // Copyright Contributors to the OpenEXR Project.
 //
 
-#define IMATH_HALF_NO_TABLES_AT_ALL
-//#define IMATH_HALF_EXCEPTIONS_ENABLED
+// For the C version test, omit the lookup table, which validates that
+// ``half.h`` works as a "header-only" implementation not requiring
+// the compiled library. Note that the C-language support for half
+// only includes conversion to and from float.
+#define IMATH_HALF_NO_LOOKUP_TABLE
 
 #include <half.h>
 #include <math.h>

--- a/src/ImathTest/half_perf_test.cpp
+++ b/src/ImathTest/half_perf_test.cpp
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenEXR Project.
 //
-//#define IMATH_HALF_NO_TABLES_AT_ALL
-//#define IMATH_HALF_EXCEPTIONS_ENABLED
-//
+
 #ifdef _MSC_VER
 #    define _CRT_RAND_S
 #endif
@@ -29,7 +27,8 @@ static const unsigned short imath_float_half_exp_table[1 << 9] =
 
 using namespace IMATH_NAMESPACE;
 
-#ifdef IMATH_ENABLE_HALF_LOOKUP_TABLES
+#ifdef IMATH_USE_HALF_LOOKUP_TABLE
+
 static inline float table_half_cast(const half &h)
 {
     return imath_half_to_float_table[h.bits()].f;


### PR DESCRIPTION
* Cmake option: IMATH_HALF_USE_LOOKUP_TABLE
* cpp #define:  IMATH_HALF_NO_LOOKUP_TABLE
* cpp #define:  IMATH_HALF_ENABLE_FP_EXCEPTIONS

I discarded the idea of reducing the two table options into a single setting, so this preserves the existing behavior but updates the names and explanations to hopefully be easier to follow.

Preview the readthedocs here: https://cary-ilm-imath.readthedocs.io/en/latest/
And the repo docs here: https://github.com/cary-ilm/Imath/tree/half-table-options

Signed-off-by: Cary Phillips <cary@ilm.com>