### PR TITLE
Add docs target only if not a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ if (PYTHON)
 endif()
 
 option(DOCS "Set ON to build html documentation")
-if (DOCS)
+if (DOCS AND NOT IMATH_IS_SUBPROJECT)
   option(INSTALL_DOCS "Set ON to install html documentation" ON)
   add_subdirectory(docs)
 endif()


### PR DESCRIPTION
When Imath is a subproject (as with OpenEXR), the "docs" target can
conflict with the parent project's "docs" target. And the Imath docs
shouldn't be built by the parent project, anyway.

Signed-off-by: Cary Phillips <cary@ilm.com>