### PR TITLE
Fix undefined access of a vector when empty

### DIFF
--- a/src/python/PyImath/PyImathFixedVArray.cpp
+++ b/src/python/PyImath/PyImathFixedVArray.cpp
@@ -309,7 +309,7 @@ FixedVArray<T>::getitem (Py_ssize_t index)
 {
     const size_t i = canonical_index (index, _length);
     std::vector<T>& data = _ptr[(_indices ? raw_ptr_index(i) : i) * _stride];
-    return FixedArray<T>(&data[0], data.size(), 1, _writable);
+    return FixedArray<T>(data.empty() ? nullptr : &data[0], data.size(), 1, _writable);
 }
 
 template <class T>


### PR DESCRIPTION
This should address #195 and #197

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>