### PR TITLE
Use _WIN32 instead of _MSC_VER to fix mingw build

### DIFF
--- a/src/ImathTest/half_perf_test.cpp
+++ b/src/ImathTest/half_perf_test.cpp
@@ -3,7 +3,7 @@
 // Copyright Contributors to the OpenEXR Project.
 //
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #    define _CRT_RAND_S
 #endif
 
@@ -14,7 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #    include <windows.h>
 #else
 #    include <time.h>
@@ -25,7 +25,7 @@
 static const unsigned short imath_float_half_exp_table[1 << 9] =
 #include "eLut.h"
 
-    using namespace IMATH_NAMESPACE;
+using namespace IMATH_NAMESPACE;
 
 #ifdef IMATH_USE_HALF_LOOKUP_TABLE
 
@@ -271,7 +271,7 @@ exptable_half_constructor (float f)
 int64_t
 get_ticks (void)
 {
-#ifdef _MSC_VER
+#ifdef _WIN32
     static uint64_t scale = 0;
     if (scale == 0)
     {
@@ -387,7 +387,7 @@ main (int argc, char* argv[])
             perf_test_half_to_float (floats, halfs, numentries);
 
             // test float -> half with real-world values
-#ifdef _MSC_VER
+#ifdef _WIN32
             unsigned int rv;
             for (int i = 0; i < numentries; ++i)
             {

--- a/src/ImathTest/half_perf_test.cpp
+++ b/src/ImathTest/half_perf_test.cpp
@@ -25,7 +25,7 @@
 static const unsigned short imath_float_half_exp_table[1 << 9] =
 #include "eLut.h"
 
-using namespace IMATH_NAMESPACE;
+    using namespace IMATH_NAMESPACE;
 
 #ifdef IMATH_USE_HALF_LOOKUP_TABLE
 


### PR DESCRIPTION
Addresses #233. 

I looked at other usage of _MSC_VER and didn't see anything obviously amiss, but Windows/mingw users please confirm.

Signed-off-by: Cary Phillips <cary@ilm.com>