### PR TITLE
Bump version for v3.1.1 release on RB-3.1 branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@ endif()
 
 # Imath version
 
-project(Imath VERSION 3.1.0 LANGUAGES C CXX)
+project(Imath VERSION 3.1.1 LANGUAGES C CXX)
 
-set(IMATH_VERSION_RELEASE_TYPE "-dev" CACHE STRING "Extra version tag string for Imath build, such as -dev, -beta1, etc.")
+set(IMATH_VERSION_RELEASE_TYPE "" CACHE STRING "Extra version tag string for Imath build, such as -dev, -beta1, etc.")
 
 set(IMATH_VERSION ${Imath_VERSION})
 set(IMATH_VERSION_API "${Imath_VERSION_MAJOR}_${Imath_VERSION_MINOR}")
@@ -39,7 +39,7 @@ set(IMATH_VERSION_API "${Imath_VERSION_MAJOR}_${Imath_VERSION_MINOR}")
 #   3. API changed:   CURRENT+1.0.0
 #
 set(IMATH_LIBTOOL_CURRENT 29)
-set(IMATH_LIBTOOL_REVISION 0)
+set(IMATH_LIBTOOL_REVISION 1)
 set(IMATH_LIBTOOL_AGE 0)
 set(IMATH_LIB_VERSION "${IMATH_LIBTOOL_CURRENT}.${IMATH_LIBTOOL_REVISION}.${IMATH_LIBTOOL_AGE}")
 set(IMATH_LIB_SOVERSION ${IMATH_LIBTOOL_CURRENT})


### PR DESCRIPTION
Per https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html:

* Source code has changed (PR #184), but no interface has been added, removed,
  or changed: soversion goes from 29.0.0 to 29.1.0.

* Also, looks like IMATH_VERSION_RELEASE_TYPE was inadvertently left
  at "-dev" for the v3.1.0 release.

Signed-off-by: Cary Phillips <cary@ilm.com>