### PR TITLE
Include <x86intrin.h> only if __x86_64__

### DIFF
--- a/src/Imath/half.h
+++ b/src/Imath/half.h
@@ -177,7 +177,7 @@
 /// floats in question.
 ///
 
-#if defined(__has_include)
+#if defined(__has_include) && defined(__x86_64__)
 #    if __has_include(<x86intrin.h>)
 #        include <x86intrin.h>
 #    elif __has_include(<intrin.h>)


### PR DESCRIPTION
Is this the proper fix for #183? 

Signed-off-by: Cary Phillips <cary@ilm.com>