### PR TITLE
Replace stray Imath:: with IMATH_INTERNAL_NAMESPACE::

### DIFF
--- a/src/Imath/ImathMatrix.h
+++ b/src/Imath/ImathMatrix.h
@@ -2167,7 +2167,7 @@ Matrix33<T>::operator*= (const Matrix33<T>& v) IMATH_NOEXCEPT
 {
     // Avoid initializing with 0 values before immediately overwriting them,
     // and unroll all loops for the best autovectorization.
-    Matrix33 tmp(Imath::UNINITIALIZED);
+    Matrix33 tmp(IMATH_INTERNAL_NAMESPACE::UNINITIALIZED);
 
     tmp.x[0][0] = x[0][0] * v.x[0][0] + x[0][1] * v.x[1][0] + x[0][2] * v.x[2][0];
     tmp.x[0][1] = x[0][0] * v.x[0][1] + x[0][1] * v.x[1][1] + x[0][2] * v.x[2][1];
@@ -2191,7 +2191,7 @@ Matrix33<T>::operator* (const Matrix33<T>& v) const IMATH_NOEXCEPT
 {
     // Avoid initializing with 0 values before immediately overwriting them,
     // and unroll all loops for the best autovectorization.
-    Matrix33 tmp(Imath::UNINITIALIZED);
+    Matrix33 tmp(IMATH_INTERNAL_NAMESPACE::UNINITIALIZED);
 
     tmp.x[0][0] = x[0][0] * v.x[0][0] + x[0][1] * v.x[1][0] + x[0][2] * v.x[2][0];
     tmp.x[0][1] = x[0][0] * v.x[0][1] + x[0][1] * v.x[1][1] + x[0][2] * v.x[2][1];

--- a/src/Imath/ImathTypeTraits.h
+++ b/src/Imath/ImathTypeTraits.h
@@ -29,7 +29,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
 /// An enable_if helper to be used in template parameters which results in
 /// much shorter symbols.
-#define IMATH_ENABLE_IF(...) Imath::enable_if_t<(__VA_ARGS__), int> = 0
+#define IMATH_ENABLE_IF(...) IMATH_INTERNAL_NAMESPACE::enable_if_t<(__VA_ARGS__), int> = 0
 
 
 #if IMATH_FOREIGN_VECTOR_INTEROP


### PR DESCRIPTION
Granted, the handling of namespaces is confusing and likely more flexible than necessary, since both the internal and external namespaces (i.e. "Imath_3_1::" and "Imath::") are configurable, but rather than open that can of worms, this fixes the current usages so it's at least consistent.

Signed-off-by: Cary Phillips <cary@ilm.com>