### PR TITLE
Fix gcc compiler warning in testFun.cpp

### DIFF
--- a/src/ImathTest/testFun.cpp
+++ b/src/ImathTest/testFun.cpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <iostream>
 #include <stdio.h>
+#include <inttypes.h>
 
 using namespace std;
 
@@ -47,11 +48,11 @@ testf (float f, bool changeExpected = true)
     float psf =
         IMATH_INTERNAL_NAMESPACE::predf (IMATH_INTERNAL_NAMESPACE::succf (f));
 
-    printf ("f %.9g %x\n", f, bit_cast<uint32_t> (f));
-    printf ("sf %.9g %x\n", sf, bit_cast<uint32_t> (sf));
-    printf ("pf %.9g %x\n", pf, bit_cast<uint32_t> (pf));
-    printf ("spf %.9g %x\n", spf, bit_cast<uint32_t> (spf));
-    printf ("psf %.9g %x\n", psf, bit_cast<uint32_t> (psf));
+    printf ("f %.9g %" PRIx32 "\n", f, bit_cast<uint32_t> (f));
+    printf ("sf %.9g %" PRIx32 "\n", sf, bit_cast<uint32_t> (sf));
+    printf ("pf %.9g %" PRIx32 "\n", pf, bit_cast<uint32_t> (pf));
+    printf ("spf %.9g %" PRIx32 "\n", spf, bit_cast<uint32_t> (spf));
+    printf ("psf %.9g %" PRIx32 "\n", psf, bit_cast<uint32_t> (psf));
 
     fflush (stdout);
 
@@ -90,11 +91,11 @@ testd (double d, bool changeExpected = true)
     double psd =
         IMATH_INTERNAL_NAMESPACE::predd (IMATH_INTERNAL_NAMESPACE::succd (d));
 
-    printf ("d   %0.18lg %llx\n", d, bit_cast<unsigned long long> (d));
-    printf ("sd  %0.18lg %llx\n", sd, bit_cast<unsigned long long> (sd));
-    printf ("pd  %0.18lg %llx\n", pd, bit_cast<unsigned long long> (pd));
-    printf ("spd %0.18lg %llx\n", spd, bit_cast<unsigned long long> (spd));
-    printf ("psd %0.18lg %llx\n", psd, bit_cast<unsigned long long> (psd));
+    printf ("d   %0.18lg %" PRIx64 "\n", d, bit_cast<uint64_t> (d));
+    printf ("sd  %0.18lg %" PRIx64 "\n", sd, bit_cast<uint64_t> (sd));
+    printf ("pd  %0.18lg %" PRIx64 "\n", pd, bit_cast<uint64_t> (pd));
+    printf ("spd %0.18lg %" PRIx64 "\n", spd, bit_cast<uint64_t> (spd));
+    printf ("psd %0.18lg %" PRIx64 "\n", psd, bit_cast<uint64_t> (psd));
 
     fflush (stdout);
 

--- a/src/ImathTest/testFun.cpp
+++ b/src/ImathTest/testFun.cpp
@@ -90,11 +90,11 @@ testd (double d, bool changeExpected = true)
     double psd =
         IMATH_INTERNAL_NAMESPACE::predd (IMATH_INTERNAL_NAMESPACE::succd (d));
 
-    printf ("d   %0.18lg %lx\n", d, bit_cast<unsigned long> (d));
-    printf ("sd  %0.18lg %lx\n", sd, bit_cast<unsigned long> (sd));
-    printf ("pd  %0.18lg %lx\n", pd, bit_cast<unsigned long> (pd));
-    printf ("spd %0.18lg %lx\n", spd, bit_cast<unsigned long> (spd));
-    printf ("psd %0.18lg %lx\n", psd, bit_cast<unsigned long> (psd));
+    printf ("d   %0.18lg %llx\n", d, bit_cast<unsigned long long> (d));
+    printf ("sd  %0.18lg %llx\n", sd, bit_cast<unsigned long long> (sd));
+    printf ("pd  %0.18lg %llx\n", pd, bit_cast<unsigned long long> (pd));
+    printf ("spd %0.18lg %llx\n", spd, bit_cast<unsigned long long> (spd));
+    printf ("psd %0.18lg %llx\n", psd, bit_cast<unsigned long long> (psd));
 
     fflush (stdout);
 

--- a/src/ImathTest/testFun.cpp
+++ b/src/ImathTest/testFun.cpp
@@ -90,11 +90,11 @@ testd (double d, bool changeExpected = true)
     double psd =
         IMATH_INTERNAL_NAMESPACE::predd (IMATH_INTERNAL_NAMESPACE::succd (d));
 
-    printf ("d   %0.18lg %llx\n", d, bit_cast<uint64_t> (d));
-    printf ("sd  %0.18lg %llx\n", sd, bit_cast<uint64_t> (sd));
-    printf ("pd  %0.18lg %llx\n", pd, bit_cast<uint64_t> (pd));
-    printf ("spd %0.18lg %llx\n", spd, bit_cast<uint64_t> (spd));
-    printf ("psd %0.18lg %llx\n", psd, bit_cast<uint64_t> (psd));
+    printf ("d   %0.18lg %lx\n", d, bit_cast<unsigned long> (d));
+    printf ("sd  %0.18lg %lx\n", sd, bit_cast<unsigned long> (sd));
+    printf ("pd  %0.18lg %lx\n", pd, bit_cast<unsigned long> (pd));
+    printf ("spd %0.18lg %lx\n", spd, bit_cast<unsigned long> (spd));
+    printf ("psd %0.18lg %lx\n", psd, bit_cast<unsigned long> (psd));
 
     fflush (stdout);
 


### PR DESCRIPTION
PR #250 changed the %lx to %llx to suppress an MSVC warning, but it
introduced a gcc warning, where uint64_t is long, not long
long. Better to leave it as %lx and just cast to long. It's only a
printf anyway.

Signed-off-by: Cary Phillips <cary@ilm.com>