### PR TITLE
Fix python imath export

### DIFF
--- a/config/ImathSetup.cmake
+++ b/config/ImathSetup.cmake
@@ -129,18 +129,3 @@ if(IMATH_USE_CLANG_TIDY)
     -checks=*;
   )
 endif()
-
-#
-# Dependent libraries
-#
-
-# So we know how to link / use threads and don't have to have a -pthread
-# everywhere...
-if(NOT TARGET Threads::Threads)
-  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-  find_package(Threads)
-  if(NOT Threads_FOUND)
-    message(FATAL_ERROR "Unable to find a threading library, required for PyImathTask")
-  endif()
-endif()

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -9,6 +9,8 @@ if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()
 
+project(PyImath VERSION 3.2.0 LANGUAGES C CXX)
+
 #######################################
 #######################################
 # This declares all the configuration variables visible

--- a/src/python/PyImath/PyImathTask.cpp
+++ b/src/python/PyImath/PyImathTask.cpp
@@ -9,7 +9,7 @@
 
 namespace PyImath {
 
-static WorkerPool *_currentPool = 0;
+static WorkerPool *_currentPool = nullptr;
 
 // Its not worth dispatching parallel tasks unless the iteration count
 // is high enough.  The time to create and launch parallel tasks takes
@@ -33,21 +33,26 @@ WorkerPool::setCurrentPool(WorkerPool *pool)
 void
 dispatchTask(Task &task,size_t length)
 {
-    if (length > _minIterations   &&
-        WorkerPool::currentPool() && !WorkerPool::currentPool()->inWorkerThread())
-        WorkerPool::currentPool()->dispatch(task,length);
-    else
-        task.execute(0,length,0);
+    if (length > _minIterations)
+    {
+        WorkerPool *curpool = WorkerPool::currentPool();
+        if (curpool && !curpool->inWorkerThread())
+        {
+            curpool->dispatch(task,length);
+            return;
+        }
+    }
+    task.execute(0,length,0);
 }
 
 
 size_t
 workers()
 {
-    if (WorkerPool::currentPool() && !WorkerPool::currentPool()->inWorkerThread())
-        return WorkerPool::currentPool()->workers();
-    else
-        return 1;
+    WorkerPool *curpool = WorkerPool::currentPool();
+    if (curpool && !curpool->inWorkerThread())
+        return curpool->workers();
+    return 1;
 }
 
 }


### PR DESCRIPTION
Also removes thread library search, which is unused in this project.

the python support was exporting a custom library config (fine, although of dubious value, seems like that could just be simplified and merged to imath), but was not starting a new project definition, so was inheriting the same name, causing a duplicate export. It should be noted that this changes the requirements for making a release, where the version number needs to be updated in two places now to keep imath and pyimath in sync.

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>