### PR TITLE
fix memory leak in V3fArrayFromBuffer

### DIFF
--- a/src/python/PyImath/PyImathBufferProtocol.cpp
+++ b/src/python/PyImath/PyImathBufferProtocol.cpp
@@ -361,6 +361,7 @@ fixedArrayFromBuffer (PyObject *obj)
 
     ArrayT *array = new ArrayT (view.shape[0], PyImath::UNINITIALIZED);
     memcpy (&array->direct_index(0), view.buf, view.len);
+    PyBuffer_Release(&view);
 
     return array;
 }


### PR DESCRIPTION
Courtesy of @cbreak-black, #266 

https://docs.python.org/3/c-api/buffer.html#c.PyBuffer_Release
https://docs.python.org/3/c-api/arg.html

> However, when a [Py_buffer](https://docs.python.org/3/c-api/buffer.html#c.Py_buffer) structure gets filled, the underlying buffer is locked so that the caller can subsequently use the buffer even inside a [Py_BEGIN_ALLOW_THREADS](https://docs.python.org/3/c-api/init.html#c.Py_BEGIN_ALLOW_THREADS) block without the risk of mutable data being resized or destroyed. As a result, you have to call [PyBuffer_Release()](https://docs.python.org/3/c-api/buffer.html#c.PyBuffer_Release) after you have finished processing the data (or in any early abort case).



Signed-off-by: Cary Phillips <cary@ilm.com>