### PR TITLE
Fix 32-bit x86 build failure with 16c instructions

### DIFF
--- a/src/Imath/half.h
+++ b/src/Imath/half.h
@@ -181,6 +181,8 @@
 #    include <intrin.h>
 #elif defined(__x86_64__)
 #    include <x86intrin.h>
+#elif defined(__F16C__)
+#    include <immintrin.h>
 #endif
 
 #include <stdint.h>


### PR DESCRIPTION
Add:
```
    #if defined(__F16C__)
    #        include <immintrin.h>
```
to the logic in half.h for including intrinsics header, which catches the i386 case.

Should address #239.

Signed-off-by: Cary Phillips <cary@ilm.com>