### PR TITLE
Cuda safety fixes

### DIFF
--- a/src/Imath/ImathBox.h
+++ b/src/Imath/ImathBox.h
@@ -166,39 +166,42 @@ typedef Box<V3f> Box3f;
 /// 3D box of base type `double`.
 typedef Box<V3d> Box3d;
 
-template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box() IMATH_NOEXCEPT
+template <class V>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Box<V>::Box() IMATH_NOEXCEPT
 {
     makeEmpty();
 }
 
-template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box (const V& point) IMATH_NOEXCEPT
+template <class V>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Box<V>::Box (const V& point) IMATH_NOEXCEPT
 {
     min = point;
     max = point;
 }
 
-template <class V> IMATH_CONSTEXPR14 inline Box<V>::Box (const V& minV, const V& maxV) IMATH_NOEXCEPT
+template <class V>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Box<V>::Box (const V& minV, const V& maxV) IMATH_NOEXCEPT
 {
     min = minV;
     max = maxV;
 }
 
 template <class V>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Box<V>::operator== (const Box<V>& src) const IMATH_NOEXCEPT
 {
     return (min == src.min && max == src.max);
 }
 
 template <class V>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Box<V>::operator!= (const Box<V>& src) const IMATH_NOEXCEPT
 {
     return (min != src.min || max != src.max);
 }
 
 template <class V>
-inline void
+IMATH_HOSTDEVICE inline void
 Box<V>::makeEmpty() IMATH_NOEXCEPT
 {
     min = V (V::baseTypeMax());
@@ -206,7 +209,7 @@ Box<V>::makeEmpty() IMATH_NOEXCEPT
 }
 
 template <class V>
-inline void
+IMATH_HOSTDEVICE inline void
 Box<V>::makeInfinite() IMATH_NOEXCEPT
 {
     min = V (V::baseTypeLowest());
@@ -214,7 +217,7 @@ Box<V>::makeInfinite() IMATH_NOEXCEPT
 }
 
 template <class V>
-inline void
+IMATH_HOSTDEVICE inline void
 Box<V>::extendBy (const V& point) IMATH_NOEXCEPT
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
@@ -228,7 +231,7 @@ Box<V>::extendBy (const V& point) IMATH_NOEXCEPT
 }
 
 template <class V>
-inline void
+IMATH_HOSTDEVICE inline void
 Box<V>::extendBy (const Box<V>& box) IMATH_NOEXCEPT
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
@@ -242,7 +245,7 @@ Box<V>::extendBy (const Box<V>& box) IMATH_NOEXCEPT
 }
 
 template <class V>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<V>::intersects (const V& point) const IMATH_NOEXCEPT
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
@@ -255,7 +258,7 @@ Box<V>::intersects (const V& point) const IMATH_NOEXCEPT
 }
 
 template <class V>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<V>::intersects (const Box<V>& box) const IMATH_NOEXCEPT
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
@@ -268,7 +271,7 @@ Box<V>::intersects (const Box<V>& box) const IMATH_NOEXCEPT
 }
 
 template <class V>
-IMATH_CONSTEXPR14 inline V
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline V
 Box<V>::size() const IMATH_NOEXCEPT
 {
     if (isEmpty())
@@ -278,14 +281,14 @@ Box<V>::size() const IMATH_NOEXCEPT
 }
 
 template <class V>
-constexpr inline V
+IMATH_HOSTDEVICE constexpr inline V
 Box<V>::center() const IMATH_NOEXCEPT
 {
     return (max + min) / 2;
 }
 
 template <class V>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<V>::isEmpty() const IMATH_NOEXCEPT
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
@@ -298,7 +301,7 @@ Box<V>::isEmpty() const IMATH_NOEXCEPT
 }
 
 template <class V>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<V>::isInfinite() const IMATH_NOEXCEPT
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
@@ -311,7 +314,7 @@ Box<V>::isInfinite() const IMATH_NOEXCEPT
 }
 
 template <class V>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<V>::hasVolume() const IMATH_NOEXCEPT
 {
     for (unsigned int i = 0; i < min.dimensions(); i++)
@@ -324,7 +327,7 @@ Box<V>::hasVolume() const IMATH_NOEXCEPT
 }
 
 template <class V>
-IMATH_CONSTEXPR14 inline unsigned int
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline unsigned int
 Box<V>::majorAxis() const IMATH_NOEXCEPT
 {
     unsigned int major = 0;
@@ -453,40 +456,40 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Box<Vec2<T>>
 //  Implementation
 //----------------
 
-template <class T> IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box() IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box() IMATH_NOEXCEPT
 {
     makeEmpty();
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box (const Vec2<T>& point) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box (const Vec2<T>& point) IMATH_NOEXCEPT
 {
     min = point;
     max = point;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box (const Vec2<T>& minT, const Vec2<T>& maxT) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Box<Vec2<T>>::Box (const Vec2<T>& minT, const Vec2<T>& maxT) IMATH_NOEXCEPT
 {
     min = minT;
     max = maxT;
 }
 
 template <class T>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Box<Vec2<T>>::operator== (const Box<Vec2<T>>& src) const IMATH_NOEXCEPT
 {
     return (min == src.min && max == src.max);
 }
 
 template <class T>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Box<Vec2<T>>::operator!= (const Box<Vec2<T>>& src) const IMATH_NOEXCEPT
 {
     return (min != src.min || max != src.max);
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Box<Vec2<T>>::makeEmpty() IMATH_NOEXCEPT
 {
     min = Vec2<T> (Vec2<T>::baseTypeMax());
@@ -494,7 +497,7 @@ Box<Vec2<T>>::makeEmpty() IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Box<Vec2<T>>::makeInfinite() IMATH_NOEXCEPT
 {
     min = Vec2<T> (Vec2<T>::baseTypeLowest());
@@ -502,7 +505,7 @@ Box<Vec2<T>>::makeInfinite() IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Box<Vec2<T>>::extendBy (const Vec2<T>& point) IMATH_NOEXCEPT
 {
     if (point[0] < min[0])
@@ -519,7 +522,7 @@ Box<Vec2<T>>::extendBy (const Vec2<T>& point) IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Box<Vec2<T>>::extendBy (const Box<Vec2<T>>& box) IMATH_NOEXCEPT
 {
     if (box.min[0] < min[0])
@@ -536,7 +539,7 @@ Box<Vec2<T>>::extendBy (const Box<Vec2<T>>& box) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T>>::intersects (const Vec2<T>& point) const IMATH_NOEXCEPT
 {
     if (point[0] < min[0] || point[0] > max[0] || point[1] < min[1] || point[1] > max[1])
@@ -546,7 +549,7 @@ Box<Vec2<T>>::intersects (const Vec2<T>& point) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T>>::intersects (const Box<Vec2<T>>& box) const IMATH_NOEXCEPT
 {
     if (box.max[0] < min[0] || box.min[0] > max[0] || box.max[1] < min[1] || box.min[1] > max[1])
@@ -556,7 +559,7 @@ Box<Vec2<T>>::intersects (const Box<Vec2<T>>& box) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Vec2<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Vec2<T>
 Box<Vec2<T>>::size() const IMATH_NOEXCEPT
 {
     if (isEmpty())
@@ -566,14 +569,14 @@ Box<Vec2<T>>::size() const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec2<T>
+IMATH_HOSTDEVICE constexpr inline Vec2<T>
 Box<Vec2<T>>::center() const IMATH_NOEXCEPT
 {
     return (max + min) / 2;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T>>::isEmpty() const IMATH_NOEXCEPT
 {
     if (max[0] < min[0] || max[1] < min[1])
@@ -583,7 +586,7 @@ Box<Vec2<T>>::isEmpty() const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T>>::isInfinite() const IMATH_NOEXCEPT
 {
     if (min[0] != std::numeric_limits<T>::lowest() ||
@@ -596,7 +599,7 @@ Box<Vec2<T>>::isInfinite() const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T>>::hasVolume() const IMATH_NOEXCEPT
 {
     if (max[0] <= min[0] || max[1] <= min[1])
@@ -606,7 +609,7 @@ Box<Vec2<T>>::hasVolume() const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline unsigned int
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline unsigned int
 Box<Vec2<T>>::majorAxis() const IMATH_NOEXCEPT
 {
     unsigned int major = 0;
@@ -707,40 +710,40 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Box<Vec3<T>>
 //  Implementation
 //----------------
 
-template <class T> IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box() IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box() IMATH_NOEXCEPT
 {
     makeEmpty();
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box (const Vec3<T>& point) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box (const Vec3<T>& point) IMATH_NOEXCEPT
 {
     min = point;
     max = point;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box (const Vec3<T>& minT, const Vec3<T>& maxT) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Box<Vec3<T>>::Box (const Vec3<T>& minT, const Vec3<T>& maxT) IMATH_NOEXCEPT
 {
     min = minT;
     max = maxT;
 }
 
 template <class T>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Box<Vec3<T>>::operator== (const Box<Vec3<T>>& src) const IMATH_NOEXCEPT
 {
     return (min == src.min && max == src.max);
 }
 
 template <class T>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Box<Vec3<T>>::operator!= (const Box<Vec3<T>>& src) const IMATH_NOEXCEPT
 {
     return (min != src.min || max != src.max);
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Box<Vec3<T>>::makeEmpty() IMATH_NOEXCEPT
 {
     min = Vec3<T> (Vec3<T>::baseTypeMax());
@@ -748,7 +751,7 @@ Box<Vec3<T>>::makeEmpty() IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Box<Vec3<T>>::makeInfinite() IMATH_NOEXCEPT
 {
     min = Vec3<T> (Vec3<T>::baseTypeLowest());
@@ -756,7 +759,7 @@ Box<Vec3<T>>::makeInfinite() IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Box<Vec3<T>>::extendBy (const Vec3<T>& point) IMATH_NOEXCEPT
 {
     if (point[0] < min[0])
@@ -779,7 +782,7 @@ Box<Vec3<T>>::extendBy (const Vec3<T>& point) IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Box<Vec3<T>>::extendBy (const Box<Vec3<T>>& box) IMATH_NOEXCEPT
 {
     if (box.min[0] < min[0])
@@ -802,7 +805,7 @@ Box<Vec3<T>>::extendBy (const Box<Vec3<T>>& box) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T>>::intersects (const Vec3<T>& point) const IMATH_NOEXCEPT
 {
     if (point[0] < min[0] || point[0] > max[0] || point[1] < min[1] || point[1] > max[1] ||
@@ -813,7 +816,7 @@ Box<Vec3<T>>::intersects (const Vec3<T>& point) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T>>::intersects (const Box<Vec3<T>>& box) const IMATH_NOEXCEPT
 {
     if (box.max[0] < min[0] || box.min[0] > max[0] || box.max[1] < min[1] || box.min[1] > max[1] ||
@@ -824,7 +827,7 @@ Box<Vec3<T>>::intersects (const Box<Vec3<T>>& box) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Vec3<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Vec3<T>
 Box<Vec3<T>>::size() const IMATH_NOEXCEPT
 {
     if (isEmpty())
@@ -834,14 +837,14 @@ Box<Vec3<T>>::size() const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Box<Vec3<T>>::center() const IMATH_NOEXCEPT
 {
     return (max + min) / 2;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T>>::isEmpty() const IMATH_NOEXCEPT
 {
     if (max[0] < min[0] || max[1] < min[1] || max[2] < min[2])
@@ -851,7 +854,7 @@ Box<Vec3<T>>::isEmpty() const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T>>::isInfinite() const IMATH_NOEXCEPT
 {
     if (min[0] != std::numeric_limits<T>::lowest() ||
@@ -866,7 +869,7 @@ Box<Vec3<T>>::isInfinite() const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T>>::hasVolume() const IMATH_NOEXCEPT
 {
     if (max[0] <= min[0] || max[1] <= min[1] || max[2] <= min[2])
@@ -876,7 +879,7 @@ Box<Vec3<T>>::hasVolume() const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline unsigned int
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline unsigned int
 Box<Vec3<T>>::majorAxis() const IMATH_NOEXCEPT
 {
     unsigned int major = 0;

--- a/src/Imath/ImathColor.h
+++ b/src/Imath/ImathColor.h
@@ -50,7 +50,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Color3 : public Vec3<T>
     template <class S> IMATH_HOSTDEVICE constexpr Color3 (const Vec3<S>& v) IMATH_NOEXCEPT; 
 
     /// Destructor
-    ~Color3() = default;
+    IMATH_HOSTDEVICE ~Color3() = default;
 
     /// Component-wise assignment
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3& operator= (const Color3& c) IMATH_NOEXCEPT; 
@@ -143,7 +143,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Color4
     template <class S> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Color4 (const Color4<S>& v) IMATH_NOEXCEPT; 
 
     /// Destructor
-    ~Color4() = default;
+    IMATH_HOSTDEVICE ~Color4() = default;
 
     /// Assignment
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4& operator= (const Color4& v) IMATH_NOEXCEPT; 
@@ -261,7 +261,8 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Color4
 template <class T> std::ostream& operator<< (std::ostream& s, const Color4<T>& v);
 
 /// Reverse multiplication: S * Color4
-template <class S, class T> constexpr Color4<T> operator* (S a, const Color4<T>& v) IMATH_NOEXCEPT;
+template <class S, class T>
+IMATH_HOSTDEVICE constexpr Color4<T> operator* (S a, const Color4<T>& v) IMATH_NOEXCEPT;
 
 /// 3 float channels
 typedef Color3<float> Color3f;
@@ -306,35 +307,35 @@ typedef unsigned int PackedColor;
 // Implementation of Color3
 //
 
-template <class T> inline Color3<T>::Color3() IMATH_NOEXCEPT : Vec3<T>()
+template <class T> IMATH_HOSTDEVICE inline Color3<T>::Color3() IMATH_NOEXCEPT : Vec3<T>()
 {
     // empty
 }
 
-template <class T> constexpr inline Color3<T>::Color3 (T a) IMATH_NOEXCEPT : Vec3<T> (a)
+template <class T> IMATH_HOSTDEVICE constexpr inline Color3<T>::Color3 (T a) IMATH_NOEXCEPT : Vec3<T> (a)
 {
     // empty
 }
 
-template <class T> constexpr inline Color3<T>::Color3 (T a, T b, T c) IMATH_NOEXCEPT : Vec3<T> (a, b, c)
+template <class T> IMATH_HOSTDEVICE constexpr inline Color3<T>::Color3 (T a, T b, T c) IMATH_NOEXCEPT : Vec3<T> (a, b, c)
 {
     // empty
 }
 
-template <class T> constexpr inline Color3<T>::Color3 (const Color3& c) IMATH_NOEXCEPT : Vec3<T> (c)
+template <class T> IMATH_HOSTDEVICE constexpr inline Color3<T>::Color3 (const Color3& c) IMATH_NOEXCEPT : Vec3<T> (c)
 {
     // empty
 }
 
 template <class T>
 template <class S>
-constexpr inline Color3<T>::Color3 (const Vec3<S>& v) IMATH_NOEXCEPT : Vec3<T> (v)
+IMATH_HOSTDEVICE constexpr inline Color3<T>::Color3 (const Vec3<S>& v) IMATH_NOEXCEPT : Vec3<T> (v)
 {
     //empty
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color3<T>&
 Color3<T>::operator= (const Color3& c) IMATH_NOEXCEPT
 {
     *((Vec3<T>*) this) = c;
@@ -342,7 +343,7 @@ Color3<T>::operator= (const Color3& c) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color3<T>&
 Color3<T>::operator+= (const Color3& c) IMATH_NOEXCEPT
 {
     *((Vec3<T>*) this) += c;
@@ -350,14 +351,14 @@ Color3<T>::operator+= (const Color3& c) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Color3<T>
+IMATH_HOSTDEVICE constexpr inline Color3<T>
 Color3<T>::operator+ (const Color3& c) const IMATH_NOEXCEPT
 {
     return Color3 (*(Vec3<T>*) this + (const Vec3<T>&) c);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color3<T>&
 Color3<T>::operator-= (const Color3& c) IMATH_NOEXCEPT
 {
     *((Vec3<T>*) this) -= c;
@@ -365,21 +366,21 @@ Color3<T>::operator-= (const Color3& c) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Color3<T>
+IMATH_HOSTDEVICE constexpr inline Color3<T>
 Color3<T>::operator- (const Color3& c) const IMATH_NOEXCEPT
 {
     return Color3 (*(Vec3<T>*) this - (const Vec3<T>&) c);
 }
 
 template <class T>
-constexpr inline Color3<T>
+IMATH_HOSTDEVICE constexpr inline Color3<T>
 Color3<T>::operator-() const IMATH_NOEXCEPT
 {
     return Color3 (-(*(Vec3<T>*) this));
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color3<T>&
 Color3<T>::negate() IMATH_NOEXCEPT
 {
     ((Vec3<T>*) this)->negate();
@@ -387,7 +388,7 @@ Color3<T>::negate() IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color3<T>&
 Color3<T>::operator*= (const Color3& c) IMATH_NOEXCEPT
 {
     *((Vec3<T>*) this) *= c;
@@ -395,7 +396,7 @@ Color3<T>::operator*= (const Color3& c) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color3<T>&
 Color3<T>::operator*= (T a) IMATH_NOEXCEPT
 {
     *((Vec3<T>*) this) *= a;
@@ -403,21 +404,21 @@ Color3<T>::operator*= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Color3<T>
+IMATH_HOSTDEVICE constexpr inline Color3<T>
 Color3<T>::operator* (const Color3& c) const IMATH_NOEXCEPT
 {
     return Color3 (*(Vec3<T>*) this * (const Vec3<T>&) c);
 }
 
 template <class T>
-constexpr inline Color3<T>
+IMATH_HOSTDEVICE constexpr inline Color3<T>
 Color3<T>::operator* (T a) const IMATH_NOEXCEPT
 {
     return Color3 (*(Vec3<T>*) this * a);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color3<T>&
 Color3<T>::operator/= (const Color3& c) IMATH_NOEXCEPT
 {
     *((Vec3<T>*) this) /= c;
@@ -425,7 +426,7 @@ Color3<T>::operator/= (const Color3& c) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color3<T>&
 Color3<T>::operator/= (T a) IMATH_NOEXCEPT
 {
     *((Vec3<T>*) this) /= a;
@@ -433,14 +434,14 @@ Color3<T>::operator/= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Color3<T>
+IMATH_HOSTDEVICE constexpr inline Color3<T>
 Color3<T>::operator/ (const Color3& c) const IMATH_NOEXCEPT
 {
     return Color3 (*(Vec3<T>*) this / (const Vec3<T>&) c);
 }
 
 template <class T>
-constexpr inline Color3<T>
+IMATH_HOSTDEVICE constexpr inline Color3<T>
 Color3<T>::operator/ (T a) const IMATH_NOEXCEPT
 {
     return Color3 (*(Vec3<T>*) this / a);
@@ -451,30 +452,33 @@ Color3<T>::operator/ (T a) const IMATH_NOEXCEPT
 //
 
 template <class T>
-inline T&
+IMATH_HOSTDEVICE inline T&
 Color4<T>::operator[] (int i) IMATH_NOEXCEPT
 {
     return (&r)[i];
 }
 
 template <class T>
-inline const T&
+IMATH_HOSTDEVICE inline const T&
 Color4<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
     return (&r)[i];
 }
 
-template <class T> inline Color4<T>::Color4() IMATH_NOEXCEPT
+template <class T>
+IMATH_HOSTDEVICE inline Color4<T>::Color4() IMATH_NOEXCEPT
 {
     // empty
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x) IMATH_NOEXCEPT
+template <class T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x) IMATH_NOEXCEPT
 {
     r = g = b = a = x;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x, T y, T z, T w) IMATH_NOEXCEPT
+template <class T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x, T y, T z, T w) IMATH_NOEXCEPT
 {
     r = x;
     g = y;
@@ -482,7 +486,8 @@ template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (T x, T y, T z, T 
     a = w;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4& v) IMATH_NOEXCEPT
+template <class T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4& v) IMATH_NOEXCEPT
 {
     r = v.r;
     g = v.g;
@@ -492,7 +497,7 @@ template <class T> IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4& v) 
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4<S>& v) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4<S>& v) IMATH_NOEXCEPT
 {
     r = T (v.r);
     g = T (v.g);
@@ -501,7 +506,7 @@ IMATH_CONSTEXPR14 inline Color4<T>::Color4 (const Color4<S>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color4<T>&
 Color4<T>::operator= (const Color4& v) IMATH_NOEXCEPT
 {
     r = v.r;
@@ -513,7 +518,7 @@ Color4<T>::operator= (const Color4& v) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Color4<T>::setValue (S x, S y, S z, S w) IMATH_NOEXCEPT
 {
     r = T (x);
@@ -524,7 +529,7 @@ Color4<T>::setValue (S x, S y, S z, S w) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Color4<T>::setValue (const Color4<S>& v) IMATH_NOEXCEPT
 {
     r = T (v.r);
@@ -535,7 +540,7 @@ Color4<T>::setValue (const Color4<S>& v) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Color4<T>::getValue (S& x, S& y, S& z, S& w) const IMATH_NOEXCEPT
 {
     x = S (r);
@@ -546,7 +551,7 @@ Color4<T>::getValue (S& x, S& y, S& z, S& w) const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Color4<T>::getValue (Color4<S>& v) const IMATH_NOEXCEPT
 {
     v.r = S (r);
@@ -556,14 +561,14 @@ Color4<T>::getValue (Color4<S>& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-inline T*
+IMATH_HOSTDEVICE inline T*
 Color4<T>::getValue() IMATH_NOEXCEPT
 {
     return (T*) &r;
 }
 
 template <class T>
-inline const T*
+IMATH_HOSTDEVICE inline const T*
 Color4<T>::getValue() const IMATH_NOEXCEPT
 {
     return (const T*) &r;
@@ -571,7 +576,7 @@ Color4<T>::getValue() const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Color4<T>::operator== (const Color4<S>& v) const IMATH_NOEXCEPT
 {
     return r == v.r && g == v.g && b == v.b && a == v.a;
@@ -579,14 +584,14 @@ Color4<T>::operator== (const Color4<S>& v) const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Color4<T>::operator!= (const Color4<S>& v) const IMATH_NOEXCEPT
 {
     return r != v.r || g != v.g || b != v.b || a != v.a;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color4<T>&
 Color4<T>::operator+= (const Color4& v) IMATH_NOEXCEPT
 {
     r += v.r;
@@ -597,14 +602,14 @@ Color4<T>::operator+= (const Color4& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Color4<T>
+IMATH_HOSTDEVICE constexpr inline Color4<T>
 Color4<T>::operator+ (const Color4& v) const IMATH_NOEXCEPT
 {
     return Color4 (r + v.r, g + v.g, b + v.b, a + v.a);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color4<T>&
 Color4<T>::operator-= (const Color4& v) IMATH_NOEXCEPT
 {
     r -= v.r;
@@ -615,21 +620,21 @@ Color4<T>::operator-= (const Color4& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Color4<T>
+IMATH_HOSTDEVICE constexpr inline Color4<T>
 Color4<T>::operator- (const Color4& v) const IMATH_NOEXCEPT
 {
     return Color4 (r - v.r, g - v.g, b - v.b, a - v.a);
 }
 
 template <class T>
-constexpr inline Color4<T>
+IMATH_HOSTDEVICE constexpr inline Color4<T>
 Color4<T>::operator-() const IMATH_NOEXCEPT
 {
     return Color4 (-r, -g, -b, -a);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color4<T>&
 Color4<T>::negate() IMATH_NOEXCEPT
 {
     r = -r;
@@ -640,7 +645,7 @@ Color4<T>::negate() IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color4<T>&
 Color4<T>::operator*= (const Color4& v) IMATH_NOEXCEPT
 {
     r *= v.r;
@@ -651,7 +656,7 @@ Color4<T>::operator*= (const Color4& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color4<T>&
 Color4<T>::operator*= (T x) IMATH_NOEXCEPT
 {
     r *= x;
@@ -662,21 +667,21 @@ Color4<T>::operator*= (T x) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Color4<T>
+IMATH_HOSTDEVICE constexpr inline Color4<T>
 Color4<T>::operator* (const Color4& v) const IMATH_NOEXCEPT
 {
     return Color4 (r * v.r, g * v.g, b * v.b, a * v.a);
 }
 
 template <class T>
-constexpr inline Color4<T>
+IMATH_HOSTDEVICE constexpr inline Color4<T>
 Color4<T>::operator* (T x) const IMATH_NOEXCEPT
 {
     return Color4 (r * x, g * x, b * x, a * x);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color4<T>&
 Color4<T>::operator/= (const Color4& v) IMATH_NOEXCEPT
 {
     r /= v.r;
@@ -687,7 +692,7 @@ Color4<T>::operator/= (const Color4& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Color4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Color4<T>&
 Color4<T>::operator/= (T x) IMATH_NOEXCEPT
 {
     r /= x;
@@ -698,14 +703,14 @@ Color4<T>::operator/= (T x) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Color4<T>
+IMATH_HOSTDEVICE constexpr inline Color4<T>
 Color4<T>::operator/ (const Color4& v) const IMATH_NOEXCEPT
 {
     return Color4 (r / v.r, g / v.g, b / v.b, a / v.a);
 }
 
 template <class T>
-constexpr inline Color4<T>
+IMATH_HOSTDEVICE constexpr inline Color4<T>
 Color4<T>::operator/ (T x) const IMATH_NOEXCEPT
 {
     return Color4 (r / x, g / x, b / x, a / x);
@@ -723,7 +728,7 @@ operator<< (std::ostream& s, const Color4<T>& v)
 //
 
 template <class S, class T>
-constexpr inline Color4<T>
+IMATH_HOSTDEVICE constexpr inline Color4<T>
 operator* (S x, const Color4<T>& v) IMATH_NOEXCEPT
 {
     return Color4<T> (x * v.r, x * v.g, x * v.b, x * v.a);

--- a/src/Imath/ImathEuler.h
+++ b/src/Imath/ImathEuler.h
@@ -234,7 +234,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Euler : public Vec3<T>
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Euler (const Matrix44<T>&, Order o = Default) IMATH_NOEXCEPT;
 
     /// Destructor
-    ~Euler() = default;
+    IMATH_HOSTDEVICE ~Euler() = default;
 
     /// @}
     
@@ -380,7 +380,7 @@ typedef Euler<double> Eulerd;
 /// @cond Doxygen_Suppress
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Euler<T>::angleOrder (int& i, int& j, int& k) const IMATH_NOEXCEPT
 {
     i = _initialAxis;
@@ -389,7 +389,7 @@ Euler<T>::angleOrder (int& i, int& j, int& k) const IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Euler<T>::angleMapping (int& i, int& j, int& k) const IMATH_NOEXCEPT
 {
     int m[3];
@@ -403,7 +403,7 @@ Euler<T>::angleMapping (int& i, int& j, int& k) const IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Euler<T>::setXYZVector (const Vec3<T>& v) IMATH_NOEXCEPT
 {
     int i, j, k;
@@ -414,7 +414,7 @@ Euler<T>::setXYZVector (const Vec3<T>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-inline Vec3<T>
+IMATH_HOSTDEVICE inline Vec3<T>
 Euler<T>::toXYZVector() const IMATH_NOEXCEPT
 {
     int i, j, k;
@@ -423,7 +423,7 @@ Euler<T>::toXYZVector() const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Euler<T>::Euler() IMATH_NOEXCEPT
+IMATH_HOSTDEVICE constexpr inline Euler<T>::Euler() IMATH_NOEXCEPT
     : Vec3<T> (0, 0, 0),
       _frameStatic (true),
       _initialRepeated (false),
@@ -432,7 +432,7 @@ constexpr inline Euler<T>::Euler() IMATH_NOEXCEPT
 {}
 
 template <class T>
-IMATH_CONSTEXPR14 inline Euler<T>::Euler (typename Euler<T>::Order p) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Euler<T>::Euler (typename Euler<T>::Order p) IMATH_NOEXCEPT
     : Vec3<T> (0, 0, 0),
       _frameStatic (true),
       _initialRepeated (false),
@@ -443,7 +443,7 @@ IMATH_CONSTEXPR14 inline Euler<T>::Euler (typename Euler<T>::Order p) IMATH_NOEX
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Vec3<T>& v,
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Vec3<T>& v,
                                           typename Euler<T>::Order p,
                                           typename Euler<T>::InputLayout l) IMATH_NOEXCEPT
 {
@@ -458,12 +458,14 @@ IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Vec3<T>& v,
     }
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Euler<T>& euler) IMATH_NOEXCEPT
+template <class T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Euler<T>& euler) IMATH_NOEXCEPT
 {
     operator= (euler);
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Euler<T>& euler, Order p) IMATH_NOEXCEPT
+template <class T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Euler<T>& euler, Order p) IMATH_NOEXCEPT
 {
     setOrder (p);
     Matrix33<T> M = euler.toMatrix33();
@@ -471,11 +473,9 @@ template <class T> IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Euler<T>& eul
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Euler<T>::Euler (T xi,
-                                          T yi,
-                                          T zi,
-                                          typename Euler<T>::Order p,
-                                          typename Euler<T>::InputLayout l) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline
+Euler<T>::Euler (T xi, T yi, T zi, typename Euler<T>::Order p,
+                 typename Euler<T>::InputLayout l) IMATH_NOEXCEPT
 {
     setOrder (p);
     if (l == XYZLayout)
@@ -489,28 +489,28 @@ IMATH_CONSTEXPR14 inline Euler<T>::Euler (T xi,
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Matrix33<T>& M, typename Euler::Order p) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Matrix33<T>& M, typename Euler::Order p) IMATH_NOEXCEPT
 {
     setOrder (p);
     extract (M);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Matrix44<T>& M, typename Euler::Order p) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Euler<T>::Euler (const Matrix44<T>& M, typename Euler::Order p) IMATH_NOEXCEPT
 {
     setOrder (p);
     extract (M);
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Euler<T>::extract (const Quat<T>& q) IMATH_NOEXCEPT
 {
     extract (q.toMatrix33());
 }
 
 template <class T>
-void
+IMATH_HOSTDEVICE void
 Euler<T>::extract (const Matrix33<T>& M) IMATH_NOEXCEPT
 {
     int i, j, k;
@@ -617,7 +617,7 @@ Euler<T>::extract (const Matrix33<T>& M) IMATH_NOEXCEPT
 }
 
 template <class T>
-void
+IMATH_HOSTDEVICE void
 Euler<T>::extract (const Matrix44<T>& M) IMATH_NOEXCEPT
 {
     int i, j, k;
@@ -694,7 +694,7 @@ Euler<T>::extract (const Matrix44<T>& M) IMATH_NOEXCEPT
 }
 
 template <class T>
-Matrix33<T>
+IMATH_HOSTDEVICE Matrix33<T>
 Euler<T>::toMatrix33() const IMATH_NOEXCEPT
 {
     int i, j, k;
@@ -753,7 +753,7 @@ Euler<T>::toMatrix33() const IMATH_NOEXCEPT
 }
 
 template <class T>
-Matrix44<T>
+IMATH_HOSTDEVICE Matrix44<T>
 Euler<T>::toMatrix44() const IMATH_NOEXCEPT
 {
     int i, j, k;
@@ -812,7 +812,7 @@ Euler<T>::toMatrix44() const IMATH_NOEXCEPT
 }
 
 template <class T>
-Quat<T>
+IMATH_HOSTDEVICE Quat<T>
 Euler<T>::toQuat() const IMATH_NOEXCEPT
 {
     Vec3<T> angles;
@@ -867,14 +867,14 @@ Euler<T>::toQuat() const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Euler<T>::legal (typename Euler<T>::Order order) IMATH_NOEXCEPT
 {
     return (order & ~Legal) ? false : true;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 typename Euler<T>::Order
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 typename Euler<T>::Order
 Euler<T>::order() const IMATH_NOEXCEPT
 {
     int foo = (_initialAxis == Z ? 0x2000 : (_initialAxis == Y ? 0x1000 : 0));
@@ -890,7 +890,7 @@ Euler<T>::order() const IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Euler<T>::setOrder (typename Euler<T>::Order p) IMATH_NOEXCEPT
 {
     set (p & 0x2000 ? Z : (p & 0x1000 ? Y : X), // initial axis
@@ -900,7 +900,7 @@ Euler<T>::setOrder (typename Euler<T>::Order p) IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Euler<T>::set (typename Euler<T>::Axis axis, bool relative, bool parityEven, bool firstRepeats) IMATH_NOEXCEPT
 {
     _initialAxis     = axis;
@@ -910,7 +910,7 @@ Euler<T>::set (typename Euler<T>::Axis axis, bool relative, bool parityEven, boo
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Euler<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Euler<T>&
 Euler<T>::operator= (const Euler<T>& euler) IMATH_NOEXCEPT
 {
     x                = euler.x;
@@ -924,7 +924,7 @@ Euler<T>::operator= (const Euler<T>& euler) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Euler<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Euler<T>&
 Euler<T>::operator= (const Vec3<T>& v) IMATH_NOEXCEPT
 {
     x = v.x;
@@ -934,7 +934,7 @@ Euler<T>::operator= (const Vec3<T>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline float
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline float
 Euler<T>::angleMod (T angle) IMATH_NOEXCEPT
 {
     const T pi = static_cast<T> (M_PI);
@@ -949,7 +949,7 @@ Euler<T>::angleMod (T angle) IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Euler<T>::simpleXYZRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot) IMATH_NOEXCEPT
 {
     Vec3<T> d = xyzRot - targetXyzRot;
@@ -959,7 +959,7 @@ Euler<T>::simpleXYZRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot) IMATH
 }
 
 template <class T>
-void
+IMATH_HOSTDEVICE void
 Euler<T>::nearestRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot, Order order) IMATH_NOEXCEPT
 {
     int i, j, k;
@@ -987,7 +987,7 @@ Euler<T>::nearestRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot, Order o
 }
 
 template <class T>
-void
+IMATH_HOSTDEVICE void
 Euler<T>::makeNear (const Euler<T>& target) IMATH_NOEXCEPT
 {
     Vec3<T> xyzRot = toXYZVector();

--- a/src/Imath/ImathFun.h
+++ b/src/Imath/ImathFun.h
@@ -200,7 +200,7 @@ IMATH_EXPORT double predd (double d) IMATH_NOEXCEPT;
 // Return true if the number is not a NaN or Infinity.
 //
 
-inline bool IMATH_HOSTDEVICE
+IMATH_HOSTDEVICE inline bool
 finitef (float f) IMATH_NOEXCEPT
 {
     union
@@ -213,7 +213,7 @@ finitef (float f) IMATH_NOEXCEPT
     return (u.i & 0x7f800000) != 0x7f800000;
 }
 
-inline bool IMATH_HOSTDEVICE
+IMATH_HOSTDEVICE inline bool
 finited (double d) IMATH_NOEXCEPT
 {
     union

--- a/src/Imath/ImathInterval.h
+++ b/src/Imath/ImathInterval.h
@@ -126,39 +126,42 @@ typedef Interval<short> Intervals;
 /// Interval of type integer
 typedef Interval<int> Intervali;
 
-template <class T> inline IMATH_CONSTEXPR14 Interval<T>::Interval() IMATH_NOEXCEPT
+template <class T>
+IMATH_HOSTDEVICE inline IMATH_CONSTEXPR14 Interval<T>::Interval() IMATH_NOEXCEPT
 {
     makeEmpty();
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Interval<T>::Interval (const T& point) IMATH_NOEXCEPT
+template <class T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Interval<T>::Interval (const T& point) IMATH_NOEXCEPT
 {
     min = point;
     max = point;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Interval<T>::Interval (const T& minV, const T& maxV) IMATH_NOEXCEPT
+template <class T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Interval<T>::Interval (const T& minV, const T& maxV) IMATH_NOEXCEPT
 {
     min = minV;
     max = maxV;
 }
 
 template <class T>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Interval<T>::operator== (const Interval<T>& src) const IMATH_NOEXCEPT
 {
     return (min == src.min && max == src.max);
 }
 
 template <class T>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Interval<T>::operator!= (const Interval<T>& src) const IMATH_NOEXCEPT
 {
     return (min != src.min || max != src.max);
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Interval<T>::makeEmpty() IMATH_NOEXCEPT
 {
     min = std::numeric_limits<T>::max();
@@ -166,7 +169,7 @@ Interval<T>::makeEmpty() IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Interval<T>::makeInfinite() IMATH_NOEXCEPT
 {
     min = std::numeric_limits<T>::lowest();
@@ -175,7 +178,7 @@ Interval<T>::makeInfinite() IMATH_NOEXCEPT
 
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Interval<T>::extendBy (const T& point) IMATH_NOEXCEPT
 {
     if (point < min)
@@ -186,7 +189,7 @@ Interval<T>::extendBy (const T& point) IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Interval<T>::extendBy (const Interval<T>& interval) IMATH_NOEXCEPT
 {
     if (interval.min < min)
@@ -197,21 +200,21 @@ Interval<T>::extendBy (const Interval<T>& interval) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Interval<T>::intersects (const T& point) const IMATH_NOEXCEPT
 {
     return point >= min && point <= max;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Interval<T>::intersects (const Interval<T>& interval) const IMATH_NOEXCEPT
 {
     return interval.max >= min && interval.min <= max;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline T
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T
 Interval<T>::size() const IMATH_NOEXCEPT
 {
     if (isEmpty())
@@ -221,28 +224,28 @@ Interval<T>::size() const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline T
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T
 Interval<T>::center() const IMATH_NOEXCEPT
 {
     return (max + min) / 2;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Interval<T>::isEmpty() const IMATH_NOEXCEPT
 {
     return max < min;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Interval<T>::hasVolume() const IMATH_NOEXCEPT
 {
     return max > min;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Interval<T>::isInfinite() const IMATH_NOEXCEPT
 {
     if (min != std::numeric_limits<T>::lowest() || max != std::numeric_limits<T>::max())

--- a/src/Imath/ImathLine.h
+++ b/src/Imath/ImathLine.h
@@ -84,13 +84,14 @@ typedef Line3<float> Line3f;
 /// Line of type double
 typedef Line3<double> Line3d;
 
-template <class T> IMATH_CONSTEXPR14 inline Line3<T>::Line3 (const Vec3<T>& p0, const Vec3<T>& p1) IMATH_NOEXCEPT
+template <class T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Line3<T>::Line3 (const Vec3<T>& p0, const Vec3<T>& p1) IMATH_NOEXCEPT
 {
     set (p0, p1);
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Line3<T>::set (const Vec3<T>& p0, const Vec3<T>& p1) IMATH_NOEXCEPT
 {
     pos = p0;
@@ -99,28 +100,28 @@ Line3<T>::set (const Vec3<T>& p0, const Vec3<T>& p1) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Line3<T>::operator() (T parameter) const IMATH_NOEXCEPT
 {
     return pos + dir * parameter;
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Line3<T>::distanceTo (const Vec3<T>& point) const IMATH_NOEXCEPT
 {
     return (closestPointTo (point) - point).length();
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Line3<T>::closestPointTo (const Vec3<T>& point) const IMATH_NOEXCEPT
 {
     return ((point - pos) ^ dir) * dir + pos;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline T
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T
 Line3<T>::distanceTo (const Line3<T>& line) const IMATH_NOEXCEPT
 {
     T d = (dir % line.dir) ^ (line.pos - pos);
@@ -128,7 +129,7 @@ Line3<T>::distanceTo (const Line3<T>& line) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Vec3<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Vec3<T>
 Line3<T>::closestPointTo (const Line3<T>& line) const IMATH_NOEXCEPT
 {
     // Assumes the lines are normalized
@@ -164,7 +165,7 @@ operator<< (std::ostream& o, const Line3<T>& line)
 
 /// Transform a line by a matrix
 template <class S, class T>
-constexpr inline Line3<S>
+IMATH_HOSTDEVICE constexpr inline Line3<S>
 operator* (const Line3<S>& line, const Matrix44<T>& M) IMATH_NOEXCEPT
 {
     return Line3<S> (line.pos * M, (line.pos + line.dir) * M);

--- a/src/Imath/ImathMath.h
+++ b/src/Imath/ImathMath.h
@@ -36,46 +36,60 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 /// @cond Doxygen_Suppress
 template <class T> struct Math
 {
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T acos (T x) { return std::acos (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T asin (T x) { return std::asin (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T atan (T x) { return std::atan (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T atan2 (T x, T y) { return std::atan2 (x, y); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T cos (T x) { return std::cos (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T sin (T x) { return std::sin (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T tan (T x) { return std::tan (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T cosh (T x) { return std::cosh (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T sinh (T x) { return std::sinh (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T tanh (T x) { return std::tanh (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T exp (T x) { return std::exp (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T log (T x) { return std::log (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T log10 (T x) { return std::log10 (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T modf (T x, T* iptr)
     {
         T ival;
@@ -84,25 +98,32 @@ template <class T> struct Math
         return rval;
     }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T pow (T x, T y) { return std::pow (x, y); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T sqrt (T x) { return std::sqrt (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T ceil (T x) { return std::ceil (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T fabs (T x) { return std::fabs (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T floor (T x) { return std::floor (x); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T fmod (T x, T y) { return std::fmod (x, y); }
 
-    IMATH_HOSTDEVICE IMATH_DEPRECATED("use std::math functions")
+    IMATH_DEPRECATED("use std::math functions")
+    IMATH_HOSTDEVICE
     static T hypot (T x, T y) { return std::hypot (x, y); }
 };
 /// @endcond

--- a/src/Imath/ImathMatrix.h
+++ b/src/Imath/ImathMatrix.h
@@ -868,7 +868,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Matrix44
 
     /// Matrix-matrix multiplication returning a result.
     IMATH_HOSTDEVICE
-    static IMATH_CONSTEXPR14 Matrix44 multiply (const Matrix44& a, const Matrix44& b) noexcept;
+    static IMATH_CONSTEXPR14 Matrix44 multiply (const Matrix44& a, const Matrix44& b) IMATH_NOEXCEPT;
 
     /// Vector-matrix multiplication: a homogeneous transformation
     /// by computing Vec3 (src.x, src.y, src.z, 1) * m and dividing by the
@@ -1144,20 +1144,20 @@ typedef Matrix44<double> M44d;
 //---------------------------
 
 template <class T>
-inline T*
+IMATH_HOSTDEVICE IMATH_HOSTDEVICE inline T*
 Matrix22<T>::operator[] (int i) IMATH_NOEXCEPT
 {
     return x[i];
 }
 
 template <class T>
-inline const T*
+IMATH_HOSTDEVICE inline const T*
 Matrix22<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
     return x[i];
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22() IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22() IMATH_NOEXCEPT
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -1165,7 +1165,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22() IMATH_NOEXCE
     x[1][1] = 1;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a) IMATH_NOEXCEPT
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -1173,7 +1173,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a) IMATH_NO
     x[1][1] = a;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const T a[2][2]) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const T a[2][2]) IMATH_NOEXCEPT
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so instead of this:
@@ -1185,7 +1185,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const T a[2][
     x[1][1] = a[1][1];
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a, T b, T c, T d) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a, T b, T c, T d) IMATH_NOEXCEPT
 {
     x[0][0] = a;
     x[0][1] = b;
@@ -1193,7 +1193,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (T a, T b, T c
     x[1][1] = d;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22& v) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22& v) IMATH_NOEXCEPT
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so we don't do this:
@@ -1207,7 +1207,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix2
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22<S>& v) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = T (v.x[0][0]);
     x[0][1] = T (v.x[0][1]);
@@ -1216,7 +1216,7 @@ IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (const Matrix22<S>& v) IMATH_NOEX
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::operator= (const Matrix22& v) IMATH_NOEXCEPT
 {
     // Function calls and aliasing issues can inhibit vectorization versus
@@ -1231,7 +1231,7 @@ Matrix22<T>::operator= (const Matrix22& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::operator= (T a) IMATH_NOEXCEPT
 {
     x[0][0] = a;
@@ -1242,14 +1242,14 @@ Matrix22<T>::operator= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-inline T*
+IMATH_HOSTDEVICE IMATH_HOSTDEVICE inline T*
 Matrix22<T>::getValue() IMATH_NOEXCEPT
 {
     return (T*) &x[0][0];
 }
 
 template <class T>
-inline const T*
+IMATH_HOSTDEVICE inline const T*
 Matrix22<T>::getValue() const IMATH_NOEXCEPT
 {
     return (const T*) &x[0][0];
@@ -1257,7 +1257,7 @@ Matrix22<T>::getValue() const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Matrix22<T>::getValue (Matrix22<S>& v) const IMATH_NOEXCEPT
 {
     v.x[0][0] = x[0][0];
@@ -1268,7 +1268,7 @@ Matrix22<T>::getValue (Matrix22<S>& v) const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>&
 Matrix22<T>::setValue (const Matrix22<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
@@ -1280,7 +1280,7 @@ Matrix22<T>::setValue (const Matrix22<S>& v) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>&
 Matrix22<T>::setTheMatrix (const Matrix22<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
@@ -1291,7 +1291,7 @@ Matrix22<T>::setTheMatrix (const Matrix22<S>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Matrix22<T>::makeIdentity() IMATH_NOEXCEPT
 {
     x[0][0] = 1;
@@ -1301,7 +1301,7 @@ Matrix22<T>::makeIdentity() IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Matrix22<T>::operator== (const Matrix22& v) const IMATH_NOEXCEPT
 {
     return x[0][0] == v.x[0][0] && x[0][1] == v.x[0][1] && x[1][0] == v.x[1][0] &&
@@ -1309,7 +1309,7 @@ Matrix22<T>::operator== (const Matrix22& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Matrix22<T>::operator!= (const Matrix22& v) const IMATH_NOEXCEPT
 {
     return x[0][0] != v.x[0][0] || x[0][1] != v.x[0][1] || x[1][0] != v.x[1][0] ||
@@ -1317,7 +1317,7 @@ Matrix22<T>::operator!= (const Matrix22& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Matrix22<T>::equalWithAbsError (const Matrix22<T>& m, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 2; i++)
@@ -1329,7 +1329,7 @@ Matrix22<T>::equalWithAbsError (const Matrix22<T>& m, T e) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Matrix22<T>::equalWithRelError (const Matrix22<T>& m, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 2; i++)
@@ -1341,7 +1341,7 @@ Matrix22<T>::equalWithRelError (const Matrix22<T>& m, T e) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::operator+= (const Matrix22<T>& v) IMATH_NOEXCEPT
 {
     x[0][0] += v.x[0][0];
@@ -1353,7 +1353,7 @@ Matrix22<T>::operator+= (const Matrix22<T>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::operator+= (T a) IMATH_NOEXCEPT
 {
     x[0][0] += a;
@@ -1365,7 +1365,7 @@ Matrix22<T>::operator+= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix22<T>
+IMATH_HOSTDEVICE constexpr inline Matrix22<T>
 Matrix22<T>::operator+ (const Matrix22<T>& v) const IMATH_NOEXCEPT
 {
     return Matrix22 (x[0][0] + v.x[0][0],
@@ -1375,7 +1375,7 @@ Matrix22<T>::operator+ (const Matrix22<T>& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::operator-= (const Matrix22<T>& v) IMATH_NOEXCEPT
 {
     x[0][0] -= v.x[0][0];
@@ -1387,7 +1387,7 @@ Matrix22<T>::operator-= (const Matrix22<T>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::operator-= (T a) IMATH_NOEXCEPT
 {
     x[0][0] -= a;
@@ -1399,7 +1399,7 @@ Matrix22<T>::operator-= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix22<T>
+IMATH_HOSTDEVICE constexpr inline Matrix22<T>
 Matrix22<T>::operator- (const Matrix22<T>& v) const IMATH_NOEXCEPT
 {
     return Matrix22 (x[0][0] - v.x[0][0],
@@ -1409,14 +1409,14 @@ Matrix22<T>::operator- (const Matrix22<T>& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix22<T>
+IMATH_HOSTDEVICE constexpr inline Matrix22<T>
 Matrix22<T>::operator-() const IMATH_NOEXCEPT
 {
     return Matrix22 (-x[0][0], -x[0][1], -x[1][0], -x[1][1]);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::negate() IMATH_NOEXCEPT
 {
     x[0][0] = -x[0][0];
@@ -1428,7 +1428,7 @@ Matrix22<T>::negate() IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::operator*= (T a) IMATH_NOEXCEPT
 {
     x[0][0] *= a;
@@ -1440,7 +1440,7 @@ Matrix22<T>::operator*= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix22<T>
+IMATH_HOSTDEVICE constexpr inline Matrix22<T>
 Matrix22<T>::operator* (T a) const IMATH_NOEXCEPT
 {
     return Matrix22 (x[0][0] * a, x[0][1] * a, x[1][0] * a, x[1][1] * a);
@@ -1448,14 +1448,14 @@ Matrix22<T>::operator* (T a) const IMATH_NOEXCEPT
 
 /// Matrix-scalar multiplication
 template <class T>
-inline Matrix22<T>
+IMATH_HOSTDEVICE inline Matrix22<T>
 operator* (T a, const Matrix22<T>& v) IMATH_NOEXCEPT
 {
     return v * a;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::operator*= (const Matrix22<T>& v) IMATH_NOEXCEPT
 {
     Matrix22 tmp (T (0));
@@ -1470,7 +1470,7 @@ Matrix22<T>::operator*= (const Matrix22<T>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Matrix22<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>
 Matrix22<T>::operator* (const Matrix22<T>& v) const IMATH_NOEXCEPT
 {
     Matrix22 tmp (T (0));
@@ -1485,7 +1485,7 @@ Matrix22<T>::operator* (const Matrix22<T>& v) const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Matrix22<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const IMATH_NOEXCEPT
 {
     S a, b;
@@ -1498,7 +1498,7 @@ Matrix22<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const IMATH_NOEXCE
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::operator/= (T a) IMATH_NOEXCEPT
 {
     x[0][0] /= a;
@@ -1510,14 +1510,14 @@ Matrix22<T>::operator/= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix22<T>
+IMATH_HOSTDEVICE constexpr inline Matrix22<T>
 Matrix22<T>::operator/ (T a) const IMATH_NOEXCEPT
 {
     return Matrix22 (x[0][0] / a, x[0][1] / a, x[1][0] / a, x[1][1] / a);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::transpose() IMATH_NOEXCEPT
 {
     Matrix22 tmp (x[0][0], x[1][0], x[0][1], x[1][1]);
@@ -1526,7 +1526,7 @@ Matrix22<T>::transpose() IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix22<T>
+IMATH_HOSTDEVICE constexpr inline Matrix22<T>
 Matrix22<T>::transposed() const IMATH_NOEXCEPT
 {
     return Matrix22 (x[0][0], x[1][0], x[0][1], x[1][1]);
@@ -1541,7 +1541,7 @@ Matrix22<T>::invert (bool singExc)
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::invert() IMATH_NOEXCEPT
 {
     *this = inverse();
@@ -1592,7 +1592,7 @@ Matrix22<T>::inverse (bool singExc) const
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Matrix22<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>
 Matrix22<T>::inverse() const IMATH_NOEXCEPT
 {
     Matrix22 s (x[1][1], -x[0][1], -x[1][0], x[0][0]);
@@ -1632,7 +1632,7 @@ Matrix22<T>::inverse() const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Matrix22<T>::determinant() const IMATH_NOEXCEPT
 {
     return x[0][0] * x[1][1] - x[1][0] * x[0][1];
@@ -1640,7 +1640,7 @@ Matrix22<T>::determinant() const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline const Matrix22<T>&
+IMATH_HOSTDEVICE inline const Matrix22<T>&
 Matrix22<T>::setRotation (S r) IMATH_NOEXCEPT
 {
     S cos_r, sin_r;
@@ -1659,8 +1659,7 @@ Matrix22<T>::setRotation (S r) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::rotate (S r) IMATH_NOEXCEPT
 {
     *this *= Matrix22<T>().setRotation (r);
@@ -1668,7 +1667,6 @@ Matrix22<T>::rotate (S r) IMATH_NOEXCEPT
 }
 
 template <class T>
-
 IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::setScale (T s) IMATH_NOEXCEPT
 {
@@ -1688,8 +1686,7 @@ Matrix22<T>::setScale (T s) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::setScale (const Vec2<S>& s) IMATH_NOEXCEPT
 {
     //
@@ -1708,8 +1705,7 @@ Matrix22<T>::setScale (const Vec2<S>& s) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-
-IMATH_CONSTEXPR14 inline const Matrix22<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix22<T>&
 Matrix22<T>::scale (const Vec2<S>& s) IMATH_NOEXCEPT
 {
     x[0][0] *= s.x;
@@ -1726,21 +1722,21 @@ Matrix22<T>::scale (const Vec2<S>& s) IMATH_NOEXCEPT
 //---------------------------
 
 template <class T>
-inline T*
+IMATH_HOSTDEVICE IMATH_HOSTDEVICE inline T*
 Matrix33<T>::operator[] (int i) IMATH_NOEXCEPT
 {
     return x[i];
 }
 
 template <class T>
-inline const T*
+IMATH_HOSTDEVICE inline const T*
 Matrix33<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
     return x[i];
 }
 
 template <class T>
-inline IMATH_CONSTEXPR14
+IMATH_HOSTDEVICE inline IMATH_CONSTEXPR14
 Matrix33<T>::Matrix33() IMATH_NOEXCEPT
 {
     x[0][0] = 1;
@@ -1754,7 +1750,7 @@ Matrix33<T>::Matrix33() IMATH_NOEXCEPT
     x[2][2] = 1;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a) IMATH_NOEXCEPT
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -1767,7 +1763,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a) IMATH_NO
     x[2][2] = a;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const T a[3][3]) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const T a[3][3]) IMATH_NOEXCEPT
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so instead of this:
@@ -1785,8 +1781,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const T a[3][
 }
 
 template <class T>
-
-IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a, T b, T c, T d, T e, T f, T g, T h, T i) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a, T b, T c, T d, T e, T f, T g, T h, T i) IMATH_NOEXCEPT
 {
     x[0][0] = a;
     x[0][1] = b;
@@ -1799,7 +1794,8 @@ IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (T a, T b, T c, T d, T e, T f, T 
     x[2][2] = i;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33& v) IMATH_NOEXCEPT
+template <class T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33& v) IMATH_NOEXCEPT
 {
     // Function calls and aliasing issues can inhibit vectorization versus
     // straight assignment of data members, so instead of this:
@@ -1818,8 +1814,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix3
 
 template <class T>
 template <class S>
-
-IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33<S>& v) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = T (v.x[0][0]);
     x[0][1] = T (v.x[0][1]);
@@ -1833,8 +1828,7 @@ IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (const Matrix33<S>& v) IMATH_NOEX
 }
 
 template <class T>
-
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::operator= (const Matrix33& v) IMATH_NOEXCEPT
 {
     // Function calls and aliasing issues can inhibit vectorization versus
@@ -1854,8 +1848,7 @@ Matrix33<T>::operator= (const Matrix33& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::operator= (T a) IMATH_NOEXCEPT
 {
     x[0][0] = a;
@@ -1871,14 +1864,14 @@ Matrix33<T>::operator= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-inline T*
+IMATH_HOSTDEVICE IMATH_HOSTDEVICE inline T*
 Matrix33<T>::getValue() IMATH_NOEXCEPT
 {
     return (T*) &x[0][0];
 }
 
 template <class T>
-inline const T*
+IMATH_HOSTDEVICE inline const T*
 Matrix33<T>::getValue() const IMATH_NOEXCEPT
 {
     return (const T*) &x[0][0];
@@ -1886,7 +1879,7 @@ Matrix33<T>::getValue() const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Matrix33<T>::getValue (Matrix33<S>& v) const IMATH_NOEXCEPT
 {
     v.x[0][0] = x[0][0];
@@ -1902,7 +1895,7 @@ Matrix33<T>::getValue (Matrix33<S>& v) const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>&
 Matrix33<T>::setValue (const Matrix33<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
@@ -1919,7 +1912,7 @@ Matrix33<T>::setValue (const Matrix33<S>& v) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>&
 Matrix33<T>::setTheMatrix (const Matrix33<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
@@ -1935,7 +1928,7 @@ Matrix33<T>::setTheMatrix (const Matrix33<S>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Matrix33<T>::makeIdentity() IMATH_NOEXCEPT
 {
     x[0][0] = 1;
@@ -1950,7 +1943,7 @@ Matrix33<T>::makeIdentity() IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Matrix33<T>::operator== (const Matrix33& v) const IMATH_NOEXCEPT
 {
     return x[0][0] == v.x[0][0] && x[0][1] == v.x[0][1] && x[0][2] == v.x[0][2] &&
@@ -1959,7 +1952,7 @@ Matrix33<T>::operator== (const Matrix33& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Matrix33<T>::operator!= (const Matrix33& v) const IMATH_NOEXCEPT
 {
     return x[0][0] != v.x[0][0] || x[0][1] != v.x[0][1] || x[0][2] != v.x[0][2] ||
@@ -1968,7 +1961,7 @@ Matrix33<T>::operator!= (const Matrix33& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Matrix33<T>::equalWithAbsError (const Matrix33<T>& m, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 3; i++)
@@ -1980,7 +1973,7 @@ Matrix33<T>::equalWithAbsError (const Matrix33<T>& m, T e) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Matrix33<T>::equalWithRelError (const Matrix33<T>& m, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 3; i++)
@@ -1992,7 +1985,7 @@ Matrix33<T>::equalWithRelError (const Matrix33<T>& m, T e) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::operator+= (const Matrix33<T>& v) IMATH_NOEXCEPT
 {
     x[0][0] += v.x[0][0];
@@ -2009,7 +2002,7 @@ Matrix33<T>::operator+= (const Matrix33<T>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::operator+= (T a) IMATH_NOEXCEPT
 {
     x[0][0] += a;
@@ -2026,7 +2019,7 @@ Matrix33<T>::operator+= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix33<T>
+IMATH_HOSTDEVICE constexpr inline Matrix33<T>
 Matrix33<T>::operator+ (const Matrix33<T>& v) const IMATH_NOEXCEPT
 {
     return Matrix33 (x[0][0] + v.x[0][0],
@@ -2041,7 +2034,7 @@ Matrix33<T>::operator+ (const Matrix33<T>& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::operator-= (const Matrix33<T>& v) IMATH_NOEXCEPT
 {
     x[0][0] -= v.x[0][0];
@@ -2058,7 +2051,7 @@ Matrix33<T>::operator-= (const Matrix33<T>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::operator-= (T a) IMATH_NOEXCEPT
 {
     x[0][0] -= a;
@@ -2075,7 +2068,7 @@ Matrix33<T>::operator-= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix33<T>
+IMATH_HOSTDEVICE constexpr inline Matrix33<T>
 Matrix33<T>::operator- (const Matrix33<T>& v) const IMATH_NOEXCEPT
 {
     return Matrix33 (x[0][0] - v.x[0][0],
@@ -2090,7 +2083,7 @@ Matrix33<T>::operator- (const Matrix33<T>& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix33<T>
+IMATH_HOSTDEVICE constexpr inline Matrix33<T>
 Matrix33<T>::operator-() const IMATH_NOEXCEPT
 {
     return Matrix33 (-x[0][0],
@@ -2105,7 +2098,7 @@ Matrix33<T>::operator-() const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::negate() IMATH_NOEXCEPT
 {
     x[0][0] = -x[0][0];
@@ -2122,7 +2115,7 @@ Matrix33<T>::negate() IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::operator*= (T a) IMATH_NOEXCEPT
 {
     x[0][0] *= a;
@@ -2139,7 +2132,7 @@ Matrix33<T>::operator*= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix33<T>
+IMATH_HOSTDEVICE constexpr inline Matrix33<T>
 Matrix33<T>::operator* (T a) const IMATH_NOEXCEPT
 {
     return Matrix33 (x[0][0] * a,
@@ -2155,14 +2148,14 @@ Matrix33<T>::operator* (T a) const IMATH_NOEXCEPT
 
 /// Matrix-scalar multiplication
 template <class T>
-inline Matrix33<T> constexpr
+IMATH_HOSTDEVICE inline Matrix33<T> constexpr
 operator* (T a, const Matrix33<T>& v) IMATH_NOEXCEPT
 {
     return v * a;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::operator*= (const Matrix33<T>& v) IMATH_NOEXCEPT
 {
     // Avoid initializing with 0 values before immediately overwriting them,
@@ -2186,7 +2179,7 @@ Matrix33<T>::operator*= (const Matrix33<T>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Matrix33<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>
 Matrix33<T>::operator* (const Matrix33<T>& v) const IMATH_NOEXCEPT
 {
     // Avoid initializing with 0 values before immediately overwriting them,
@@ -2210,7 +2203,7 @@ Matrix33<T>::operator* (const Matrix33<T>& v) const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Matrix33<T>::multVecMatrix (const Vec2<S>& src, Vec2<S>& dst) const IMATH_NOEXCEPT
 {
     S a, b, w;
@@ -2225,7 +2218,7 @@ Matrix33<T>::multVecMatrix (const Vec2<S>& src, Vec2<S>& dst) const IMATH_NOEXCE
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Matrix33<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const IMATH_NOEXCEPT
 {
     S a, b;
@@ -2238,7 +2231,7 @@ Matrix33<T>::multDirMatrix (const Vec2<S>& src, Vec2<S>& dst) const IMATH_NOEXCE
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::operator/= (T a) IMATH_NOEXCEPT
 {
     x[0][0] /= a;
@@ -2255,7 +2248,7 @@ Matrix33<T>::operator/= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix33<T>
+IMATH_HOSTDEVICE constexpr inline Matrix33<T>
 Matrix33<T>::operator/ (T a) const IMATH_NOEXCEPT
 {
     return Matrix33 (x[0][0] / a,
@@ -2270,7 +2263,7 @@ Matrix33<T>::operator/ (T a) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::transpose() IMATH_NOEXCEPT
 {
     Matrix33 tmp (x[0][0], x[1][0], x[2][0], x[0][1], x[1][1], x[2][1], x[0][2], x[1][2], x[2][2]);
@@ -2279,7 +2272,7 @@ Matrix33<T>::transpose() IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix33<T>
+IMATH_HOSTDEVICE constexpr inline Matrix33<T>
 Matrix33<T>::transposed() const IMATH_NOEXCEPT
 {
     return Matrix33 (x[0][0],
@@ -2302,7 +2295,7 @@ Matrix33<T>::gjInvert (bool singExc)
 }
 
 template <class T>
-const inline Matrix33<T>&
+IMATH_HOSTDEVICE const inline Matrix33<T>&
 Matrix33<T>::gjInvert() IMATH_NOEXCEPT
 {
     *this = gjInverse();
@@ -2414,7 +2407,7 @@ Matrix33<T>::gjInverse (bool singExc) const
 }
 
 template <class T>
-inline Matrix33<T>
+IMATH_HOSTDEVICE inline Matrix33<T>
 Matrix33<T>::gjInverse() const IMATH_NOEXCEPT
 {
     int i, j, k;
@@ -2512,7 +2505,7 @@ Matrix33<T>::gjInverse() const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::invert (bool singExc)
 {
     *this = inverse (singExc);
@@ -2520,7 +2513,7 @@ Matrix33<T>::invert (bool singExc)
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::invert() IMATH_NOEXCEPT
 {
     *this = inverse();
@@ -2639,7 +2632,7 @@ Matrix33<T>::inverse (bool singExc) const
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Matrix33<T>
+IMATH_HOSTDEVICE IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>
 Matrix33<T>::inverse() const IMATH_NOEXCEPT
 {
     if (x[0][2] != 0 || x[1][2] != 0 || x[2][2] != 1)
@@ -2744,7 +2737,7 @@ Matrix33<T>::inverse() const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline T
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T
 Matrix33<T>::minorOf (const int r, const int c) const IMATH_NOEXCEPT
 {
     int r0 = 0 + (r < 1 ? 1 : 0);
@@ -2756,14 +2749,14 @@ Matrix33<T>::minorOf (const int r, const int c) const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Matrix33<T>::fastMinor (const int r0, const int r1, const int c0, const int c1) const IMATH_NOEXCEPT
 {
     return x[r0][c0] * x[r1][c1] - x[r0][c1] * x[r1][c0];
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Matrix33<T>::determinant() const IMATH_NOEXCEPT
 {
     return x[0][0] * (x[1][1] * x[2][2] - x[1][2] * x[2][1]) +
@@ -2773,7 +2766,7 @@ Matrix33<T>::determinant() const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline const Matrix33<T>&
+IMATH_HOSTDEVICE inline const Matrix33<T>&
 Matrix33<T>::setRotation (S r) IMATH_NOEXCEPT
 {
     S cos_r, sin_r;
@@ -2798,7 +2791,7 @@ Matrix33<T>::setRotation (S r) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::rotate (S r) IMATH_NOEXCEPT
 {
     *this *= Matrix33<T>().setRotation (r);
@@ -2806,7 +2799,7 @@ Matrix33<T>::rotate (S r) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::setScale (T s) IMATH_NOEXCEPT
 {
     //
@@ -2830,7 +2823,7 @@ Matrix33<T>::setScale (T s) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::setScale (const Vec2<S>& s) IMATH_NOEXCEPT
 {
     //
@@ -2854,7 +2847,7 @@ Matrix33<T>::setScale (const Vec2<S>& s) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::scale (const Vec2<S>& s) IMATH_NOEXCEPT
 {
     x[0][0] *= s.x;
@@ -2870,7 +2863,7 @@ Matrix33<T>::scale (const Vec2<S>& s) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::setTranslation (const Vec2<S>& t) IMATH_NOEXCEPT
 {
     x[0][0] = 1;
@@ -2889,7 +2882,7 @@ Matrix33<T>::setTranslation (const Vec2<S>& t) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec2<T>
+IMATH_HOSTDEVICE constexpr inline Vec2<T>
 Matrix33<T>::translation() const IMATH_NOEXCEPT
 {
     return Vec2<T> (x[2][0], x[2][1]);
@@ -2897,7 +2890,7 @@ Matrix33<T>::translation() const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::translate (const Vec2<S>& t) IMATH_NOEXCEPT
 {
     x[2][0] += t.x * x[0][0] + t.y * x[1][0];
@@ -2909,7 +2902,7 @@ Matrix33<T>::translate (const Vec2<S>& t) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::setShear (const S& xy) IMATH_NOEXCEPT
 {
     x[0][0] = 1;
@@ -2929,7 +2922,7 @@ Matrix33<T>::setShear (const S& xy) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::setShear (const Vec2<S>& h) IMATH_NOEXCEPT
 {
     x[0][0] = 1;
@@ -2949,7 +2942,7 @@ Matrix33<T>::setShear (const Vec2<S>& h) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::shear (const S& xy) IMATH_NOEXCEPT
 {
     //
@@ -2967,7 +2960,7 @@ Matrix33<T>::shear (const S& xy) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::shear (const Vec2<S>& h) IMATH_NOEXCEPT
 {
     Matrix33<T> P (*this);
@@ -2988,20 +2981,20 @@ Matrix33<T>::shear (const Vec2<S>& h) IMATH_NOEXCEPT
 //---------------------------
 
 template <class T>
-inline T*
+IMATH_HOSTDEVICE IMATH_HOSTDEVICE inline T*
 Matrix44<T>::operator[] (int i) IMATH_NOEXCEPT
 {
     return x[i];
 }
 
 template <class T>
-inline const T*
+IMATH_HOSTDEVICE inline const T*
 Matrix44<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
     return x[i];
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44() IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44() IMATH_NOEXCEPT
 {
     x[0][0] = 1;
     x[0][1] = 0;
@@ -3021,7 +3014,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44() IMATH_NOEXCE
     x[3][3] = 1;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (T a) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (T a) IMATH_NOEXCEPT
 {
     x[0][0] = a;
     x[0][1] = a;
@@ -3041,7 +3034,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (T a) IMATH_NO
     x[3][3] = a;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const T a[4][4]) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const T a[4][4]) IMATH_NOEXCEPT
 {
     x[0][0] = a[0][0];
     x[0][1] = a[0][1];
@@ -3062,7 +3055,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const T a[4][
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Matrix44<
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<
     T>::Matrix44 (T a, T b, T c, T d, T e, T f, T g, T h, T i, T j, T k, T l, T m, T n, T o, T p) IMATH_NOEXCEPT
 {
     x[0][0] = a;
@@ -3083,7 +3076,7 @@ IMATH_CONSTEXPR14 inline Matrix44<
     x[3][3] = p;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (Matrix33<T> r, Vec3<T> t) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (Matrix33<T> r, Vec3<T> t) IMATH_NOEXCEPT
 {
     x[0][0] = r[0][0];
     x[0][1] = r[0][1];
@@ -3103,7 +3096,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (Matrix33<T> r
     x[3][3] = 1;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44& v) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
     x[0][1] = v.x[0][1];
@@ -3125,7 +3118,7 @@ template <class T> IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix4
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44<S>& v) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = T (v.x[0][0]);
     x[0][1] = T (v.x[0][1]);
@@ -3146,7 +3139,7 @@ IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (const Matrix44<S>& v) IMATH_NOEX
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::operator= (const Matrix44& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
@@ -3169,7 +3162,7 @@ Matrix44<T>::operator= (const Matrix44& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::operator= (T a) IMATH_NOEXCEPT
 {
     x[0][0] = a;
@@ -3192,14 +3185,14 @@ Matrix44<T>::operator= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-inline T*
+IMATH_HOSTDEVICE IMATH_HOSTDEVICE inline T*
 Matrix44<T>::getValue() IMATH_NOEXCEPT
 {
     return (T*) &x[0][0];
 }
 
 template <class T>
-inline const T*
+IMATH_HOSTDEVICE inline const T*
 Matrix44<T>::getValue() const IMATH_NOEXCEPT
 {
     return (const T*) &x[0][0];
@@ -3207,7 +3200,7 @@ Matrix44<T>::getValue() const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Matrix44<T>::getValue (Matrix44<S>& v) const IMATH_NOEXCEPT
 {
     v.x[0][0] = x[0][0];
@@ -3230,7 +3223,7 @@ Matrix44<T>::getValue (Matrix44<S>& v) const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>&
 Matrix44<T>::setValue (const Matrix44<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
@@ -3254,7 +3247,7 @@ Matrix44<T>::setValue (const Matrix44<S>& v) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>&
 Matrix44<T>::setTheMatrix (const Matrix44<S>& v) IMATH_NOEXCEPT
 {
     x[0][0] = v.x[0][0];
@@ -3277,7 +3270,7 @@ Matrix44<T>::setTheMatrix (const Matrix44<S>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Matrix44<T>::makeIdentity() IMATH_NOEXCEPT
 {
     x[0][0] = 1;
@@ -3299,7 +3292,7 @@ Matrix44<T>::makeIdentity() IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Matrix44<T>::operator== (const Matrix44& v) const IMATH_NOEXCEPT
 {
     return x[0][0] == v.x[0][0] && x[0][1] == v.x[0][1] && x[0][2] == v.x[0][2] &&
@@ -3311,7 +3304,7 @@ Matrix44<T>::operator== (const Matrix44& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Matrix44<T>::operator!= (const Matrix44& v) const IMATH_NOEXCEPT
 {
     return x[0][0] != v.x[0][0] || x[0][1] != v.x[0][1] || x[0][2] != v.x[0][2] ||
@@ -3323,7 +3316,7 @@ Matrix44<T>::operator!= (const Matrix44& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Matrix44<T>::equalWithAbsError (const Matrix44<T>& m, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 4; i++)
@@ -3335,7 +3328,7 @@ Matrix44<T>::equalWithAbsError (const Matrix44<T>& m, T e) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Matrix44<T>::equalWithRelError (const Matrix44<T>& m, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 4; i++)
@@ -3347,7 +3340,7 @@ Matrix44<T>::equalWithRelError (const Matrix44<T>& m, T e) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::operator+= (const Matrix44<T>& v) IMATH_NOEXCEPT
 {
     x[0][0] += v.x[0][0];
@@ -3371,7 +3364,7 @@ Matrix44<T>::operator+= (const Matrix44<T>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::operator+= (T a) IMATH_NOEXCEPT
 {
     x[0][0] += a;
@@ -3395,7 +3388,7 @@ Matrix44<T>::operator+= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix44<T>
+IMATH_HOSTDEVICE constexpr inline Matrix44<T>
 Matrix44<T>::operator+ (const Matrix44<T>& v) const IMATH_NOEXCEPT
 {
     return Matrix44 (x[0][0] + v.x[0][0],
@@ -3417,7 +3410,7 @@ Matrix44<T>::operator+ (const Matrix44<T>& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::operator-= (const Matrix44<T>& v) IMATH_NOEXCEPT
 {
     x[0][0] -= v.x[0][0];
@@ -3441,7 +3434,7 @@ Matrix44<T>::operator-= (const Matrix44<T>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::operator-= (T a) IMATH_NOEXCEPT
 {
     x[0][0] -= a;
@@ -3465,7 +3458,7 @@ Matrix44<T>::operator-= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix44<T>
+IMATH_HOSTDEVICE constexpr inline Matrix44<T>
 Matrix44<T>::operator- (const Matrix44<T>& v) const IMATH_NOEXCEPT
 {
     return Matrix44 (x[0][0] - v.x[0][0],
@@ -3487,7 +3480,7 @@ Matrix44<T>::operator- (const Matrix44<T>& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix44<T>
+IMATH_HOSTDEVICE constexpr inline Matrix44<T>
 Matrix44<T>::operator-() const IMATH_NOEXCEPT
 {
     return Matrix44 (-x[0][0],
@@ -3509,7 +3502,7 @@ Matrix44<T>::operator-() const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::negate() IMATH_NOEXCEPT
 {
     x[0][0] = -x[0][0];
@@ -3533,7 +3526,7 @@ Matrix44<T>::negate() IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::operator*= (T a) IMATH_NOEXCEPT
 {
     x[0][0] *= a;
@@ -3557,7 +3550,7 @@ Matrix44<T>::operator*= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix44<T>
+IMATH_HOSTDEVICE constexpr inline Matrix44<T>
 Matrix44<T>::operator* (T a) const IMATH_NOEXCEPT
 {
     return Matrix44 (x[0][0] * a,
@@ -3580,7 +3573,7 @@ Matrix44<T>::operator* (T a) const IMATH_NOEXCEPT
 
 /// Matrix-scalar multiplication
 template <class T>
-inline Matrix44<T>
+IMATH_HOSTDEVICE inline Matrix44<T>
 operator* (T a, const Matrix44<T>& v) IMATH_NOEXCEPT
 {
     return v * a;
@@ -3588,8 +3581,8 @@ operator* (T a, const Matrix44<T>& v) IMATH_NOEXCEPT
 
 
 template <class T>
-inline IMATH_CONSTEXPR14 Matrix44<T>
-Matrix44<T>::multiply (const Matrix44 &a, const Matrix44 &b) noexcept
+IMATH_HOSTDEVICE inline IMATH_CONSTEXPR14 Matrix44<T>
+Matrix44<T>::multiply (const Matrix44 &a, const Matrix44 &b) IMATH_NOEXCEPT
 {
     const auto a00 = a.x[0][0];
     const auto a01 = a.x[0][1];
@@ -3638,7 +3631,7 @@ Matrix44<T>::multiply (const Matrix44 &a, const Matrix44 &b) noexcept
 
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::operator*= (const Matrix44<T>& v) IMATH_NOEXCEPT
 {
     *this = multiply(*this, v);
@@ -3646,14 +3639,14 @@ Matrix44<T>::operator*= (const Matrix44<T>& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Matrix44<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>
 Matrix44<T>::operator* (const Matrix44<T>& v) const IMATH_NOEXCEPT
 {
     return multiply(*this, v);
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Matrix44<T>::multiply (const Matrix44<T>& a, const Matrix44<T>& b, Matrix44<T>& c) IMATH_NOEXCEPT
 {
     c = multiply(a, b);
@@ -3661,7 +3654,7 @@ Matrix44<T>::multiply (const Matrix44<T>& a, const Matrix44<T>& b, Matrix44<T>& 
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Matrix44<T>::multVecMatrix (const Vec3<S>& src, Vec3<S>& dst) const IMATH_NOEXCEPT
 {
     S a, b, c, w;
@@ -3678,7 +3671,7 @@ Matrix44<T>::multVecMatrix (const Vec3<S>& src, Vec3<S>& dst) const IMATH_NOEXCE
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Matrix44<T>::multDirMatrix (const Vec3<S>& src, Vec3<S>& dst) const IMATH_NOEXCEPT
 {
     S a, b, c;
@@ -3693,7 +3686,7 @@ Matrix44<T>::multDirMatrix (const Vec3<S>& src, Vec3<S>& dst) const IMATH_NOEXCE
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::operator/= (T a) IMATH_NOEXCEPT
 {
     x[0][0] /= a;
@@ -3717,7 +3710,7 @@ Matrix44<T>::operator/= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix44<T>
+IMATH_HOSTDEVICE constexpr inline Matrix44<T>
 Matrix44<T>::operator/ (T a) const IMATH_NOEXCEPT
 {
     return Matrix44 (x[0][0] / a,
@@ -3739,7 +3732,7 @@ Matrix44<T>::operator/ (T a) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::transpose() IMATH_NOEXCEPT
 {
     Matrix44 tmp (x[0][0],
@@ -3763,7 +3756,7 @@ Matrix44<T>::transpose() IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix44<T>
+IMATH_HOSTDEVICE constexpr inline Matrix44<T>
 Matrix44<T>::transposed() const IMATH_NOEXCEPT
 {
     return Matrix44 (x[0][0],
@@ -3793,7 +3786,7 @@ Matrix44<T>::gjInvert (bool singExc)
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::gjInvert() IMATH_NOEXCEPT
 {
     *this = gjInverse();
@@ -3905,7 +3898,7 @@ Matrix44<T>::gjInverse (bool singExc) const
 }
 
 template <class T>
-inline Matrix44<T>
+IMATH_HOSTDEVICE inline Matrix44<T>
 Matrix44<T>::gjInverse() const IMATH_NOEXCEPT
 {
     int i, j, k;
@@ -4011,7 +4004,7 @@ Matrix44<T>::invert (bool singExc)
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::invert() IMATH_NOEXCEPT
 {
     *this = inverse();
@@ -4088,7 +4081,7 @@ Matrix44<T>::inverse (bool singExc) const
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Matrix44<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>
 Matrix44<T>::inverse() const IMATH_NOEXCEPT
 {
     if (x[0][3] != 0 || x[1][3] != 0 || x[2][3] != 0 || x[3][3] != 1)
@@ -4154,7 +4147,7 @@ Matrix44<T>::inverse() const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Matrix44<T>::fastMinor (const int r0,
                         const int r1,
                         const int r2,
@@ -4168,7 +4161,7 @@ Matrix44<T>::fastMinor (const int r0,
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline T
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T
 Matrix44<T>::minorOf (const int r, const int c) const IMATH_NOEXCEPT
 {
     int r0 = 0 + (r < 1 ? 1 : 0);
@@ -4192,7 +4185,7 @@ Matrix44<T>::minorOf (const int r, const int c) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline T
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T
 Matrix44<T>::determinant() const IMATH_NOEXCEPT
 {
     T sum = (T) 0;
@@ -4211,7 +4204,7 @@ Matrix44<T>::determinant() const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline const Matrix44<T>&
+IMATH_HOSTDEVICE inline const Matrix44<T>&
 Matrix44<T>::setEulerAngles (const Vec3<S>& r) IMATH_NOEXCEPT
 {
     S cos_rz, sin_rz, cos_ry, sin_ry, cos_rx, sin_rx;
@@ -4249,7 +4242,7 @@ Matrix44<T>::setEulerAngles (const Vec3<S>& r) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::setAxisAngle (const Vec3<S>& axis, S angle) IMATH_NOEXCEPT
 {
     Vec3<S> unit (axis.normalized());
@@ -4281,7 +4274,7 @@ Matrix44<T>::setAxisAngle (const Vec3<S>& axis, S angle) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline const Matrix44<T>&
+IMATH_HOSTDEVICE inline const Matrix44<T>&
 Matrix44<T>::rotate (const Vec3<S>& r) IMATH_NOEXCEPT
 {
     S cos_rz, sin_rz, cos_ry, sin_ry, cos_rx, sin_rx;
@@ -4328,7 +4321,7 @@ Matrix44<T>::rotate (const Vec3<S>& r) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::setScale (T s) IMATH_NOEXCEPT
 {
     //
@@ -4360,7 +4353,7 @@ Matrix44<T>::setScale (T s) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::setScale (const Vec3<S>& s) IMATH_NOEXCEPT
 {
     //
@@ -4392,7 +4385,7 @@ Matrix44<T>::setScale (const Vec3<S>& s) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::scale (const Vec3<S>& s) IMATH_NOEXCEPT
 {
     x[0][0] *= s.x;
@@ -4415,7 +4408,7 @@ Matrix44<T>::scale (const Vec3<S>& s) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::setTranslation (const Vec3<S>& t) IMATH_NOEXCEPT
 {
     x[0][0] = 1;
@@ -4442,7 +4435,7 @@ Matrix44<T>::setTranslation (const Vec3<S>& t) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline const Vec3<T>
+IMATH_HOSTDEVICE constexpr inline const Vec3<T>
 Matrix44<T>::translation() const IMATH_NOEXCEPT
 {
     return Vec3<T> (x[3][0], x[3][1], x[3][2]);
@@ -4450,7 +4443,7 @@ Matrix44<T>::translation() const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::translate (const Vec3<S>& t) IMATH_NOEXCEPT
 {
     x[3][0] += t.x * x[0][0] + t.y * x[1][0] + t.z * x[2][0];
@@ -4463,7 +4456,7 @@ Matrix44<T>::translate (const Vec3<S>& t) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::setShear (const Vec3<S>& h) IMATH_NOEXCEPT
 {
     x[0][0] = 1;
@@ -4491,7 +4484,7 @@ Matrix44<T>::setShear (const Vec3<S>& h) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::setShear (const Shear6<S>& h) IMATH_NOEXCEPT
 {
     x[0][0] = 1;
@@ -4519,7 +4512,7 @@ Matrix44<T>::setShear (const Shear6<S>& h) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::shear (const Vec3<S>& h) IMATH_NOEXCEPT
 {
     //
@@ -4539,7 +4532,7 @@ Matrix44<T>::shear (const Vec3<S>& h) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Matrix44<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix44<T>&
 Matrix44<T>::shear (const Shear6<S>& h) IMATH_NOEXCEPT
 {
     Matrix44<T> P (*this);
@@ -4663,7 +4656,7 @@ operator<< (std::ostream& s, const Matrix44<T>& m)
 //---------------------------------------------------------------
 
 template <class S, class T>
-inline const Vec2<S>&
+IMATH_HOSTDEVICE inline const Vec2<S>&
 operator*= (Vec2<S>& v, const Matrix22<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0]);
@@ -4676,7 +4669,7 @@ operator*= (Vec2<S>& v, const Matrix22<T>& m) IMATH_NOEXCEPT
 }
 
 template <class S, class T>
-inline Vec2<S>
+IMATH_HOSTDEVICE inline Vec2<S>
 operator* (const Vec2<S>& v, const Matrix22<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0]);
@@ -4686,7 +4679,7 @@ operator* (const Vec2<S>& v, const Matrix22<T>& m) IMATH_NOEXCEPT
 }
 
 template <class S, class T>
-inline const Vec2<S>&
+IMATH_HOSTDEVICE inline const Vec2<S>&
 operator*= (Vec2<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + m[2][0]);
@@ -4700,7 +4693,7 @@ operator*= (Vec2<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT
 }
 
 template <class S, class T>
-inline Vec2<S>
+IMATH_HOSTDEVICE inline Vec2<S>
 operator* (const Vec2<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + m[2][0]);
@@ -4711,7 +4704,7 @@ operator* (const Vec2<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT
 }
 
 template <class S, class T>
-inline const Vec3<S>&
+IMATH_HOSTDEVICE inline const Vec3<S>&
 operator*= (Vec3<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0]);
@@ -4726,7 +4719,7 @@ operator*= (Vec3<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT
 }
 
 template <class S, class T>
-inline Vec3<S>
+IMATH_HOSTDEVICE inline Vec3<S>
 operator* (const Vec3<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0]);
@@ -4737,7 +4730,7 @@ operator* (const Vec3<S>& v, const Matrix33<T>& m) IMATH_NOEXCEPT
 }
 
 template <class S, class T>
-inline const Vec3<S>&
+IMATH_HOSTDEVICE inline const Vec3<S>&
 operator*= (Vec3<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0] + m[3][0]);
@@ -4753,8 +4746,8 @@ operator*= (Vec3<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT
 }
 
 template <class S, class T>
-inline Vec3<S>
-operator* (const Vec3<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE inline Vec3<S>
+IMATH_HOSTDEVICE operator* (const Vec3<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0] + m[3][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1] + m[3][1]);
@@ -4765,8 +4758,8 @@ operator* (const Vec3<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT
 }
 
 template <class S, class T>
-inline const Vec4<S>&
-operator*= (Vec4<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE inline const Vec4<S>&
+IMATH_HOSTDEVICE operator*= (Vec4<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0] + v.w * m[3][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1] + v.w * m[3][1]);
@@ -4782,8 +4775,8 @@ operator*= (Vec4<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT
 }
 
 template <class S, class T>
-inline Vec4<S>
-operator* (const Vec4<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE inline Vec4<S>
+IMATH_HOSTDEVICE operator* (const Vec4<S>& v, const Matrix44<T>& m) IMATH_NOEXCEPT
 {
     S x = S (v.x * m[0][0] + v.y * m[1][0] + v.z * m[2][0] + v.w * m[3][0]);
     S y = S (v.x * m[0][1] + v.y * m[1][1] + v.z * m[2][1] + v.w * m[3][1]);

--- a/src/Imath/ImathPlane.h
+++ b/src/Imath/ImathPlane.h
@@ -115,23 +115,25 @@ typedef Plane3<double> Plane3d;
 //---------------
 
 template <class T>
-IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& p0, const Vec3<T>& p1, const Vec3<T>& p2) IMATH_NOEXCEPT
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& p0, const Vec3<T>& p1, const Vec3<T>& p2) IMATH_NOEXCEPT
 {
     set (p0, p1, p2);
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& n, T d) IMATH_NOEXCEPT
+template <class T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& n, T d) IMATH_NOEXCEPT
 {
     set (n, d);
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& p, const Vec3<T>& n) IMATH_NOEXCEPT
+template <class T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Plane3<T>::Plane3 (const Vec3<T>& p, const Vec3<T>& n) IMATH_NOEXCEPT
 {
     set (p, n);
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Plane3<T>::set (const Vec3<T>& point1, const Vec3<T>& point2, const Vec3<T>& point3) IMATH_NOEXCEPT
 {
     normal = (point2 - point1) % (point3 - point1);
@@ -140,7 +142,7 @@ Plane3<T>::set (const Vec3<T>& point1, const Vec3<T>& point2, const Vec3<T>& poi
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Plane3<T>::set (const Vec3<T>& point, const Vec3<T>& n) IMATH_NOEXCEPT
 {
     normal = n;
@@ -149,7 +151,7 @@ Plane3<T>::set (const Vec3<T>& point, const Vec3<T>& n) IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Plane3<T>::set (const Vec3<T>& n, T d) IMATH_NOEXCEPT
 {
     normal = n;
@@ -158,28 +160,28 @@ Plane3<T>::set (const Vec3<T>& n, T d) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Plane3<T>::distanceTo (const Vec3<T>& point) const IMATH_NOEXCEPT
 {
     return (point ^ normal) - distance;
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Plane3<T>::reflectPoint (const Vec3<T>& point) const IMATH_NOEXCEPT
 {
     return normal * distanceTo (point) * -2.0 + point;
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Plane3<T>::reflectVector (const Vec3<T>& v) const IMATH_NOEXCEPT
 {
     return normal * (normal ^ v) * 2.0 - v;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Plane3<T>::intersect (const Line3<T>& line, Vec3<T>& point) const IMATH_NOEXCEPT
 {
     T d = normal ^ line.dir;
@@ -191,7 +193,7 @@ Plane3<T>::intersect (const Line3<T>& line, Vec3<T>& point) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Plane3<T>::intersectT (const Line3<T>& line, T& t) const IMATH_NOEXCEPT
 {
     T d = normal ^ line.dir;
@@ -211,7 +213,7 @@ operator<< (std::ostream& o, const Plane3<T>& plane)
 
 /// Transform a plane by a matrix
 template <class T>
-IMATH_CONSTEXPR14 Plane3<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Plane3<T>
 operator* (const Plane3<T>& plane, const Matrix44<T>& M) IMATH_NOEXCEPT
 {
     //                        T
@@ -247,7 +249,7 @@ operator* (const Plane3<T>& plane, const Matrix44<T>& M) IMATH_NOEXCEPT
 
 /// Reflect the pla
 template <class T>
-constexpr inline Plane3<T>
+IMATH_HOSTDEVICE constexpr inline Plane3<T>
 operator- (const Plane3<T>& plane) IMATH_NOEXCEPT
 {
     return Plane3<T> (-plane.normal, -plane.distance);

--- a/src/Imath/ImathQuat.h
+++ b/src/Imath/ImathQuat.h
@@ -87,7 +87,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Quat
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Quat<T>& operator= (const Quat<T>& q) IMATH_NOEXCEPT;
 
     /// Destructor
-    ~Quat() IMATH_NOEXCEPT = default;
+    IMATH_HOSTDEVICE ~Quat() IMATH_NOEXCEPT = default;
 
     /// @}
 
@@ -196,13 +196,14 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Quat
     IMATH_HOSTDEVICE void setRotationInternal (const Vec3<T>& f0, const Vec3<T>& t0, Quat<T>& q) IMATH_NOEXCEPT;
 };
 
-template <class T> IMATH_CONSTEXPR14 Quat<T> slerp (const Quat<T>& q1, const Quat<T>& q2, T t) IMATH_NOEXCEPT;
+template <class T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T> slerp (const Quat<T>& q1, const Quat<T>& q2, T t) IMATH_NOEXCEPT;
 
 template <class T>
-IMATH_CONSTEXPR14 Quat<T> slerpShortestArc (const Quat<T>& q1, const Quat<T>& q2, T t) IMATH_NOEXCEPT;
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T> slerpShortestArc (const Quat<T>& q1, const Quat<T>& q2, T t) IMATH_NOEXCEPT;
 
 template <class T>
-IMATH_CONSTEXPR14 Quat<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Quat<T>
 squad (const Quat<T>& q1, const Quat<T>& q2, const Quat<T>& qa, const Quat<T>& qb, T t) IMATH_NOEXCEPT;
 
 ///
@@ -212,38 +213,50 @@ squad (const Quat<T>& q1, const Quat<T>& q2, const Quat<T>& qa, const Quat<T>& q
 /// computing the inner quadrangle points (qa and qb) to guarantee
 /// tangent continuity.
 template <class T>
-void intermediate (const Quat<T>& q0,
+IMATH_HOSTDEVICE void intermediate (const Quat<T>& q0,
                    const Quat<T>& q1,
                    const Quat<T>& q2,
                    const Quat<T>& q3,
                    Quat<T>& qa,
                    Quat<T>& qb) IMATH_NOEXCEPT;
 
-template <class T> constexpr Matrix33<T> operator* (const Matrix33<T>& M, const Quat<T>& q) IMATH_NOEXCEPT;
+template <class T>
+IMATH_HOSTDEVICE constexpr Matrix33<T> operator* (const Matrix33<T>& M, const Quat<T>& q) IMATH_NOEXCEPT;
 
-template <class T> constexpr Matrix33<T> operator* (const Quat<T>& q, const Matrix33<T>& M) IMATH_NOEXCEPT;
+template <class T>
+IMATH_HOSTDEVICE constexpr Matrix33<T> operator* (const Quat<T>& q, const Matrix33<T>& M) IMATH_NOEXCEPT;
 
 template <class T> std::ostream& operator<< (std::ostream& o, const Quat<T>& q);
 
-template <class T> constexpr Quat<T> operator* (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT;
+template <class T>
+IMATH_HOSTDEVICE constexpr Quat<T> operator* (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator/ (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT;
+template <class T>
+IMATH_HOSTDEVICE constexpr Quat<T> operator/ (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator/ (const Quat<T>& q, T t) IMATH_NOEXCEPT;
+template <class T>
+IMATH_HOSTDEVICE constexpr Quat<T> operator/ (const Quat<T>& q, T t) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator* (const Quat<T>& q, T t) IMATH_NOEXCEPT;
+template <class T>
+IMATH_HOSTDEVICE constexpr Quat<T> operator* (const Quat<T>& q, T t) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator* (T t, const Quat<T>& q) IMATH_NOEXCEPT;
+template <class T>
+IMATH_HOSTDEVICE constexpr Quat<T> operator* (T t, const Quat<T>& q) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator+ (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT;
+template <class T>
+IMATH_HOSTDEVICE constexpr Quat<T> operator+ (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator- (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT;
+template <class T>
+IMATH_HOSTDEVICE constexpr Quat<T> operator- (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator~ (const Quat<T>& q) IMATH_NOEXCEPT;
+template <class T>
+IMATH_HOSTDEVICE constexpr Quat<T> operator~ (const Quat<T>& q) IMATH_NOEXCEPT;
 
-template <class T> constexpr Quat<T> operator- (const Quat<T>& q) IMATH_NOEXCEPT;
+template <class T>
+IMATH_HOSTDEVICE constexpr Quat<T> operator- (const Quat<T>& q) IMATH_NOEXCEPT;
 
-template <class T> IMATH_CONSTEXPR14 Vec3<T> operator* (const Vec3<T>& v, const Quat<T>& q) IMATH_NOEXCEPT;
+template <class T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Vec3<T> operator* (const Vec3<T>& v, const Quat<T>& q) IMATH_NOEXCEPT;
 
 /// Quaternion of type float
 typedef Quat<float> Quatf;
@@ -255,42 +268,46 @@ typedef Quat<double> Quatd;
 // Implementation
 //---------------
 
-template <class T> constexpr inline Quat<T>::Quat() IMATH_NOEXCEPT : r (1), v (0, 0, 0)
+template <class T>
+IMATH_HOSTDEVICE constexpr inline Quat<T>::Quat() IMATH_NOEXCEPT : r (1), v (0, 0, 0)
 {
     // empty
 }
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Quat<T>::Quat (const Quat<S>& q) IMATH_NOEXCEPT : r (q.r), v (q.v)
-{
-    // empty
-}
-
-template <class T> constexpr inline Quat<T>::Quat (T s, T i, T j, T k) IMATH_NOEXCEPT : r (s), v (i, j, k)
-{
-    // empty
-}
-
-template <class T> constexpr inline Quat<T>::Quat (T s, Vec3<T> d) IMATH_NOEXCEPT : r (s), v (d)
-{
-    // empty
-}
-
-template <class T> constexpr inline Quat<T>::Quat (const Quat<T>& q) IMATH_NOEXCEPT : r (q.r), v (q.v)
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Quat<T>::Quat (const Quat<S>& q) IMATH_NOEXCEPT : r (q.r), v (q.v)
 {
     // empty
 }
 
 template <class T>
-constexpr inline Quat<T>
+IMATH_HOSTDEVICE constexpr inline Quat<T>::Quat (T s, T i, T j, T k) IMATH_NOEXCEPT : r (s), v (i, j, k)
+{
+    // empty
+}
+
+template <class T>
+IMATH_HOSTDEVICE constexpr inline Quat<T>::Quat (T s, Vec3<T> d) IMATH_NOEXCEPT : r (s), v (d)
+{
+    // empty
+}
+
+template <class T>
+IMATH_HOSTDEVICE constexpr inline Quat<T>::Quat (const Quat<T>& q) IMATH_NOEXCEPT : r (q.r), v (q.v)
+{
+    // empty
+}
+
+template <class T>
+IMATH_HOSTDEVICE constexpr inline Quat<T>
 Quat<T>::identity() IMATH_NOEXCEPT
 {
     return Quat<T>();
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Quat<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Quat<T>&
 Quat<T>::operator= (const Quat<T>& q) IMATH_NOEXCEPT
 {
     r = q.r;
@@ -299,7 +316,7 @@ Quat<T>::operator= (const Quat<T>& q) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Quat<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Quat<T>&
 Quat<T>::operator*= (const Quat<T>& q) IMATH_NOEXCEPT
 {
     T rtmp = r * q.r - (v ^ q.v);
@@ -309,7 +326,7 @@ Quat<T>::operator*= (const Quat<T>& q) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Quat<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Quat<T>&
 Quat<T>::operator*= (T t) IMATH_NOEXCEPT
 {
     r *= t;
@@ -318,7 +335,7 @@ Quat<T>::operator*= (T t) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Quat<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Quat<T>&
 Quat<T>::operator/= (const Quat<T>& q) IMATH_NOEXCEPT
 {
     *this = *this * q.inverse();
@@ -326,7 +343,7 @@ Quat<T>::operator/= (const Quat<T>& q) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Quat<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Quat<T>&
 Quat<T>::operator/= (T t) IMATH_NOEXCEPT
 {
     r /= t;
@@ -335,7 +352,7 @@ Quat<T>::operator/= (T t) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Quat<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Quat<T>&
 Quat<T>::operator+= (const Quat<T>& q) IMATH_NOEXCEPT
 {
     r += q.r;
@@ -344,7 +361,7 @@ Quat<T>::operator+= (const Quat<T>& q) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Quat<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Quat<T>&
 Quat<T>::operator-= (const Quat<T>& q) IMATH_NOEXCEPT
 {
     r -= q.r;
@@ -353,14 +370,14 @@ Quat<T>::operator-= (const Quat<T>& q) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline T&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T&
 Quat<T>::operator[] (int index) IMATH_NOEXCEPT
 {
     return index ? v[index - 1] : r;
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Quat<T>::operator[] (int index) const IMATH_NOEXCEPT
 {
     return index ? v[index - 1] : r;
@@ -368,7 +385,7 @@ Quat<T>::operator[] (int index) const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Quat<T>::operator== (const Quat<S>& q) const IMATH_NOEXCEPT
 {
     return r == q.r && v == q.v;
@@ -376,7 +393,7 @@ Quat<T>::operator== (const Quat<S>& q) const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Quat<T>::operator!= (const Quat<S>& q) const IMATH_NOEXCEPT
 {
     return r != q.r || v != q.v;
@@ -391,14 +408,14 @@ operator^ (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Quat<T>::length() const IMATH_NOEXCEPT
 {
     return std::sqrt (r * r + (v ^ v));
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Quat<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Quat<T>&
 Quat<T>::normalize() IMATH_NOEXCEPT
 {
     if (T l = length())
@@ -416,7 +433,7 @@ Quat<T>::normalize() IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Quat<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Quat<T>
 Quat<T>::normalized() const IMATH_NOEXCEPT
 {
     if (T l = length())
@@ -426,7 +443,7 @@ Quat<T>::normalized() const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Quat<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Quat<T>
 Quat<T>::inverse() const IMATH_NOEXCEPT
 {
     //
@@ -440,7 +457,7 @@ Quat<T>::inverse() const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Quat<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Quat<T>&
 Quat<T>::invert() IMATH_NOEXCEPT
 {
     T qdot = (*this) ^ (*this);
@@ -450,7 +467,7 @@ Quat<T>::invert() IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Vec3<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Vec3<T>
 Quat<T>::rotateVector (const Vec3<T>& original) const IMATH_NOEXCEPT
 {
     //
@@ -470,7 +487,7 @@ Quat<T>::rotateVector (const Vec3<T>& original) const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Quat<T>::euclideanInnerProduct (const Quat<T>& q) const IMATH_NOEXCEPT
 {
     return r * q.r + v.x * q.v.x + v.y * q.v.y + v.z * q.v.z;
@@ -480,7 +497,7 @@ Quat<T>::euclideanInnerProduct (const Quat<T>& q) const IMATH_NOEXCEPT
 /// Compute the angle between two quaternions,
 /// interpreting the quaternions as 4D vectors.
 template <class T>
-IMATH_CONSTEXPR14 inline T
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T
 angle4D (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 {
     Quat<T> d = q1 - q2;
@@ -510,7 +527,7 @@ angle4D (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 /// web page, The Right Way to Calculate Stuff, at
 /// http://www.plunk.org/~hatch/rightway.php
 template <class T>
-IMATH_CONSTEXPR14 inline Quat<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Quat<T>
 slerp (const Quat<T>& q1, const Quat<T>& q2, T t) IMATH_NOEXCEPT
 {
     T a = angle4D (q1, q2);
@@ -527,7 +544,7 @@ slerp (const Quat<T>& q1, const Quat<T>& q2, T t) IMATH_NOEXCEPT
 /// arc from q1 to either q2 or -q2, whichever is closer.
 /// Assumes q1 and q2 are unit quaternions.
 template <class T>
-IMATH_CONSTEXPR14 inline Quat<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Quat<T>
 slerpShortestArc (const Quat<T>& q1, const Quat<T>& q2, T t) IMATH_NOEXCEPT
 {
     if ((q1 ^ q2) >= 0)
@@ -555,7 +572,7 @@ slerpShortestArc (const Quat<T>& q1, const Quat<T>& q2, T t) IMATH_NOEXCEPT
 /// next adjacent segment. The q0 and q3 are used in computing qa and
 /// qb.
 template <class T>
-IMATH_CONSTEXPR14 inline Quat<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Quat<T>
 spline (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2, const Quat<T>& q3, T t) IMATH_NOEXCEPT
 {
     Quat<T> qa     = intermediate (q0, q1, q2);
@@ -573,7 +590,7 @@ spline (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2, const Quat<T>& 
 /// spherical linear interpolations of a quadrangle of unit
 /// quaternions.
 template <class T>
-IMATH_CONSTEXPR14 inline Quat<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Quat<T>
 squad (const Quat<T>& q1, const Quat<T>& qa, const Quat<T>& qb, const Quat<T>& q2, T t) IMATH_NOEXCEPT
 {
     Quat<T> r1     = slerp (q1, q2, t);
@@ -586,7 +603,7 @@ squad (const Quat<T>& q1, const Quat<T>& qa, const Quat<T>& qb, const Quat<T>& q
 /// Compute the intermediate point between three quaternions `q0`, `q1`,
 /// and `q2`.
 template <class T>
-IMATH_CONSTEXPR14 inline Quat<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Quat<T>
 intermediate (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 {
     Quat<T> q1inv = q1.inverse();
@@ -599,7 +616,7 @@ intermediate (const Quat<T>& q0, const Quat<T>& q1, const Quat<T>& q2) IMATH_NOE
 }
 
 template <class T>
-inline Quat<T>
+IMATH_HOSTDEVICE inline Quat<T>
 Quat<T>::log() const IMATH_NOEXCEPT
 {
     //
@@ -624,7 +641,7 @@ Quat<T>::log() const IMATH_NOEXCEPT
 }
 
 template <class T>
-inline Quat<T>
+IMATH_HOSTDEVICE inline Quat<T>
 Quat<T>::exp() const IMATH_NOEXCEPT
 {
     //
@@ -648,21 +665,21 @@ Quat<T>::exp() const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Quat<T>::angle() const IMATH_NOEXCEPT
 {
     return 2 * std::atan2 (v.length(), r);
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Quat<T>::axis() const IMATH_NOEXCEPT
 {
     return v.normalized();
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Quat<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Quat<T>&
 Quat<T>::setAxisAngle (const Vec3<T>& axis, T radians) IMATH_NOEXCEPT
 {
     r = std::cos (radians / 2);
@@ -671,7 +688,7 @@ Quat<T>::setAxisAngle (const Vec3<T>& axis, T radians) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline Quat<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Quat<T>&
 Quat<T>::setRotation (const Vec3<T>& from, const Vec3<T>& to) IMATH_NOEXCEPT
 {
     //
@@ -745,7 +762,7 @@ Quat<T>::setRotation (const Vec3<T>& from, const Vec3<T>& to) IMATH_NOEXCEPT
 }
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Quat<T>::setRotationInternal (const Vec3<T>& f0, const Vec3<T>& t0, Quat<T>& q) IMATH_NOEXCEPT
 {
     //
@@ -776,7 +793,7 @@ Quat<T>::setRotationInternal (const Vec3<T>& f0, const Vec3<T>& t0, Quat<T>& q) 
 }
 
 template <class T>
-constexpr inline Matrix33<T>
+IMATH_HOSTDEVICE constexpr inline Matrix33<T>
 Quat<T>::toMatrix33() const IMATH_NOEXCEPT
 {
     return Matrix33<T> (1 - 2 * (v.y * v.y + v.z * v.z),
@@ -793,7 +810,7 @@ Quat<T>::toMatrix33() const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Matrix44<T>
+IMATH_HOSTDEVICE constexpr inline Matrix44<T>
 Quat<T>::toMatrix44() const IMATH_NOEXCEPT
 {
     return Matrix44<T> (1 - 2 * (v.y * v.y + v.z * v.z),
@@ -817,7 +834,7 @@ Quat<T>::toMatrix44() const IMATH_NOEXCEPT
 /// Transform the quaternion by the matrix
 /// @return M * q
 template <class T>
-constexpr inline Matrix33<T>
+IMATH_HOSTDEVICE constexpr inline Matrix33<T>
 operator* (const Matrix33<T>& M, const Quat<T>& q) IMATH_NOEXCEPT
 {
     return M * q.toMatrix33();
@@ -826,7 +843,7 @@ operator* (const Matrix33<T>& M, const Quat<T>& q) IMATH_NOEXCEPT
 /// Transform the matrix by the quaterion:
 /// @return q * M
 template <class T>
-constexpr inline Matrix33<T>
+IMATH_HOSTDEVICE constexpr inline Matrix33<T>
 operator* (const Quat<T>& q, const Matrix33<T>& M) IMATH_NOEXCEPT
 {
     return q.toMatrix33() * M;
@@ -842,7 +859,7 @@ operator<< (std::ostream& o, const Quat<T>& q)
 
 /// Quaterion multiplication
 template <class T>
-constexpr inline Quat<T>
+IMATH_HOSTDEVICE constexpr inline Quat<T>
 operator* (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 {
     return Quat<T> (q1.r * q2.r - (q1.v ^ q2.v), q1.r * q2.v + q1.v * q2.r + q1.v % q2.v);
@@ -850,7 +867,7 @@ operator* (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 
 /// Quaterion division
 template <class T>
-constexpr inline Quat<T>
+IMATH_HOSTDEVICE constexpr inline Quat<T>
 operator/ (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 {
     return q1 * q2.inverse();
@@ -858,7 +875,7 @@ operator/ (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 
 /// Quaterion division
 template <class T>
-constexpr inline Quat<T>
+IMATH_HOSTDEVICE constexpr inline Quat<T>
 operator/ (const Quat<T>& q, T t) IMATH_NOEXCEPT
 {
     return Quat<T> (q.r / t, q.v / t);
@@ -867,7 +884,7 @@ operator/ (const Quat<T>& q, T t) IMATH_NOEXCEPT
 /// Quaterion*scalar multiplication
 /// @return q * t
 template <class T>
-constexpr inline Quat<T>
+IMATH_HOSTDEVICE constexpr inline Quat<T>
 operator* (const Quat<T>& q, T t) IMATH_NOEXCEPT
 {
     return Quat<T> (q.r * t, q.v * t);
@@ -876,7 +893,7 @@ operator* (const Quat<T>& q, T t) IMATH_NOEXCEPT
 /// Quaterion*scalar multiplication
 /// @return q * t
 template <class T>
-constexpr inline Quat<T>
+IMATH_HOSTDEVICE constexpr inline Quat<T>
 operator* (T t, const Quat<T>& q) IMATH_NOEXCEPT
 {
     return Quat<T> (q.r * t, q.v * t);
@@ -884,7 +901,7 @@ operator* (T t, const Quat<T>& q) IMATH_NOEXCEPT
 
 /// Quaterion addition
 template <class T>
-constexpr inline Quat<T>
+IMATH_HOSTDEVICE constexpr inline Quat<T>
 operator+ (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 {
     return Quat<T> (q1.r + q2.r, q1.v + q2.v);
@@ -892,7 +909,7 @@ operator+ (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 
 /// Quaterion subtraction
 template <class T>
-constexpr inline Quat<T>
+IMATH_HOSTDEVICE constexpr inline Quat<T>
 operator- (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 {
     return Quat<T> (q1.r - q2.r, q1.v - q2.v);
@@ -900,7 +917,7 @@ operator- (const Quat<T>& q1, const Quat<T>& q2) IMATH_NOEXCEPT
 
 /// Compute the conjugate
 template <class T>
-constexpr inline Quat<T>
+IMATH_HOSTDEVICE constexpr inline Quat<T>
 operator~ (const Quat<T>& q) IMATH_NOEXCEPT
 {
     return Quat<T> (q.r, -q.v);
@@ -908,7 +925,7 @@ operator~ (const Quat<T>& q) IMATH_NOEXCEPT
 
 /// Negate the quaterion
 template <class T>
-constexpr inline Quat<T>
+IMATH_HOSTDEVICE constexpr inline Quat<T>
 operator- (const Quat<T>& q) IMATH_NOEXCEPT
 {
     return Quat<T> (-q.r, -q.v);
@@ -917,7 +934,7 @@ operator- (const Quat<T>& q) IMATH_NOEXCEPT
 /// Quaterion*vector multiplcation
 /// @return v * q
 template <class T>
-IMATH_CONSTEXPR14 inline Vec3<T>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Vec3<T>
 operator* (const Vec3<T>& v, const Quat<T>& q) IMATH_NOEXCEPT
 {
     Vec3<T> a = q.v % v;

--- a/src/Imath/ImathRandom.h
+++ b/src/Imath/ImathRandom.h
@@ -119,24 +119,24 @@ IMATH_HOSTDEVICE IMATH_EXPORT void srand48 (long int seed);
 // Implementation
 //---------------
 
-inline void
+IMATH_HOSTDEVICE inline void
 Rand32::init (unsigned long int seed)
 {
     _state = (seed * 0xa5a573a5L) ^ 0x5a5a5a5aL;
 }
 
-inline Rand32::Rand32 (unsigned long int seed)
+IMATH_HOSTDEVICE inline Rand32::Rand32 (unsigned long int seed)
 {
     init (seed);
 }
 
-inline void
+IMATH_HOSTDEVICE inline void
 Rand32::next()
 {
     _state = 1664525L * _state + 1013904223L;
 }
 
-inline bool
+IMATH_HOSTDEVICE inline bool
 Rand32::nextb()
 {
     next();
@@ -144,21 +144,21 @@ Rand32::nextb()
     return !!(_state & 2147483648UL);
 }
 
-inline unsigned long int
+IMATH_HOSTDEVICE inline unsigned long int
 Rand32::nexti()
 {
     next();
     return _state & 0xffffffff;
 }
 
-inline float
+IMATH_HOSTDEVICE inline float
 Rand32::nextf (float rangeMin, float rangeMax)
 {
     float f = nextf();
     return rangeMin * (1 - f) + rangeMax * f;
 }
 
-inline void
+IMATH_HOSTDEVICE inline void
 Rand48::init (unsigned long int seed)
 {
     seed = (seed * 0xa5a573a5L) ^ 0x5a5a5a5aL;
@@ -168,30 +168,30 @@ Rand48::init (unsigned long int seed)
     _state[2] = (unsigned short int) (seed & 0xFFFF);
 }
 
-inline Rand48::Rand48 (unsigned long int seed)
+IMATH_HOSTDEVICE inline Rand48::Rand48 (unsigned long int seed)
 {
     init (seed);
 }
 
-inline bool
+IMATH_HOSTDEVICE inline bool
 Rand48::nextb()
 {
     return nrand48 (_state) & 1;
 }
 
-inline long int
+IMATH_HOSTDEVICE inline long int
 Rand48::nexti()
 {
     return nrand48 (_state);
 }
 
-inline double
+IMATH_HOSTDEVICE inline double
 Rand48::nextf()
 {
     return erand48 (_state);
 }
 
-inline double
+IMATH_HOSTDEVICE inline double
 Rand48::nextf (double rangeMin, double rangeMax)
 {
     double f = nextf();
@@ -199,7 +199,7 @@ Rand48::nextf (double rangeMin, double rangeMax)
 }
 
 template <class Vec, class Rand>
-Vec
+IMATH_HOSTDEVICE Vec
 solidSphereRand (Rand& rand)
 {
     Vec v;
@@ -214,7 +214,7 @@ solidSphereRand (Rand& rand)
 }
 
 template <class Vec, class Rand>
-Vec
+IMATH_HOSTDEVICE Vec
 hollowSphereRand (Rand& rand)
 {
     Vec v;
@@ -232,7 +232,7 @@ hollowSphereRand (Rand& rand)
 }
 
 template <class Rand>
-float
+IMATH_HOSTDEVICE float
 gaussRand (Rand& rand)
 {
     float x;       // Note: to avoid numerical problems with very small
@@ -250,7 +250,7 @@ gaussRand (Rand& rand)
 }
 
 template <class Vec, class Rand>
-Vec
+IMATH_HOSTDEVICE Vec
 gaussSphereRand (Rand& rand)
 {
     return hollowSphereRand<Vec> (rand) * gaussRand (rand);

--- a/src/Imath/ImathShear.h
+++ b/src/Imath/ImathShear.h
@@ -167,7 +167,7 @@ template <class T> class IMATH_EXPORT_TEMPLATE_TYPE Shear6
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Shear6& operator= (const Vec3<S>& v);
 
     /// Destructor
-    ~Shear6() = default;
+    IMATH_HOSTDEVICE ~Shear6() = default;
 
     /// @}
     
@@ -308,25 +308,25 @@ typedef Shear6<double> Shear6d;
 //-----------------------
 
 template <class T>
-IMATH_CONSTEXPR14 inline T&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T&
 Shear6<T>::operator[] (int i)
 {
     return (&xy)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>
-constexpr inline const T&
+IMATH_HOSTDEVICE constexpr inline const T&
 Shear6<T>::operator[] (int i) const
 {
     return (&xy)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Shear6<T>::Shear6()
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Shear6<T>::Shear6()
 {
     xy = xz = yz = yx = zx = zy = 0;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (T XY, T XZ, T YZ)
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (T XY, T XZ, T YZ)
 {
     xy = XY;
     xz = XZ;
@@ -336,7 +336,7 @@ template <class T> IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (T XY, T XZ, T YZ)
     zy = 0;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (const Vec3<T>& v)
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (const Vec3<T>& v)
 {
     xy = v.x;
     xz = v.y;
@@ -346,7 +346,9 @@ template <class T> IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (const Vec3<T>& v)
     zy = 0;
 }
 
-template <class T> template <class S> IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (const Vec3<S>& v)
+template <class T>
+template <class S>
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (const Vec3<S>& v)
 {
     xy = T (v.x);
     xz = T (v.y);
@@ -356,7 +358,7 @@ template <class T> template <class S> IMATH_CONSTEXPR14 inline Shear6<T>::Shear6
     zy = 0;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (T XY, T XZ, T YZ, T YX, T ZX, T ZY)
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (T XY, T XZ, T YZ, T YX, T ZX, T ZY)
 {
     xy = XY;
     xz = XZ;
@@ -366,7 +368,7 @@ template <class T> IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (T XY, T XZ, T YZ,
     zy = ZY;
 }
 
-template <class T> IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (const Shear6& h)
+template <class T> IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (const Shear6& h)
 {
     xy = h.xy;
     xz = h.xz;
@@ -378,7 +380,7 @@ template <class T> IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (const Shear6& h)
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (const Shear6<S>& h)
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (const Shear6<S>& h)
 {
     xy = T (h.xy);
     xz = T (h.xz);
@@ -389,7 +391,7 @@ IMATH_CONSTEXPR14 inline Shear6<T>::Shear6 (const Shear6<S>& h)
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Shear6<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Shear6<T>&
 Shear6<T>::operator= (const Shear6& h)
 {
     xy = h.xy;
@@ -403,7 +405,7 @@ Shear6<T>::operator= (const Shear6& h)
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline const Shear6<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Shear6<T>&
 Shear6<T>::operator= (const Vec3<S>& v)
 {
     xy = T (v.x);
@@ -417,7 +419,7 @@ Shear6<T>::operator= (const Vec3<S>& v)
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Shear6<T>::setValue (S XY, S XZ, S YZ, S YX, S ZX, S ZY)
 {
     xy = T (XY);
@@ -430,7 +432,7 @@ Shear6<T>::setValue (S XY, S XZ, S YZ, S YX, S ZX, S ZY)
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Shear6<T>::setValue (const Shear6<S>& h)
 {
     xy = T (h.xy);
@@ -443,7 +445,7 @@ Shear6<T>::setValue (const Shear6<S>& h)
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Shear6<T>::getValue (S& XY, S& XZ, S& YZ, S& YX, S& ZX, S& ZY) const
 {
     XY = S (xy);
@@ -456,7 +458,7 @@ Shear6<T>::getValue (S& XY, S& XZ, S& YZ, S& YX, S& ZX, S& ZY) const
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Shear6<T>::getValue (Shear6<S>& h) const
 {
     h.xy = S (xy);
@@ -468,14 +470,14 @@ Shear6<T>::getValue (Shear6<S>& h) const
 }
 
 template <class T>
-inline T*
+IMATH_HOSTDEVICE inline T*
 Shear6<T>::getValue()
 {
     return (T*) &xy;
 }
 
 template <class T>
-inline const T*
+IMATH_HOSTDEVICE inline const T*
 Shear6<T>::getValue() const
 {
     return (const T*) &xy;
@@ -483,7 +485,7 @@ Shear6<T>::getValue() const
 
 template <class T>
 template <class S>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Shear6<T>::operator== (const Shear6<S>& h) const
 {
     return xy == h.xy && xz == h.xz && yz == h.yz && yx == h.yx && zx == h.zx && zy == h.zy;
@@ -491,14 +493,14 @@ Shear6<T>::operator== (const Shear6<S>& h) const
 
 template <class T>
 template <class S>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Shear6<T>::operator!= (const Shear6<S>& h) const
 {
     return xy != h.xy || xz != h.xz || yz != h.yz || yx != h.yx || zx != h.zx || zy != h.zy;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Shear6<T>::equalWithAbsError (const Shear6<T>& h, T e) const
 {
     for (int i = 0; i < 6; i++)
@@ -509,7 +511,7 @@ Shear6<T>::equalWithAbsError (const Shear6<T>& h, T e) const
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Shear6<T>::equalWithRelError (const Shear6<T>& h, T e) const
 {
     for (int i = 0; i < 6; i++)
@@ -520,7 +522,7 @@ Shear6<T>::equalWithRelError (const Shear6<T>& h, T e) const
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Shear6<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Shear6<T>&
 Shear6<T>::operator+= (const Shear6& h)
 {
     xy += h.xy;
@@ -533,14 +535,14 @@ Shear6<T>::operator+= (const Shear6& h)
 }
 
 template <class T>
-constexpr inline Shear6<T>
+IMATH_HOSTDEVICE constexpr inline Shear6<T>
 Shear6<T>::operator+ (const Shear6& h) const
 {
     return Shear6 (xy + h.xy, xz + h.xz, yz + h.yz, yx + h.yx, zx + h.zx, zy + h.zy);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Shear6<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Shear6<T>&
 Shear6<T>::operator-= (const Shear6& h)
 {
     xy -= h.xy;
@@ -553,21 +555,21 @@ Shear6<T>::operator-= (const Shear6& h)
 }
 
 template <class T>
-constexpr inline Shear6<T>
+IMATH_HOSTDEVICE constexpr inline Shear6<T>
 Shear6<T>::operator- (const Shear6& h) const
 {
     return Shear6 (xy - h.xy, xz - h.xz, yz - h.yz, yx - h.yx, zx - h.zx, zy - h.zy);
 }
 
 template <class T>
-constexpr inline Shear6<T>
+IMATH_HOSTDEVICE constexpr inline Shear6<T>
 Shear6<T>::operator-() const
 {
     return Shear6 (-xy, -xz, -yz, -yx, -zx, -zy);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Shear6<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Shear6<T>&
 Shear6<T>::negate()
 {
     xy = -xy;
@@ -580,7 +582,7 @@ Shear6<T>::negate()
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Shear6<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Shear6<T>&
 Shear6<T>::operator*= (const Shear6& h)
 {
     xy *= h.xy;
@@ -593,7 +595,7 @@ Shear6<T>::operator*= (const Shear6& h)
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Shear6<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Shear6<T>&
 Shear6<T>::operator*= (T a)
 {
     xy *= a;
@@ -606,21 +608,21 @@ Shear6<T>::operator*= (T a)
 }
 
 template <class T>
-constexpr inline Shear6<T>
+IMATH_HOSTDEVICE constexpr inline Shear6<T>
 Shear6<T>::operator* (const Shear6& h) const
 {
     return Shear6 (xy * h.xy, xz * h.xz, yz * h.yz, yx * h.yx, zx * h.zx, zy * h.zy);
 }
 
 template <class T>
-constexpr inline Shear6<T>
+IMATH_HOSTDEVICE constexpr inline Shear6<T>
 Shear6<T>::operator* (T a) const
 {
     return Shear6 (xy * a, xz * a, yz * a, yx * a, zx * a, zy * a);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Shear6<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Shear6<T>&
 Shear6<T>::operator/= (const Shear6& h)
 {
     xy /= h.xy;
@@ -633,7 +635,7 @@ Shear6<T>::operator/= (const Shear6& h)
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Shear6<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Shear6<T>&
 Shear6<T>::operator/= (T a)
 {
     xy /= a;
@@ -646,14 +648,14 @@ Shear6<T>::operator/= (T a)
 }
 
 template <class T>
-constexpr inline Shear6<T>
+IMATH_HOSTDEVICE constexpr inline Shear6<T>
 Shear6<T>::operator/ (const Shear6& h) const
 {
     return Shear6 (xy / h.xy, xz / h.xz, yz / h.yz, yx / h.yx, zx / h.zx, zy / h.zy);
 }
 
 template <class T>
-constexpr inline Shear6<T>
+IMATH_HOSTDEVICE constexpr inline Shear6<T>
 Shear6<T>::operator/ (T a) const
 {
     return Shear6 (xy / a, xz / a, yz / a, yx / a, zx / a, zy / a);
@@ -676,7 +678,7 @@ operator<< (std::ostream& s, const Shear6<T>& h)
 //-----------------------------------------
 
 template <class S, class T>
-constexpr inline Shear6<T>
+IMATH_HOSTDEVICE constexpr inline Shear6<T>
 operator* (S a, const Shear6<T>& h)
 {
     return Shear6<T> (a * h.xy, a * h.xz, a * h.yz, a * h.yx, a * h.zx, a * h.zy);

--- a/src/Imath/ImathSphere.h
+++ b/src/Imath/ImathSphere.h
@@ -94,7 +94,7 @@ typedef Sphere3<double> Sphere3d;
 //---------------
 
 template <class T>
-inline void
+IMATH_HOSTDEVICE inline void
 Sphere3<T>::circumscribe (const Box<Vec3<T>>& box)
 {
     center = T (0.5) * (box.min + box.max);
@@ -102,7 +102,7 @@ Sphere3<T>::circumscribe (const Box<Vec3<T>>& box)
 }
 
 template <class T>
-IMATH_CONSTEXPR14 bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 bool
 Sphere3<T>::intersectT (const Line3<T>& line, T& t) const
 {
     bool doesIntersect = true;

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -873,131 +873,131 @@ typedef Vec4<double> V4d;
 //----------------------------------------------------------------------------
 
 // Vec2<short>
-template <> short Vec2<short>::length() const IMATH_NOEXCEPT = delete;
-template <> const Vec2<short>& Vec2<short>::normalize() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE short Vec2<short>::length() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec2<short>& Vec2<short>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec2<short>& Vec2<short>::normalizeExc() = delete;
-template <> const Vec2<short>& Vec2<short>::normalizeNonNull() IMATH_NOEXCEPT = delete;
-template <> Vec2<short> Vec2<short>::normalized() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec2<short>& Vec2<short>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec2<short> Vec2<short>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec2<short> Vec2<short>::normalizedExc() const = delete;
-template <> Vec2<short> Vec2<short>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec2<short> Vec2<short>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec2<int>
-template <> int Vec2<int>::length() const IMATH_NOEXCEPT = delete;
-template <> const Vec2<int>& Vec2<int>::normalize() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE int Vec2<int>::length() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec2<int>& Vec2<int>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec2<int>& Vec2<int>::normalizeExc() = delete;
-template <> const Vec2<int>& Vec2<int>::normalizeNonNull() IMATH_NOEXCEPT = delete;
-template <> Vec2<int> Vec2<int>::normalized() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec2<int>& Vec2<int>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec2<int> Vec2<int>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec2<int> Vec2<int>::normalizedExc() const = delete;
-template <> Vec2<int> Vec2<int>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec2<int> Vec2<int>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec2<int64_t>
-template <> int64_t Vec2<int64_t>::length() const IMATH_NOEXCEPT = delete;
-template <> const Vec2<int64_t>& Vec2<int64_t>::normalize() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE int64_t Vec2<int64_t>::length() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec2<int64_t>& Vec2<int64_t>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec2<int64_t>& Vec2<int64_t>::normalizeExc() = delete;
-template <> const Vec2<int64_t>& Vec2<int64_t>::normalizeNonNull() IMATH_NOEXCEPT = delete;
-template <> Vec2<int64_t> Vec2<int64_t>::normalized() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec2<int64_t>& Vec2<int64_t>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec2<int64_t> Vec2<int64_t>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec2<int64_t> Vec2<int64_t>::normalizedExc() const = delete;
-template <> Vec2<int64_t> Vec2<int64_t>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec2<int64_t> Vec2<int64_t>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec3<short>
-template <> short Vec3<short>::length() const IMATH_NOEXCEPT = delete;
-template <> const Vec3<short>& Vec3<short>::normalize() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE short Vec3<short>::length() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec3<short>& Vec3<short>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec3<short>& Vec3<short>::normalizeExc() = delete;
-template <> const Vec3<short>& Vec3<short>::normalizeNonNull() IMATH_NOEXCEPT = delete;
-template <> Vec3<short> Vec3<short>::normalized() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec3<short>& Vec3<short>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec3<short> Vec3<short>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec3<short> Vec3<short>::normalizedExc() const = delete;
-template <> Vec3<short> Vec3<short>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec3<short> Vec3<short>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec3<int>
-template <> int Vec3<int>::length() const IMATH_NOEXCEPT = delete;
-template <> const Vec3<int>& Vec3<int>::normalize() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE int Vec3<int>::length() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec3<int>& Vec3<int>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec3<int>& Vec3<int>::normalizeExc() = delete;
-template <> const Vec3<int>& Vec3<int>::normalizeNonNull() IMATH_NOEXCEPT = delete;
-template <> Vec3<int> Vec3<int>::normalized() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec3<int>& Vec3<int>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec3<int> Vec3<int>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec3<int> Vec3<int>::normalizedExc() const = delete;
-template <> Vec3<int> Vec3<int>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec3<int> Vec3<int>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec3<int64_t>
-template <> int64_t Vec3<int64_t>::length() const IMATH_NOEXCEPT = delete;
-template <> const Vec3<int64_t>& Vec3<int64_t>::normalize() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE int64_t Vec3<int64_t>::length() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec3<int64_t>& Vec3<int64_t>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec3<int64_t>& Vec3<int64_t>::normalizeExc() = delete;
-template <> const Vec3<int64_t>& Vec3<int64_t>::normalizeNonNull() IMATH_NOEXCEPT = delete;
-template <> Vec3<int64_t> Vec3<int64_t>::normalized() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec3<int64_t>& Vec3<int64_t>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec3<int64_t> Vec3<int64_t>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec3<int64_t> Vec3<int64_t>::normalizedExc() const = delete;
-template <> Vec3<int64_t> Vec3<int64_t>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec3<int64_t> Vec3<int64_t>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec4<short>
-template <> short Vec4<short>::length() const IMATH_NOEXCEPT = delete;
-template <> const Vec4<short>& Vec4<short>::normalize() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE short Vec4<short>::length() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec4<short>& Vec4<short>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec4<short>& Vec4<short>::normalizeExc() = delete;
-template <> const Vec4<short>& Vec4<short>::normalizeNonNull() IMATH_NOEXCEPT = delete;
-template <> Vec4<short> Vec4<short>::normalized() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec4<short>& Vec4<short>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec4<short> Vec4<short>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec4<short> Vec4<short>::normalizedExc() const = delete;
-template <> Vec4<short> Vec4<short>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec4<short> Vec4<short>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec4<int>
-template <> int Vec4<int>::length() const IMATH_NOEXCEPT = delete;
-template <> const Vec4<int>& Vec4<int>::normalize() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE int Vec4<int>::length() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec4<int>& Vec4<int>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec4<int>& Vec4<int>::normalizeExc() = delete;
-template <> const Vec4<int>& Vec4<int>::normalizeNonNull() IMATH_NOEXCEPT = delete;
-template <> Vec4<int> Vec4<int>::normalized() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec4<int>& Vec4<int>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec4<int> Vec4<int>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec4<int> Vec4<int>::normalizedExc() const = delete;
-template <> Vec4<int> Vec4<int>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec4<int> Vec4<int>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 // Vec4<int64_t>
-template <> int64_t Vec4<int64_t>::length() const IMATH_NOEXCEPT = delete;
-template <> const Vec4<int64_t>& Vec4<int64_t>::normalize() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE int64_t Vec4<int64_t>::length() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec4<int64_t>& Vec4<int64_t>::normalize() IMATH_NOEXCEPT = delete;
 template <> const Vec4<int64_t>& Vec4<int64_t>::normalizeExc() = delete;
-template <> const Vec4<int64_t>& Vec4<int64_t>::normalizeNonNull() IMATH_NOEXCEPT = delete;
-template <> Vec4<int64_t> Vec4<int64_t>::normalized() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE const Vec4<int64_t>& Vec4<int64_t>::normalizeNonNull() IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec4<int64_t> Vec4<int64_t>::normalized() const IMATH_NOEXCEPT = delete;
 template <> Vec4<int64_t> Vec4<int64_t>::normalizedExc() const = delete;
-template <> Vec4<int64_t> Vec4<int64_t>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
+template <> IMATH_HOSTDEVICE Vec4<int64_t> Vec4<int64_t>::normalizedNonNull() const IMATH_NOEXCEPT = delete;
 
 //------------------------
 // Implementation of Vec2:
 //------------------------
 
 template <class T>
-IMATH_CONSTEXPR14 inline T&
+IMATH_CONSTEXPR14 IMATH_HOSTDEVICE inline T&
 Vec2<T>::operator[] (int i) IMATH_NOEXCEPT
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>
-constexpr inline const T&
+constexpr IMATH_HOSTDEVICE inline const T&
 Vec2<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
-template <class T> inline Vec2<T>::Vec2() IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE inline Vec2<T>::Vec2() IMATH_NOEXCEPT
 {
     // empty, and not constexpr because data is uninitialized.
 }
 
-template <class T> constexpr inline Vec2<T>::Vec2 (T a) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE constexpr inline Vec2<T>::Vec2 (T a) IMATH_NOEXCEPT
     : x(a), y(a)
 {
 }
 
-template <class T> constexpr inline Vec2<T>::Vec2 (T a, T b) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE constexpr inline Vec2<T>::Vec2 (T a, T b) IMATH_NOEXCEPT
     : x(a), y(b)
 {
 }
 
-template <class T> constexpr inline Vec2<T>::Vec2 (const Vec2& v) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE constexpr inline Vec2<T>::Vec2 (const Vec2& v) IMATH_NOEXCEPT
     : x(v.x), y(v.y)
 {
 }
 
-template <class T> template <class S> constexpr inline Vec2<T>::Vec2 (const Vec2<S>& v) IMATH_NOEXCEPT
+template <class T> template <class S> IMATH_HOSTDEVICE constexpr inline Vec2<T>::Vec2 (const Vec2<S>& v) IMATH_NOEXCEPT
     : x(T(v.x)), y(T(v.y))
 {
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec2<T>&
+IMATH_CONSTEXPR14 IMATH_HOSTDEVICE inline const Vec2<T>&
 Vec2<T>::operator= (const Vec2& v) IMATH_NOEXCEPT
 {
     x = v.x;
@@ -1007,7 +1007,7 @@ Vec2<T>::operator= (const Vec2& v) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Vec2<T>::setValue (S a, S b) IMATH_NOEXCEPT
 {
     x = T (a);
@@ -1016,7 +1016,7 @@ Vec2<T>::setValue (S a, S b) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Vec2<T>::setValue (const Vec2<S>& v) IMATH_NOEXCEPT
 {
     x = T (v.x);
@@ -1025,7 +1025,7 @@ Vec2<T>::setValue (const Vec2<S>& v) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Vec2<T>::getValue (S& a, S& b) const IMATH_NOEXCEPT
 {
     a = S (x);
@@ -1034,7 +1034,7 @@ Vec2<T>::getValue (S& a, S& b) const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Vec2<T>::getValue (Vec2<S>& v) const IMATH_NOEXCEPT
 {
     v.x = S (x);
@@ -1042,14 +1042,14 @@ Vec2<T>::getValue (Vec2<S>& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-inline T*
+IMATH_HOSTDEVICE inline T*
 Vec2<T>::getValue() IMATH_NOEXCEPT
 {
     return (T*) &x;
 }
 
 template <class T>
-inline const T*
+IMATH_HOSTDEVICE inline const T*
 Vec2<T>::getValue() const IMATH_NOEXCEPT
 {
     return (const T*) &x;
@@ -1057,7 +1057,7 @@ Vec2<T>::getValue() const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Vec2<T>::operator== (const Vec2<S>& v) const IMATH_NOEXCEPT
 {
     return x == v.x && y == v.y;
@@ -1065,14 +1065,14 @@ Vec2<T>::operator== (const Vec2<S>& v) const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Vec2<T>::operator!= (const Vec2<S>& v) const IMATH_NOEXCEPT
 {
     return x != v.x || y != v.y;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Vec2<T>::equalWithAbsError (const Vec2<T>& v, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 2; i++)
@@ -1083,7 +1083,7 @@ Vec2<T>::equalWithAbsError (const Vec2<T>& v, T e) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Vec2<T>::equalWithRelError (const Vec2<T>& v, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 2; i++)
@@ -1094,35 +1094,35 @@ Vec2<T>::equalWithRelError (const Vec2<T>& v, T e) const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Vec2<T>::dot (const Vec2& v) const IMATH_NOEXCEPT
 {
     return x * v.x + y * v.y;
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Vec2<T>::operator^ (const Vec2& v) const IMATH_NOEXCEPT
 {
     return dot (v);
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Vec2<T>::cross (const Vec2& v) const IMATH_NOEXCEPT
 {
     return x * v.y - y * v.x;
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Vec2<T>::operator% (const Vec2& v) const IMATH_NOEXCEPT
 {
     return x * v.y - y * v.x;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec2<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec2<T>&
 Vec2<T>::operator+= (const Vec2& v) IMATH_NOEXCEPT
 {
     x += v.x;
@@ -1131,14 +1131,14 @@ Vec2<T>::operator+= (const Vec2& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec2<T>
+IMATH_HOSTDEVICE constexpr inline Vec2<T>
 Vec2<T>::operator+ (const Vec2& v) const IMATH_NOEXCEPT
 {
     return Vec2 (x + v.x, y + v.y);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec2<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec2<T>&
 Vec2<T>::operator-= (const Vec2& v) IMATH_NOEXCEPT
 {
     x -= v.x;
@@ -1147,21 +1147,21 @@ Vec2<T>::operator-= (const Vec2& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec2<T>
+IMATH_HOSTDEVICE constexpr inline Vec2<T>
 Vec2<T>::operator- (const Vec2& v) const IMATH_NOEXCEPT
 {
     return Vec2 (x - v.x, y - v.y);
 }
 
 template <class T>
-constexpr inline Vec2<T>
+IMATH_HOSTDEVICE constexpr inline Vec2<T>
 Vec2<T>::operator-() const IMATH_NOEXCEPT
 {
     return Vec2 (-x, -y);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec2<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec2<T>&
 Vec2<T>::negate() IMATH_NOEXCEPT
 {
     x = -x;
@@ -1170,7 +1170,7 @@ Vec2<T>::negate() IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec2<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec2<T>&
 Vec2<T>::operator*= (const Vec2& v) IMATH_NOEXCEPT
 {
     x *= v.x;
@@ -1179,7 +1179,7 @@ Vec2<T>::operator*= (const Vec2& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec2<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec2<T>&
 Vec2<T>::operator*= (T a) IMATH_NOEXCEPT
 {
     x *= a;
@@ -1188,21 +1188,21 @@ Vec2<T>::operator*= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec2<T>
+IMATH_HOSTDEVICE constexpr inline Vec2<T>
 Vec2<T>::operator* (const Vec2& v) const IMATH_NOEXCEPT
 {
     return Vec2 (x * v.x, y * v.y);
 }
 
 template <class T>
-constexpr inline Vec2<T>
+IMATH_HOSTDEVICE constexpr inline Vec2<T>
 Vec2<T>::operator* (T a) const IMATH_NOEXCEPT
 {
     return Vec2 (x * a, y * a);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec2<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec2<T>&
 Vec2<T>::operator/= (const Vec2& v) IMATH_NOEXCEPT
 {
     x /= v.x;
@@ -1211,7 +1211,7 @@ Vec2<T>::operator/= (const Vec2& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec2<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec2<T>&
 Vec2<T>::operator/= (T a) IMATH_NOEXCEPT
 {
     x /= a;
@@ -1220,21 +1220,21 @@ Vec2<T>::operator/= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec2<T>
+IMATH_HOSTDEVICE constexpr inline Vec2<T>
 Vec2<T>::operator/ (const Vec2& v) const IMATH_NOEXCEPT
 {
     return Vec2 (x / v.x, y / v.y);
 }
 
 template <class T>
-constexpr inline Vec2<T>
+IMATH_HOSTDEVICE constexpr inline Vec2<T>
 Vec2<T>::operator/ (T a) const IMATH_NOEXCEPT
 {
     return Vec2 (x / a, y / a);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline T
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T
 Vec2<T>::lengthTiny() const IMATH_NOEXCEPT
 {
     T absX = std::abs(x);
@@ -1261,7 +1261,7 @@ Vec2<T>::lengthTiny() const IMATH_NOEXCEPT
 }
 
 template <class T>
-inline T
+IMATH_HOSTDEVICE inline T
 Vec2<T>::length() const IMATH_NOEXCEPT
 {
     T length2 = dot (*this);
@@ -1273,14 +1273,14 @@ Vec2<T>::length() const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Vec2<T>::length2() const IMATH_NOEXCEPT
 {
     return dot (*this);
 }
 
 template <class T>
-inline const Vec2<T>&
+IMATH_HOSTDEVICE inline const Vec2<T>&
 Vec2<T>::normalize() IMATH_NOEXCEPT
 {
     T l = length();
@@ -1315,7 +1315,7 @@ Vec2<T>::normalizeExc()
 }
 
 template <class T>
-inline const Vec2<T>&
+IMATH_HOSTDEVICE inline const Vec2<T>&
 Vec2<T>::normalizeNonNull() IMATH_NOEXCEPT
 {
     T l = length();
@@ -1325,7 +1325,7 @@ Vec2<T>::normalizeNonNull() IMATH_NOEXCEPT
 }
 
 template <class T>
-inline Vec2<T>
+IMATH_HOSTDEVICE inline Vec2<T>
 Vec2<T>::normalized() const IMATH_NOEXCEPT
 {
     T l = length();
@@ -1349,7 +1349,7 @@ Vec2<T>::normalizedExc() const
 }
 
 template <class T>
-inline Vec2<T>
+IMATH_HOSTDEVICE inline Vec2<T>
 Vec2<T>::normalizedNonNull() const IMATH_NOEXCEPT
 {
     T l = length();
@@ -1361,6 +1361,7 @@ Vec2<T>::normalizedNonNull() const IMATH_NOEXCEPT
 //-----------------------
 
 template <class T>
+IMATH_HOSTDEVICE
 IMATH_CONSTEXPR14 inline T&
 Vec3<T>::operator[] (int i) IMATH_NOEXCEPT
 {
@@ -1368,39 +1369,40 @@ Vec3<T>::operator[] (int i) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline const T&
+IMATH_HOSTDEVICE constexpr inline const T&
 Vec3<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
-template <class T> inline Vec3<T>::Vec3() IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE inline Vec3<T>::Vec3() IMATH_NOEXCEPT
 {
     // empty, and not constexpr because data is uninitialized.
 }
 
-template <class T> constexpr inline Vec3<T>::Vec3 (T a) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE constexpr inline Vec3<T>::Vec3 (T a) IMATH_NOEXCEPT
     : x(a), y(a), z(a)
 {
 }
 
-template <class T> constexpr inline Vec3<T>::Vec3 (T a, T b, T c) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE constexpr inline Vec3<T>::Vec3 (T a, T b, T c) IMATH_NOEXCEPT
     : x(a), y(b), z(c)
 {
 }
 
-template <class T> constexpr inline Vec3<T>::Vec3 (const Vec3& v) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE constexpr inline Vec3<T>::Vec3 (const Vec3& v) IMATH_NOEXCEPT
     : x(v.x), y(v.y), z(v.z)
 {
 }
 
-template <class T> template <class S> constexpr inline Vec3<T>::Vec3 (const Vec3<S>& v) IMATH_NOEXCEPT
+template <class T> template <class S>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>::Vec3 (const Vec3<S>& v) IMATH_NOEXCEPT
     : x(T(v.x)), y(T(v.y)), z(T(v.z))
 {
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec3<T>&
 Vec3<T>::operator= (const Vec3& v) IMATH_NOEXCEPT
 {
     x = v.x;
@@ -1409,14 +1411,15 @@ Vec3<T>::operator= (const Vec3& v) IMATH_NOEXCEPT
     return *this;
 }
 
-template <class T> template <class S> constexpr inline Vec3<T>::Vec3 (const Vec4<S>& v) IMATH_NOEXCEPT
+template <class T> template <class S>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>::Vec3 (const Vec4<S>& v) IMATH_NOEXCEPT
     : x(T(v.x/v.w)), y(T(v.y/v.w)), z(T(v.z/v.w))
 {
 }
 
 template <class T>
 template <class S>
-IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (const Vec4<S>& v, InfException)
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (const Vec4<S>& v, InfException)
 {
     T vx = T (v.x);
     T vy = T (v.y);
@@ -1440,7 +1443,7 @@ IMATH_CONSTEXPR14 inline Vec3<T>::Vec3 (const Vec4<S>& v, InfException)
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Vec3<T>::setValue (S a, S b, S c) IMATH_NOEXCEPT
 {
     x = T (a);
@@ -1450,7 +1453,7 @@ Vec3<T>::setValue (S a, S b, S c) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Vec3<T>::setValue (const Vec3<S>& v) IMATH_NOEXCEPT
 {
     x = T (v.x);
@@ -1460,7 +1463,7 @@ Vec3<T>::setValue (const Vec3<S>& v) IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Vec3<T>::getValue (S& a, S& b, S& c) const IMATH_NOEXCEPT
 {
     a = S (x);
@@ -1470,7 +1473,7 @@ Vec3<T>::getValue (S& a, S& b, S& c) const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-inline void
+IMATH_HOSTDEVICE inline void
 Vec3<T>::getValue (Vec3<S>& v) const IMATH_NOEXCEPT
 {
     v.x = S (x);
@@ -1479,14 +1482,14 @@ Vec3<T>::getValue (Vec3<S>& v) const IMATH_NOEXCEPT
 }
 
 template <class T>
-inline T*
+IMATH_HOSTDEVICE inline T*
 Vec3<T>::getValue() IMATH_NOEXCEPT
 {
     return (T*) &x;
 }
 
 template <class T>
-inline const T*
+IMATH_HOSTDEVICE inline const T*
 Vec3<T>::getValue() const IMATH_NOEXCEPT
 {
     return (const T*) &x;
@@ -1494,7 +1497,7 @@ Vec3<T>::getValue() const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Vec3<T>::operator== (const Vec3<S>& v) const IMATH_NOEXCEPT
 {
     return x == v.x && y == v.y && z == v.z;
@@ -1502,14 +1505,14 @@ Vec3<T>::operator== (const Vec3<S>& v) const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Vec3<T>::operator!= (const Vec3<S>& v) const IMATH_NOEXCEPT
 {
     return x != v.x || y != v.y || z != v.z;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Vec3<T>::equalWithAbsError (const Vec3<T>& v, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 3; i++)
@@ -1520,7 +1523,7 @@ Vec3<T>::equalWithAbsError (const Vec3<T>& v, T e) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Vec3<T>::equalWithRelError (const Vec3<T>& v, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 3; i++)
@@ -1531,28 +1534,28 @@ Vec3<T>::equalWithRelError (const Vec3<T>& v, T e) const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Vec3<T>::dot (const Vec3& v) const IMATH_NOEXCEPT
 {
     return x * v.x + y * v.y + z * v.z;
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Vec3<T>::operator^ (const Vec3& v) const IMATH_NOEXCEPT
 {
     return dot (v);
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Vec3<T>::cross (const Vec3& v) const IMATH_NOEXCEPT
 {
     return Vec3 (y * v.z - z * v.y, z * v.x - x * v.z, x * v.y - y * v.x);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec3<T>&
 Vec3<T>::operator%= (const Vec3& v) IMATH_NOEXCEPT
 {
     T a = y * v.z - z * v.y;
@@ -1565,14 +1568,14 @@ Vec3<T>::operator%= (const Vec3& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Vec3<T>::operator% (const Vec3& v) const IMATH_NOEXCEPT
 {
     return Vec3 (y * v.z - z * v.y, z * v.x - x * v.z, x * v.y - y * v.x);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec3<T>&
 Vec3<T>::operator+= (const Vec3& v) IMATH_NOEXCEPT
 {
     x += v.x;
@@ -1582,14 +1585,14 @@ Vec3<T>::operator+= (const Vec3& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Vec3<T>::operator+ (const Vec3& v) const IMATH_NOEXCEPT
 {
     return Vec3 (x + v.x, y + v.y, z + v.z);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec3<T>&
 Vec3<T>::operator-= (const Vec3& v) IMATH_NOEXCEPT
 {
     x -= v.x;
@@ -1599,21 +1602,21 @@ Vec3<T>::operator-= (const Vec3& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Vec3<T>::operator- (const Vec3& v) const IMATH_NOEXCEPT
 {
     return Vec3 (x - v.x, y - v.y, z - v.z);
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Vec3<T>::operator-() const IMATH_NOEXCEPT
 {
     return Vec3 (-x, -y, -z);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec3<T>&
 Vec3<T>::negate() IMATH_NOEXCEPT
 {
     x = -x;
@@ -1623,7 +1626,7 @@ Vec3<T>::negate() IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec3<T>&
 Vec3<T>::operator*= (const Vec3& v) IMATH_NOEXCEPT
 {
     x *= v.x;
@@ -1633,7 +1636,7 @@ Vec3<T>::operator*= (const Vec3& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec3<T>&
 Vec3<T>::operator*= (T a) IMATH_NOEXCEPT
 {
     x *= a;
@@ -1643,21 +1646,21 @@ Vec3<T>::operator*= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Vec3<T>::operator* (const Vec3& v) const IMATH_NOEXCEPT
 {
     return Vec3 (x * v.x, y * v.y, z * v.z);
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Vec3<T>::operator* (T a) const IMATH_NOEXCEPT
 {
     return Vec3 (x * a, y * a, z * a);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec3<T>&
 Vec3<T>::operator/= (const Vec3& v) IMATH_NOEXCEPT
 {
     x /= v.x;
@@ -1667,7 +1670,7 @@ Vec3<T>::operator/= (const Vec3& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec3<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec3<T>&
 Vec3<T>::operator/= (T a) IMATH_NOEXCEPT
 {
     x /= a;
@@ -1677,21 +1680,21 @@ Vec3<T>::operator/= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Vec3<T>::operator/ (const Vec3& v) const IMATH_NOEXCEPT
 {
     return Vec3 (x / v.x, y / v.y, z / v.z);
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 Vec3<T>::operator/ (T a) const IMATH_NOEXCEPT
 {
     return Vec3 (x / a, y / a, z / a);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline T
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T
 Vec3<T>::lengthTiny() const IMATH_NOEXCEPT
 {
     T absX = (x >= T (0)) ? x : -x;
@@ -1723,7 +1726,7 @@ Vec3<T>::lengthTiny() const IMATH_NOEXCEPT
 }
 
 template <class T>
-inline T
+IMATH_HOSTDEVICE inline T
 Vec3<T>::length() const IMATH_NOEXCEPT
 {
     T length2 = dot (*this);
@@ -1735,14 +1738,14 @@ Vec3<T>::length() const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Vec3<T>::length2() const IMATH_NOEXCEPT
 {
     return dot (*this);
 }
 
 template <class T>
-inline const Vec3<T>&
+IMATH_HOSTDEVICE inline const Vec3<T>&
 Vec3<T>::normalize() IMATH_NOEXCEPT
 {
     T l = length();
@@ -1779,7 +1782,7 @@ Vec3<T>::normalizeExc()
 }
 
 template <class T>
-inline const Vec3<T>&
+IMATH_HOSTDEVICE inline const Vec3<T>&
 Vec3<T>::normalizeNonNull() IMATH_NOEXCEPT
 {
     T l = length();
@@ -1790,7 +1793,7 @@ Vec3<T>::normalizeNonNull() IMATH_NOEXCEPT
 }
 
 template <class T>
-inline Vec3<T>
+IMATH_HOSTDEVICE inline Vec3<T>
 Vec3<T>::normalized() const IMATH_NOEXCEPT
 {
     T l = length();
@@ -1814,7 +1817,7 @@ Vec3<T>::normalizedExc() const
 }
 
 template <class T>
-inline Vec3<T>
+IMATH_HOSTDEVICE inline Vec3<T>
 Vec3<T>::normalizedNonNull() const IMATH_NOEXCEPT
 {
     T l = length();
@@ -1826,6 +1829,7 @@ Vec3<T>::normalizedNonNull() const IMATH_NOEXCEPT
 //-----------------------
 
 template <class T>
+IMATH_HOSTDEVICE
 IMATH_CONSTEXPR14 inline T&
 Vec4<T>::operator[] (int i) IMATH_NOEXCEPT
 {
@@ -1833,39 +1837,40 @@ Vec4<T>::operator[] (int i) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline const T&
+IMATH_HOSTDEVICE constexpr inline const T&
 Vec4<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
     return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
-template <class T> inline Vec4<T>::Vec4() IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE inline Vec4<T>::Vec4() IMATH_NOEXCEPT
 {
     // empty, and not constexpr because data is uninitialized.
 }
 
-template <class T> constexpr inline Vec4<T>::Vec4 (T a) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE constexpr inline Vec4<T>::Vec4 (T a) IMATH_NOEXCEPT
     : x(a), y(a), z(a), w(a)
 {
 }
 
-template <class T> constexpr inline Vec4<T>::Vec4 (T a, T b, T c, T d) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE constexpr inline Vec4<T>::Vec4 (T a, T b, T c, T d) IMATH_NOEXCEPT
     : x(a), y(b), z(c), w(d)
 {
 }
 
-template <class T> constexpr inline Vec4<T>::Vec4 (const Vec4& v) IMATH_NOEXCEPT
+template <class T> IMATH_HOSTDEVICE constexpr inline Vec4<T>::Vec4 (const Vec4& v) IMATH_NOEXCEPT
     : x(v.x), y(v.y), z(v.z), w(v.w)
 {
 }
 
-template <class T> template <class S> constexpr inline Vec4<T>::Vec4 (const Vec4<S>& v) IMATH_NOEXCEPT
+template <class T> template <class S>
+IMATH_HOSTDEVICE constexpr inline Vec4<T>::Vec4 (const Vec4<S>& v) IMATH_NOEXCEPT
     : x(T(v.x)), y(T(v.y)), z(T(v.z)), w(T(v.w))
 {
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec4<T>&
 Vec4<T>::operator= (const Vec4& v) IMATH_NOEXCEPT
 {
     x = v.x;
@@ -1875,14 +1880,15 @@ Vec4<T>::operator= (const Vec4& v) IMATH_NOEXCEPT
     return *this;
 }
 
-template <class T> template <class S> constexpr inline Vec4<T>::Vec4 (const Vec3<S>& v) IMATH_NOEXCEPT
+template <class T> template <class S>
+IMATH_HOSTDEVICE constexpr inline Vec4<T>::Vec4 (const Vec3<S>& v) IMATH_NOEXCEPT
     : x(T(v.x)), y(T(v.y)), z(T(v.z)), w(T(1))
 {
 }
 
 template <class T>
 template <class S>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Vec4<T>::operator== (const Vec4<S>& v) const IMATH_NOEXCEPT
 {
     return x == v.x && y == v.y && z == v.z && w == v.w;
@@ -1890,14 +1896,14 @@ Vec4<T>::operator== (const Vec4<S>& v) const IMATH_NOEXCEPT
 
 template <class T>
 template <class S>
-constexpr inline bool
+IMATH_HOSTDEVICE constexpr inline bool
 Vec4<T>::operator!= (const Vec4<S>& v) const IMATH_NOEXCEPT
 {
     return x != v.x || y != v.y || z != v.z || w != v.w;
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Vec4<T>::equalWithAbsError (const Vec4<T>& v, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 4; i++)
@@ -1908,7 +1914,7 @@ Vec4<T>::equalWithAbsError (const Vec4<T>& v, T e) const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline bool
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Vec4<T>::equalWithRelError (const Vec4<T>& v, T e) const IMATH_NOEXCEPT
 {
     for (int i = 0; i < 4; i++)
@@ -1919,21 +1925,21 @@ Vec4<T>::equalWithRelError (const Vec4<T>& v, T e) const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Vec4<T>::dot (const Vec4& v) const IMATH_NOEXCEPT
 {
     return x * v.x + y * v.y + z * v.z + w * v.w;
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Vec4<T>::operator^ (const Vec4& v) const IMATH_NOEXCEPT
 {
     return dot (v);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec4<T>&
 Vec4<T>::operator+= (const Vec4& v) IMATH_NOEXCEPT
 {
     x += v.x;
@@ -1944,14 +1950,14 @@ Vec4<T>::operator+= (const Vec4& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec4<T>
+IMATH_HOSTDEVICE constexpr inline Vec4<T>
 Vec4<T>::operator+ (const Vec4& v) const IMATH_NOEXCEPT
 {
     return Vec4 (x + v.x, y + v.y, z + v.z, w + v.w);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec4<T>&
 Vec4<T>::operator-= (const Vec4& v) IMATH_NOEXCEPT
 {
     x -= v.x;
@@ -1962,21 +1968,21 @@ Vec4<T>::operator-= (const Vec4& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec4<T>
+IMATH_HOSTDEVICE constexpr inline Vec4<T>
 Vec4<T>::operator- (const Vec4& v) const IMATH_NOEXCEPT
 {
     return Vec4 (x - v.x, y - v.y, z - v.z, w - v.w);
 }
 
 template <class T>
-constexpr inline Vec4<T>
+IMATH_HOSTDEVICE constexpr inline Vec4<T>
 Vec4<T>::operator-() const IMATH_NOEXCEPT
 {
     return Vec4 (-x, -y, -z, -w);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec4<T>&
 Vec4<T>::negate() IMATH_NOEXCEPT
 {
     x = -x;
@@ -1987,7 +1993,7 @@ Vec4<T>::negate() IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec4<T>&
 Vec4<T>::operator*= (const Vec4& v) IMATH_NOEXCEPT
 {
     x *= v.x;
@@ -1998,7 +2004,7 @@ Vec4<T>::operator*= (const Vec4& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec4<T>&
 Vec4<T>::operator*= (T a) IMATH_NOEXCEPT
 {
     x *= a;
@@ -2009,21 +2015,21 @@ Vec4<T>::operator*= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec4<T>
+IMATH_HOSTDEVICE constexpr inline Vec4<T>
 Vec4<T>::operator* (const Vec4& v) const IMATH_NOEXCEPT
 {
     return Vec4 (x * v.x, y * v.y, z * v.z, w * v.w);
 }
 
 template <class T>
-constexpr inline Vec4<T>
+IMATH_HOSTDEVICE constexpr inline Vec4<T>
 Vec4<T>::operator* (T a) const IMATH_NOEXCEPT
 {
     return Vec4 (x * a, y * a, z * a, w * a);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec4<T>&
 Vec4<T>::operator/= (const Vec4& v) IMATH_NOEXCEPT
 {
     x /= v.x;
@@ -2034,7 +2040,7 @@ Vec4<T>::operator/= (const Vec4& v) IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Vec4<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Vec4<T>&
 Vec4<T>::operator/= (T a) IMATH_NOEXCEPT
 {
     x /= a;
@@ -2045,21 +2051,21 @@ Vec4<T>::operator/= (T a) IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline Vec4<T>
+IMATH_HOSTDEVICE constexpr inline Vec4<T>
 Vec4<T>::operator/ (const Vec4& v) const IMATH_NOEXCEPT
 {
     return Vec4 (x / v.x, y / v.y, z / v.z, w / v.w);
 }
 
 template <class T>
-constexpr inline Vec4<T>
+IMATH_HOSTDEVICE constexpr inline Vec4<T>
 Vec4<T>::operator/ (T a) const IMATH_NOEXCEPT
 {
     return Vec4 (x / a, y / a, z / a, w / a);
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline T
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T
 Vec4<T>::lengthTiny() const IMATH_NOEXCEPT
 {
     T absX = (x >= T (0)) ? x : -x;
@@ -2096,7 +2102,7 @@ Vec4<T>::lengthTiny() const IMATH_NOEXCEPT
 }
 
 template <class T>
-inline T
+IMATH_HOSTDEVICE inline T
 Vec4<T>::length() const IMATH_NOEXCEPT
 {
     T length2 = dot (*this);
@@ -2108,14 +2114,14 @@ Vec4<T>::length() const IMATH_NOEXCEPT
 }
 
 template <class T>
-constexpr inline T
+IMATH_HOSTDEVICE constexpr inline T
 Vec4<T>::length2() const IMATH_NOEXCEPT
 {
     return dot (*this);
 }
 
 template <class T>
-const inline Vec4<T>&
+IMATH_HOSTDEVICE const inline Vec4<T>&
 Vec4<T>::normalize() IMATH_NOEXCEPT
 {
     T l = length();
@@ -2154,7 +2160,7 @@ Vec4<T>::normalizeExc()
 }
 
 template <class T>
-inline const Vec4<T>&
+IMATH_HOSTDEVICE inline const Vec4<T>&
 Vec4<T>::normalizeNonNull() IMATH_NOEXCEPT
 {
     T l = length();
@@ -2166,7 +2172,7 @@ Vec4<T>::normalizeNonNull() IMATH_NOEXCEPT
 }
 
 template <class T>
-inline Vec4<T>
+IMATH_HOSTDEVICE inline Vec4<T>
 Vec4<T>::normalized() const IMATH_NOEXCEPT
 {
     T l = length();
@@ -2190,7 +2196,7 @@ Vec4<T>::normalizedExc() const
 }
 
 template <class T>
-inline Vec4<T>
+IMATH_HOSTDEVICE inline Vec4<T>
 Vec4<T>::normalizedNonNull() const IMATH_NOEXCEPT
 {
     T l = length();
@@ -2227,21 +2233,21 @@ operator<< (std::ostream& s, const Vec4<T>& v)
 //-----------------------------------------
 
 template <class T>
-constexpr inline Vec2<T>
+IMATH_HOSTDEVICE constexpr inline Vec2<T>
 operator* (T a, const Vec2<T>& v) IMATH_NOEXCEPT
 {
     return Vec2<T> (a * v.x, a * v.y);
 }
 
 template <class T>
-constexpr inline Vec3<T>
+IMATH_HOSTDEVICE constexpr inline Vec3<T>
 operator* (T a, const Vec3<T>& v) IMATH_NOEXCEPT
 {
     return Vec3<T> (a * v.x, a * v.y, a * v.z);
 }
 
 template <class T>
-constexpr inline Vec4<T>
+IMATH_HOSTDEVICE constexpr inline Vec4<T>
 operator* (T a, const Vec4<T>& v) IMATH_NOEXCEPT
 {
     return Vec4<T> (a * v.x, a * v.y, a * v.z, a * v.w);


### PR DESCRIPTION
[This is a cherry-pick of PR 198 from RB-3.1]

Many places (basically everywhere), we had the following idiom:

    template<class T>
    class Foo {
        IMATH_HOSTDEVICE float bar();    // declaration
    };
    ...
    template<class T> float Foo<T>::bar() { return 0.0; } // implementation

But this is wrong! When actually compiled in Cuda mode (maybe depending
on the compiler?), you can get errors about how you can't overload
a `__host__ __device__` declaration with a `__host__`-only implementation.
Which kinda makes sense. You have to match the two. So I have a WHOLE LOT
of places where I had to add IMATH_HOSTDEVICE.

Also, in ImathMath.h, we used this idiom:

    IMATH_HOSTDEVICE IMATH_DEPRECATED("reason") float foo() { ... }

Now, this seems to work with `cudacc`, but when you use
`clang++ --language=cuda` to compile Cuda to PTX (it can do that!), clang
really doesn't like it when the `__host__ __device__` comes before the
`[[ deprecated("msg") ]]`, it has an error about how the deprecated
attribute can't go there. So we have to transpose these so that the
IMATH_DEPRECATED is alwys the first thing in the declaration (which is
the way we almost always write it anyway).
