### PR TITLE
Move numeric_limits<half> specializations into half.h

### DIFF
--- a/docs/half_limits.rst
+++ b/docs/half_limits.rst
@@ -1,6 +1,9 @@
 half Limits
 ###########
 
+Constants
+---------
+
 ``HALF_DENORM_MIN``
   Smallest positive denormalized half.
 
@@ -48,3 +51,63 @@ half Limits
 ``HALF_MAX_10_EXP``
   Maximum positive integer such that 10 raised to that power is a
   normalized half.
+
+``std::numeric_limits<half>``
+-----------------------------
+
+The ``half`` type provides specializations for
+``std::numeric_limits<half>``:
+
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::min() <https://en.cppreference.com/w/cpp/types/numeric_limits/min>`_                           | ``HALF_MIN``               |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::max() <https://en.cppreference.com/w/cpp/types/numeric_limits/max>`_                           | ``HALF_MAX``               |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::lowest() <https://en.cppreference.com/w/cpp/types/numeric_limits/lowest>`_                     | ``-HALF_MAX``              |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::digits <https://en.cppreference.com/w/cpp/types/numeric_limits/digits>`_                       | ``HALF_MANT_DIG``          |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::digits10 <https://en.cppreference.com/w/cpp/types/numeric_limits/digits10>`_                   | ``HALF_DIG``               |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::max_digits10 <https://en.cppreference.com/w/cpp/types/numeric_limits/max_digits10>`_           | ``HALF_DECIMAL_DIG``       |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::is_signed <https://en.cppreference.com/w/cpp/types/numeric_limits/is_signed>`_                 | ``true``                   |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::is_integer <https://en.cppreference.com/w/cpp/types/numeric_limits/is_integer>`_               | ``false``                  |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::is_exact <https://en.cppreference.com/w/cpp/types/numeric_limits/is_exact>`_                   | ``false``                  |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::radix <https://en.cppreference.com/w/cpp/types/numeric_limits/radix>`_                         | ``HALF_RADIX``             |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::epsilon() <https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon>`_                   | ``HALF_EPSILON``           |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::round_error() <https://en.cppreference.com/w/cpp/types/numeric_limits/round_error()>`_         | ``0.5``                    |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::min_exponent <https://en.cppreference.com/w/cpp/types/numeric_limits/min_exponent>`_           | ``HALF_DENORM_MIN_EXP``    |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::min_exponent10 <https://en.cppreference.com/w/cpp/types/numeric_limits/min_exponent10>`_       | ``HALF_DENORM_MIN_10_EXP`` |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::max_exponent <https://en.cppreference.com/w/cpp/types/numeric_limits/max_exponent>`_           | ``HALF_MAX_EXP``           |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::max_exponent10 <https://en.cppreference.com/w/cpp/types/numeric_limits/max_exponent10>`_       | ``HALF_MAX_10_EXP``        |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::has_infinity <https://en.cppreference.com/w/cpp/types/numeric_limits/has_infinity>`_           | ``true``                   |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::has_quiet_NaN <https://en.cppreference.com/w/cpp/types/numeric_limits/has_quiet_NaN>`_         | ``true``                   |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::has_signaling_NaN <https://en.cppreference.com/w/cpp/types/numeric_limits/has_signaling_NaN>`_ | ``true``                   |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::has_denorm <https://en.cppreference.com/w/cpp/types/numeric_limits/denorm_style>`_             | ``std::denorm_present``    |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::has_denorm_loss <https://en.cppreference.com/w/cpp/types/numeric_limits/has_denorm_loss>`_     | ``false``                  |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::infinity() <https://en.cppreference.com/w/cpp/types/numeric_limits/infinity()>`_               | ``half::posInf()``         |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::quiet_NaN() <https://en.cppreference.com/w/cpp/types/numeric_limits/quiet_NaN()>`_             | ``half::qNan()``           |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::signaling_NaN() <https://en.cppreference.com/w/cpp/types/numeric_limits/signaling_NaN()>`_     | ``half::sNan()``           |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+| `std::numeric_limits<half>::denorm_min() <https://en.cppreference.com/w/cpp/types/numeric_limits/denorm_min()>`_           | ``HALF_DENORM_MIN``        |
++----------------------------------------------------------------------------------------------------------------------------+----------------------------+
+
+  

--- a/src/Imath/half.h
+++ b/src/Imath/half.h
@@ -888,6 +888,83 @@ IMATH_EXPORT std::ostream&
 IMATH_EXPORT std::istream&
              operator>> (std::istream& is, IMATH_INTERNAL_NAMESPACE::half& h);
 
+#include <limits>
+
+namespace std
+{
+
+template <> class numeric_limits<IMATH_INTERNAL_NAMESPACE::half>
+{
+public:
+    static const bool is_specialized = true;
+
+    static constexpr IMATH_INTERNAL_NAMESPACE::half min () IMATH_NOEXCEPT
+    {
+        return IMATH_INTERNAL_NAMESPACE::half (IMATH_INTERNAL_NAMESPACE::half::FromBits, 0x0400); /*HALF_MIN*/
+    }
+    static constexpr IMATH_INTERNAL_NAMESPACE::half max () IMATH_NOEXCEPT
+    {
+        return IMATH_INTERNAL_NAMESPACE::half (IMATH_INTERNAL_NAMESPACE::half::FromBits, 0x7bff); /*HALF_MAX*/
+    }
+    static constexpr IMATH_INTERNAL_NAMESPACE::half lowest ()
+    {
+        return IMATH_INTERNAL_NAMESPACE::half (IMATH_INTERNAL_NAMESPACE::half::FromBits, 0xfbff); /* -HALF_MAX */
+    }
+
+    static constexpr int  digits       = HALF_MANT_DIG;
+    static constexpr int  digits10     = HALF_DIG;
+    static constexpr int  max_digits10 = HALF_DECIMAL_DIG;
+    static constexpr bool is_signed    = true;
+    static constexpr bool is_integer   = false;
+    static constexpr bool is_exact     = false;
+    static constexpr int  radix        = HALF_RADIX;
+    static constexpr IMATH_INTERNAL_NAMESPACE::half epsilon () IMATH_NOEXCEPT
+    {
+        return IMATH_INTERNAL_NAMESPACE::half (IMATH_INTERNAL_NAMESPACE::half::FromBits, 0x1400); /*HALF_EPSILON*/
+    }
+    static constexpr IMATH_INTERNAL_NAMESPACE::half round_error () IMATH_NOEXCEPT
+    {
+        return IMATH_INTERNAL_NAMESPACE::half (IMATH_INTERNAL_NAMESPACE::half::FromBits, 0x3800); /*0.5*/
+    }
+
+    static constexpr int min_exponent   = HALF_DENORM_MIN_EXP;
+    static constexpr int min_exponent10 = HALF_DENORM_MIN_10_EXP;
+    static constexpr int max_exponent   = HALF_MAX_EXP;
+    static constexpr int max_exponent10 = HALF_MAX_10_EXP;
+
+    static constexpr bool               has_infinity      = true;
+    static constexpr bool               has_quiet_NaN     = true;
+    static constexpr bool               has_signaling_NaN = true;
+    static constexpr float_denorm_style has_denorm        = denorm_present;
+    static constexpr bool               has_denorm_loss   = false;
+    static constexpr IMATH_INTERNAL_NAMESPACE::half               infinity () IMATH_NOEXCEPT
+    {
+        return IMATH_INTERNAL_NAMESPACE::half (IMATH_INTERNAL_NAMESPACE::half::FromBits, 0x7c00); /*half::posInf()*/
+    }
+    static constexpr IMATH_INTERNAL_NAMESPACE::half quiet_NaN () IMATH_NOEXCEPT
+    {
+        return IMATH_INTERNAL_NAMESPACE::half (IMATH_INTERNAL_NAMESPACE::half::FromBits, 0x7fff); /*half::qNan()*/
+    }
+    static constexpr IMATH_INTERNAL_NAMESPACE::half signaling_NaN () IMATH_NOEXCEPT
+    {
+        return IMATH_INTERNAL_NAMESPACE::half (IMATH_INTERNAL_NAMESPACE::half::FromBits, 0x7dff); /*half::sNan()*/
+    }
+    static constexpr IMATH_INTERNAL_NAMESPACE::half denorm_min () IMATH_NOEXCEPT
+    {
+        return IMATH_INTERNAL_NAMESPACE::half (IMATH_INTERNAL_NAMESPACE::half::FromBits, 0x0001); /*HALF_DENORM_MIN*/
+    }
+
+    static constexpr bool is_iec559  = false;
+    static constexpr bool is_bounded = false;
+    static constexpr bool is_modulo  = false;
+
+    static constexpr bool              traps           = true;
+    static constexpr bool              tinyness_before = false;
+    static constexpr float_round_style round_style     = round_to_nearest;
+};
+
+} // namespace std
+
 //----------
 // Debugging
 //----------

--- a/src/Imath/halfLimits.h
+++ b/src/Imath/halfLimits.h
@@ -3,101 +3,18 @@
 // Copyright Contributors to the OpenEXR Project.
 //
 
-//
-// Primary origin authors:
-//     Florian Kainz <kainz@ilm.com>
-//     Rod Bogart <rgb@ilm.com>
-//
-
 #ifndef INCLUDED_HALF_LIMITS_H
 #define INCLUDED_HALF_LIMITS_H
 
-//------------------------------------------------------------------------
 //
-//	C++ standard library-style numeric_limits for class half
+// This file is now deprecated. It previously included the
+// specialization of std::numeric_limits<half>, but those now appear
+// directly in half.h, because they should be regarded as inseperable
+// from the half class.
 //
-//------------------------------------------------------------------------
+
+#warning "ImathLimits is deprecated; use #include <half.h>"
 
 #include "half.h"
-#include <limits>
-
-/// @cond Doxygen_Suppress
-
-namespace std
-{
-
-template <> class numeric_limits<half>
-{
-public:
-    static const bool is_specialized = true;
-
-    static constexpr half min () IMATH_NOEXCEPT
-    {
-        return half (half::FromBits, 0x0400); /*HALF_MIN*/
-    }
-    static constexpr half max () IMATH_NOEXCEPT
-    {
-        return half (half::FromBits, 0x7bff); /*HALF_MAX*/
-    }
-    static constexpr half lowest ()
-    {
-        return half (half::FromBits, 0xfbff); /* -HALF_MAX */
-    }
-
-    static constexpr int  digits       = HALF_MANT_DIG;
-    static constexpr int  digits10     = HALF_DIG;
-    static constexpr int  max_digits10 = HALF_DECIMAL_DIG;
-    static constexpr bool is_signed    = true;
-    static constexpr bool is_integer   = false;
-    static constexpr bool is_exact     = false;
-    static constexpr int  radix        = HALF_RADIX;
-    static constexpr half epsilon () IMATH_NOEXCEPT
-    {
-        return half (half::FromBits, 0x1400); /*HALF_EPSILON*/
-    }
-    static constexpr half round_error () IMATH_NOEXCEPT
-    {
-        return half (half::FromBits, 0x3800); /*0.5*/
-    }
-
-    static constexpr int min_exponent   = HALF_DENORM_MIN_EXP;
-    static constexpr int min_exponent10 = HALF_DENORM_MIN_10_EXP;
-    static constexpr int max_exponent   = HALF_MAX_EXP;
-    static constexpr int max_exponent10 = HALF_MAX_10_EXP;
-
-    static constexpr bool               has_infinity      = true;
-    static constexpr bool               has_quiet_NaN     = true;
-    static constexpr bool               has_signaling_NaN = true;
-    static constexpr float_denorm_style has_denorm        = denorm_present;
-    static constexpr bool               has_denorm_loss   = false;
-    static constexpr half               infinity () IMATH_NOEXCEPT
-    {
-        return half (half::FromBits, 0x7c00); /*half::posInf()*/
-    }
-    static constexpr half quiet_NaN () IMATH_NOEXCEPT
-    {
-        return half (half::FromBits, 0x7fff); /*half::qNan()*/
-    }
-    static constexpr half signaling_NaN () IMATH_NOEXCEPT
-    {
-        return half (half::FromBits, 0x7dff); /*half::sNan()*/
-    }
-    static constexpr half denorm_min () IMATH_NOEXCEPT
-    {
-        return half (half::FromBits, 0x0001); /*HALF_DENORM_MIN*/
-    }
-
-    static constexpr bool is_iec559  = false;
-    static constexpr bool is_bounded = false;
-    static constexpr bool is_modulo  = false;
-
-    static constexpr bool              traps           = true;
-    static constexpr bool              tinyness_before = false;
-    static constexpr float_round_style round_style     = round_to_nearest;
-};
-
-/// @endcond
-
-} // namespace std
 
 #endif

--- a/src/ImathTest/testLimits.cpp
+++ b/src/ImathTest/testLimits.cpp
@@ -8,7 +8,7 @@
 #endif
 
 #include "testLimits.h"
-#include "halfLimits.h"
+#include "half.h"
 #include <assert.h>
 #include <cmath>
 #include <iostream>


### PR DESCRIPTION
Previously, these specializations have been in the header `halfLimit.h`,
but without this header, the` numeric_limits<>` template provides
default specializations that return 0, so, for example,
`std::numeric_limits<half>::min()` would silently return 0 in code that
inadvertently omitted the `#include <halfLimits.h>`.

The `numeric_limits` specializations should be considered an inseparable
part of the class definition.

This change moves the specializations directly into half.h and
deprecates the `halfLimits.h` header altogether. For backwards
compatibility, it includes `half.h` with a warning.

An alternative would be to keep `halfLimits.h` and include it in `half.h`,
but then each header would include the other circularly, which is
awkward.

Should address #240.

Signed-off-by: Cary Phillips <cary@ilm.com>