### PR TITLE
add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 _build/
 _install/
+.envrc


### PR DESCRIPTION
direnv (https://github.com/direnv/direnv) can be used for local developer workflow enhancements.  direnv uses .envrc file for configuration.  Because .envrc is usually specific to a developer workflow, it is generally not committed.

Signed-off-by: Mark Sisson <5761292+marksisson@users.noreply.github.com>