### PR TITLE
Require sphinx 4.0.3

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 breathe
+sphinx == 4.0.3


### PR DESCRIPTION
There seems to be a bug in newer versions of Sphinx that cause the
readthedocs build to fail, reported here:
https://github.com/sphinx-doc/sphinx/issues/9584.

Until that is resolved, this avoids it.

Signed-off-by: Cary Phillips <cary@ilm.com>