### PR TITLE
SolveNormalizedCubic fix to return proper real root

### DIFF
--- a/src/Imath/ImathRoots.h
+++ b/src/Imath/ImathRoots.h
@@ -153,28 +153,31 @@ solveNormalizedCubic (T r, T s, T t, T x[3])
         return 1;
     }
 
-    COMPLEX_NAMESPACE::complex<T> u = COMPLEX_NAMESPACE::pow (
-        -q / 2 + COMPLEX_NAMESPACE::sqrt (COMPLEX_NAMESPACE::complex<T> (D)),
-        T (1) / T (3));
+    if (D > 0)
+    {
+        auto real_root = [] (T a, T x) -> T {
+            T sign = a < T (0) ? T (-1) : T (1);
+            return sign * std::pow (sign * a, T (1) / x);
+        };
 
-    COMPLEX_NAMESPACE::complex<T> v = -p / (T (3) * u);
+        T u = real_root (-q / 2 + std::sqrt (D), 3);
+        T v = -p / (T (3) * u);
+
+        x[0] = u + v - r / 3;
+        return 1;
+    }
+
+    namespace CN     = COMPLEX_NAMESPACE;
+    CN::complex<T> u = CN::pow (-q / 2 + CN::sqrt (CN::complex<T> (D)), T (1) / T (3));
+    CN::complex<T> v = -p / (T (3) * u);
 
     const T sqrt3 = T (1.73205080756887729352744634150587); // enough digits
                                                             // for long double
-    COMPLEX_NAMESPACE::complex<T> y0 (u + v);
+    CN::complex<T> y0 (u + v);
+    CN::complex<T> y1 (-(u + v) / T (2) + (u - v) / T (2) * CN::complex<T> (0, sqrt3));
+    CN::complex<T> y2 (-(u + v) / T (2) - (u - v) / T (2) * CN::complex<T> (0, sqrt3));
 
-    COMPLEX_NAMESPACE::complex<T> y1 (-(u + v) / T (2) +
-                                      (u - v) / T (2) * COMPLEX_NAMESPACE::complex<T> (0, sqrt3));
-
-    COMPLEX_NAMESPACE::complex<T> y2 (-(u + v) / T (2) -
-                                      (u - v) / T (2) * COMPLEX_NAMESPACE::complex<T> (0, sqrt3));
-
-    if (D > 0)
-    {
-        x[0] = y0.real() - r / 3;
-        return 1;
-    }
-    else if (D == 0)
+    if (D == 0)
     {
         x[0] = y0.real() - r / 3;
         x[1] = y1.real() - r / 3;

--- a/src/Imath/ImathRoots.h
+++ b/src/Imath/ImathRoots.h
@@ -156,7 +156,7 @@ solveNormalizedCubic (T r, T s, T t, T x[3])
     if (D > 0)
     {
         auto real_root = [] (T a, T x) -> T {
-            T sign = a < T (0) ? T (-1) : T (1);
+            T sign = std::copysign(T(1), a);
             return sign * std::pow (sign * a, T (1) / x);
         };
 

--- a/src/ImathTest/testRoots.cpp
+++ b/src/ImathTest/testRoots.cpp
@@ -206,6 +206,7 @@ testRoots()
     solve (0, 0, 1, 0, 1, 0, 0, 0);      // real solutions: 0
     solve (0, 0, 0, 1, 0, 0, 0, 0);      // real solutions: none
     solve (0, 0, 0, 0, -1, 0, 0, 0);     // real solutions: [-inf, inf]
+    solve (36, -37, 0, 12, 1, -0.4715155, 0, 0);
 
     cout << endl << "solveQuadratic" << endl;
     // Solve quadratic equations


### PR DESCRIPTION
In some cases `solveNormalizedCubic` can return a real value from principled root that is a complex root. This happens in #86 for example. 

In case of discriminant `D > 0` there must be one real and two complex roots. Given formula: `-q/2 + sqrt(D)` might be a negative number.  Instead of searching though `y0`, `y1`, `y2` to find the real root, we can solve it as follows:
```
T sign = a < T (0) ? T (-1) : T (1);
return sign * std::pow (sign * a, T (1) / x);
```