### PR TITLE
Use ${Imath_VERSION} for python project version

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -9,7 +9,7 @@ if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()
 
-project(PyImath VERSION 3.2.0 LANGUAGES C CXX)
+project(PyImath VERSION ${Imath_VERSION} LANGUAGES C CXX)
 
 #######################################
 #######################################


### PR DESCRIPTION
This version should always be the same as the top-level Imath library,
so better to keep it all in one place.

Signed-off-by: Cary Phillips <cary@ilm.com>