### PR TITLE
v3.1.2 fix, notes, and version bump (RB-3.1 branch)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Imath Release Notes
 
+* [Version 3.1.2](#version-312-july-31-2021) July 31, 2021
 * [Version 3.1.1](#version-311-july-20-2021) July 20, 2021
 * [Version 3.1.0](#version-310-july-13-2021) July 13, 2021
 * [Version 3.0.5](#version-305-june-29-2021) June 29, 2021
@@ -9,6 +10,13 @@
 * [Version 3.0.1-beta](#version-301-beta-march-28-2021) March 28, 2021
 * [Version 3.0.0-beta](#version-300-beta-march-15-2021) March 15, 2021
 * [Inherited History from OpenEXR](#inherited-history-from-openexr)
+
+## Version 3.1.2 (July 31, 2021)
+
+Patch release that fixes a Windows header issue.
+
+* \[[#190](https://github.com/AcademySoftwareFoundation/Imath/pull/190)\] 
+  Improve handling of ``#include <*intrin.h>``
 
 ## Version 3.1.1 (July 20, 2021)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # Imath version
 
-project(Imath VERSION 3.1.1 LANGUAGES C CXX)
+project(Imath VERSION 3.1.2 LANGUAGES C CXX)
 
 set(IMATH_VERSION_RELEASE_TYPE "" CACHE STRING "Extra version tag string for Imath build, such as -dev, -beta1, etc.")
 

--- a/src/Imath/half.h
+++ b/src/Imath/half.h
@@ -177,12 +177,10 @@
 /// floats in question.
 ///
 
-#if defined(__has_include) && defined(__x86_64__)
-#    if __has_include(<x86intrin.h>)
-#        include <x86intrin.h>
-#    elif __has_include(<intrin.h>)
+#ifdef _WIN32
 #        include <intrin.h>
-#    endif
+#elif defined(__x86_64__)
+#        include <x86intrin.h>
 #endif
 
 #include <stdint.h>


### PR DESCRIPTION
Make the handling of #include <*intrin.h> consistent with OpenEXR.

Because this is such a minor header change, I'm inclined to leave the soversion for 3.1.2 the same as 3.1.1, at 29.1.0, even though the strict interpretation of the rules should bump to 29.2.0.