### PR TITLE
Cuda safety in several headers

### DIFF
--- a/src/Imath/ImathColor.h
+++ b/src/Imath/ImathColor.h
@@ -50,7 +50,7 @@ public:
     IMATH_HOSTDEVICE constexpr Color3 (const Vec3<S>& v) IMATH_NOEXCEPT;
 
     /// Destructor
-    IMATH_HOSTDEVICE ~Color3 () = default;
+    ~Color3() = default;
 
     /// Component-wise assignment
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color3&
@@ -156,7 +156,7 @@ public:
         IMATH_NOEXCEPT;
 
     /// Destructor
-    IMATH_HOSTDEVICE ~Color4 () = default;
+    ~Color4() = default;
 
     /// Assignment
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 const Color4&

--- a/src/Imath/ImathEuler.h
+++ b/src/Imath/ImathEuler.h
@@ -239,7 +239,7 @@ public:
     Euler (const Matrix44<T>&, Order o = Default) IMATH_NOEXCEPT;
 
     /// Destructor
-    IMATH_HOSTDEVICE ~Euler () = default;
+    ~Euler () = default;
 
     /// @}
 

--- a/src/Imath/ImathQuat.h
+++ b/src/Imath/ImathQuat.h
@@ -89,7 +89,7 @@ public:
     operator= (const Quat<T>& q) IMATH_NOEXCEPT;
 
     /// Destructor
-    IMATH_HOSTDEVICE ~Quat () IMATH_NOEXCEPT = default;
+    ~Quat () IMATH_NOEXCEPT = default;
 
     /// @}
 

--- a/src/Imath/ImathShear.h
+++ b/src/Imath/ImathShear.h
@@ -165,7 +165,7 @@ public:
     operator= (const Vec3<S>& v);
 
     /// Destructor
-    IMATH_HOSTDEVICE ~Shear6 () = default;
+    ~Shear6() = default;
 
     /// @}
 

--- a/src/Imath/half.h
+++ b/src/Imath/half.h
@@ -177,7 +177,9 @@
 /// floats in question.
 ///
 
-#ifdef _WIN32
+#ifdef __CUDA_ARCH__
+// do not include intrinsics headers on Cuda
+#elif defined(_WIN32)
 #    include <intrin.h>
 #elif defined(__x86_64__)
 #    include <x86intrin.h>


### PR DESCRIPTION
* Hide x86 intrinsics from Cuda compilation (half.h) that is a hard
  error when compiling for Cuda.

* Avoid warnings about host/device decorations for defaulted
  destructors for Color3, Color4, Euler, Quat, and Shear classes -- if
  you define the destructor as `= default`, you shouldn't also add the
  IMATH_HOSTDEVICE decorator.

Signed-off-by: Larry Gritz <lg@larrygritz.com>