### PR TITLE
Remove export attribute from inline half::bits()/setBits()

### DIFF
--- a/src/Imath/half.h
+++ b/src/Imath/half.h
@@ -619,10 +619,10 @@ public:
     /// @name Access to the internal representation
 
     /// Return the bit pattern
-    IMATH_EXPORT constexpr uint16_t bits () const IMATH_NOEXCEPT;
+    constexpr uint16_t bits () const IMATH_NOEXCEPT;
 
     /// Set the bit pattern
-    IMATH_EXPORT IMATH_CONSTEXPR14 void setBits (uint16_t bits) IMATH_NOEXCEPT;
+    IMATH_CONSTEXPR14 void setBits (uint16_t bits) IMATH_NOEXCEPT;
 
     /// @}
 


### PR DESCRIPTION
Meaningless, and generates a warning under MinGW

Should resolve #272 

Signed-off-by: Cary Phillips <cary@ilm.com>