### PR TITLE
Test return value of extractSHRT to avoid uninitialized reference

### DIFF
--- a/src/Imath/ImathMatrixAlgo.h
+++ b/src/Imath/ImathMatrixAlgo.h
@@ -1128,7 +1128,8 @@ computeRSMatrix (
     extractSHRT (A, as, ah, ar, at);
 
     Vec3<T> bs, bh, br, bt;
-    extractSHRT (B, bs, bh, br, bt);
+    if (!extractSHRT (B, bs, bh, br, bt))
+        throw std::domain_error ("degenerate B matrix in computeRSMatrix");
 
     if (!keepRotateA) ar = br;
 

--- a/src/ImathTest/testExtractSHRT.cpp
+++ b/src/ImathTest/testExtractSHRT.cpp
@@ -206,7 +206,11 @@ testMatrix (const M44f M)
 
     V3f s, h, r, t;
 
-    extractSHRT (M, s, h, r, t, true);
+    if (!extractSHRT (M, s, h, r, t, true))
+    {
+        cout << "Unable to extractSHRT" << std::endl;
+        assert (false);
+    }
 
     M44f N;
 


### PR DESCRIPTION
If extractSHRT failes in computeRSMatrix, it's an error, so throw.

If extractSHRT fails in testMatrix in testExtractSHRT.cpp, it's fatal. The test was present for testMatrix(M33f) but missing for testMatrix(M44f). This lead to an uninitialized memory refererence since the failure leaves the arguments uninitialized.

Signed-off-by: Cary Phillips <cary@ilm.com>