### PR TITLE
Adding missing stdexcept header

### DIFF
--- a/src/python/PyImath/PyImathStringTable.cpp
+++ b/src/python/PyImath/PyImathStringTable.cpp
@@ -6,6 +6,7 @@
 // clang-format off
 
 #include <limits>
+#include <stdexcept>
 #include "PyImathExport.h"
 #include "PyImathStringTable.h"
 


### PR DESCRIPTION
I got the same build issue as #70 but with a different file when building PyImath on Windows:
`Imath\src\python\PyImath\PyImathStringTable.cpp(38,18): error C2039: 'domain_error': is not a member of 'std'`

So I fixed it the same way and added the missing header `<stdexcept>`.