### PR TITLE
Use equalWithAbsError instead of equal operator for float

### DIFF
--- a/src/python/PyImathTest/pyImathTest.in
+++ b/src/python/PyImathTest/pyImathTest.in
@@ -586,7 +586,7 @@ def testBinaryVecMethods(f1, f2):
     f = f1.cross(f2)
     assert(len(f) == len(f1))
     for i in range(0, len(f)):
-        assert(f[i] == f1[i].cross(f2[i]))
+        assert(equalWithAbsError(f[i], f1[i].cross(f2[i]), eps))
 
     assert(f1.cross(f2) == -f2.cross(f1))
 
@@ -601,7 +601,7 @@ def testBinaryVecMethods(f1, f2):
     f = f1.cross(v)
     assert(len(f) == len(f1))
     for i in range(0, len(f)):
-        assert(f[i] == f1[i].cross(v))
+        assert(equalWithAbsError(f[i], f1[i].cross(v), eps))
 
     assert(f1.cross(v) == -v.cross(f1))
 


### PR DESCRIPTION
### Problem
`make test` fails on `testBinaryVecMethods` due to float error.

### Version
3.1.3

### Environments
- OS: CentOS7
- Toolchain: GCC 11.2
- CPU: Broadwell

### Detail

These `assert` with `==` fails on comparing `f[i].y` and `f1[i].cross(?)`.

https://github.com/AcademySoftwareFoundation/Imath/blob/6402a530a4b106181c058301a9580c866e6fe2f3/src/python/PyImathTest/pyImathTest.in#L589

https://github.com/AcademySoftwareFoundation/Imath/blob/6402a530a4b106181c058301a9580c866e6fe2f3/src/python/PyImathTest/pyImathTest.in#L604

Verified with `print`

    print(f[i].y)
    print(f1[i].cross(f2[i]).y)

    7.900001525878906
    7.900001049041748

This float errors only happen on these 2 asserts with `cross`. `make test` passes without failures with this PR.

> 100% tests passed, 0 tests failed out of 38
> Total Test time (real) =   5.63 sec