### PR TITLE
Do not warn if half.h has already being included

### DIFF
--- a/src/Imath/halfLimits.h
+++ b/src/Imath/halfLimits.h
@@ -6,6 +6,8 @@
 #ifndef INCLUDED_HALF_LIMITS_H
 #define INCLUDED_HALF_LIMITS_H
 
+// Warn if half.h hasn't being included
+#ifndef IMATH_HALF_H_
 //
 // This file is now deprecated. It previously included the
 // specialization of std::numeric_limits<half>, but those now appear
@@ -20,5 +22,5 @@
 #endif
 
 #include "half.h"
-
+#endif
 #endif


### PR DESCRIPTION
The issue with the warning of halfLimits.h being deprecated is that it
is very tempting to simply remove the include of halfLimits.h in favor
of simply half.h. However this change does depends on the version of
Imath used, and halfLimits.h should be kept for compatibility with
older version. Simply do not warn if short.h is already included.
