### PR TITLE
Improve handling of #include <*intrin.h>

### DIFF
--- a/src/Imath/half.h
+++ b/src/Imath/half.h
@@ -177,12 +177,10 @@
 /// floats in question.
 ///
 
-#if defined(__has_include) && defined(__x86_64__)
-#    if __has_include(<x86intrin.h>)
-#        include <x86intrin.h>
-#    elif __has_include(<intrin.h>)
+#ifdef _WIN32
 #        include <intrin.h>
-#    endif
+#elif defined(__x86_64__)
+#        include <x86intrin.h>
 #endif
 
 #include <stdint.h>


### PR DESCRIPTION
* Don't use __has_include, it may report files exist when they don't.
* _WIN32 and __x86_64__ seem to be the most universal controls

Signed-off-by: Cary Phillips <cary@ilm.com>