### PR TITLE
Use Py_ssize_t in place of size_t where appropriate to avoid warnings

### DIFF
--- a/src/python/PyImath/PyImathBufferProtocol.cpp
+++ b/src/python/PyImath/PyImathBufferProtocol.cpp
@@ -56,7 +56,7 @@ class BufferAPI
     {
         shape[0]  = Py_ssize_t (length);
         stride[0] = atomicSize() * FixedArrayWidth<T>::value * interleave;
-        for (unsigned int d=1; d<dimensions; d++)
+        for (int d=1; d<dimensions; d++)
         {
             shape[d]  = FixedArrayWidth<T>::value * interleave;
             stride[d] = atomicSize();
@@ -360,7 +360,7 @@ fixedArrayFromBuffer (PyObject *obj)
     }
 
     ArrayT *array = new ArrayT (view.shape[0], PyImath::UNINITIALIZED);
-    memcpy (&array->direct_index(0), view.buf, view.len);
+    memcpy (reinterpret_cast<void*>(&array->direct_index(0)), view.buf, view.len);
     PyBuffer_Release(&view);
 
     return array;

--- a/src/python/PyImath/PyImathFixedArray.h
+++ b/src/python/PyImath/PyImathFixedArray.h
@@ -550,7 +550,7 @@ class FixedArray
         }
         else
         {
-            size_t count = 0;
+            Py_ssize_t count = 0;
             for (size_t i = 0; i < len; ++i)
                 if (mask[i]) count++;
 
@@ -691,7 +691,7 @@ class FixedArray
             throwExc = true;
         else if (isMaskedReference())
         {
-            if (_unmaskedLength != a1.len())
+            if (static_cast<Py_ssize_t>(_unmaskedLength) != a1.len())
                 throwExc = true;
         }
         else

--- a/src/python/PyImath/PyImathFixedVArray.cpp
+++ b/src/python/PyImath/PyImathFixedVArray.cpp
@@ -367,19 +367,19 @@ FixedVArray<T>::setitem_scalar (PyObject* index, const FixedArray<T>& data)
         for (size_t i = 0; i < sliceLength; ++i)
         {
             std::vector<T> &d =_ptr[raw_ptr_index(start + i*step)*_stride];
-            if (data.len() != d.size())
+            if (data.len() != static_cast<Py_ssize_t>(d.size()))
                 throw std::invalid_argument("FixedVArray::setitem: length of data does not match length of array element");
 
             if (data.isMaskedReference())
             {
-                for (size_t j = 0; j < data.len(); ++j)
+                for (Py_ssize_t j = 0; j < data.len(); ++j)
                 {
                     d[j] = data[j];
                 }
             }
             else
             {
-                for (size_t j = 0; j < data.len(); ++j)
+                for (Py_ssize_t j = 0; j < data.len(); ++j)
                 {
                     d[j] = data.direct_index(j);
                 }
@@ -391,19 +391,19 @@ FixedVArray<T>::setitem_scalar (PyObject* index, const FixedArray<T>& data)
         for (size_t i = 0; i < sliceLength; ++i)
         {
             std::vector<T> &d =_ptr[(start + i*step)*_stride];
-            if (data.len() != d.size())
+            if (data.len() != static_cast<Py_ssize_t>(d.size()))
                 throw std::invalid_argument("FixedVArray::setitem: length of data does not match length of array element");
 
             if (data.isMaskedReference())
             {
-                for (size_t j = 0; j < data.len(); ++j)
+                for (Py_ssize_t j = 0; j < data.len(); ++j)
                 {
                     d[j] = data[j];
                 }
             }
             else
             {
-                for (size_t j = 0; j < data.len(); ++j)
+                for (Py_ssize_t j = 0; j < data.len(); ++j)
                 {
                     d[j] = data.direct_index(j);
                 }
@@ -428,19 +428,19 @@ FixedVArray<T>::setitem_scalar_mask (const FixedArray<int>& mask, const FixedArr
             // We don't need to actually look at 'mask' because
             // match_dimensions has already forced some expected condition.
             std::vector<T> &d =_ptr[raw_ptr_index(i)*_stride];
-            if (data.len() != d.size())
+            if (data.len() != static_cast<Py_ssize_t>(d.size()))
                 throw std::invalid_argument("FixedVArray::setitem: length of data does not match length of array element");
 
             if (data.isMaskedReference())
             {
-                for (size_t j = 0; j < data.len(); ++j)
+                for (Py_ssize_t j = 0; j < data.len(); ++j)
                 {
                     d[j] = data[j];
                 }
             }
             else
             {
-                for (size_t j = 0; j < data.len(); ++j)
+                for (Py_ssize_t j = 0; j < data.len(); ++j)
                 {
                     d[j] = data.direct_index(j);
                 }
@@ -454,19 +454,19 @@ FixedVArray<T>::setitem_scalar_mask (const FixedArray<int>& mask, const FixedArr
             if (mask[i])
             {
                 std::vector<T> &d = _ptr[i*_stride];
-                if (data.len() != d.size())
+                if (data.len() != static_cast<Py_ssize_t>(d.size()))
                     throw std::invalid_argument("FixedVArray::setitem: length of data does not match length of array element");
 
                 if (data.isMaskedReference())
                 {
-                    for (size_t j = 0; j < data.len(); ++j)
+                    for (Py_ssize_t j = 0; j < data.len(); ++j)
                     {
                         d[j] = data[j];
                     }
                 }
                 else
                 {
-                    for (size_t j = 0; j < data.len(); ++j)
+                    for (Py_ssize_t j = 0; j < data.len(); ++j)
                     {
                         d[j] = data.direct_index(j);
                     }
@@ -623,7 +623,7 @@ FixedVArray<T>::SizeHelper::getitem_mask (const FixedArray<int>& mask) const
     }
     
     int count = 0;
-    for (size_t i = 0; i < mask.len(); ++i)
+    for (Py_ssize_t i = 0; i < mask.len(); ++i)
     {
         if (mask[i]) count += 1;
     }
@@ -633,7 +633,7 @@ FixedVArray<T>::SizeHelper::getitem_mask (const FixedArray<int>& mask) const
     if (_a._indices)
     {
         size_t index = 0;
-        for (size_t i = 0; i < mask.len(); ++i)
+        for (Py_ssize_t i = 0; i < mask.len(); ++i)
         {
             if (mask[i])
             {
@@ -645,7 +645,7 @@ FixedVArray<T>::SizeHelper::getitem_mask (const FixedArray<int>& mask) const
     else
     {
         size_t index = 0;
-        for (size_t i = 0; i < mask.len(); ++i)
+        for (Py_ssize_t i = 0; i < mask.len(); ++i)
         {
             if (mask[i])
             {
@@ -730,7 +730,7 @@ FixedVArray<T>::SizeHelper::setitem_vector(PyObject *index, const FixedArray<int
     extract_slice_indices(index,start,end,step,slicelength,_a._length);
         
     // we have a valid range of indices
-    if (size.len() != slicelength) {
+    if (size.len() != static_cast<Py_ssize_t>(slicelength)) {
         PyErr_SetString(PyExc_IndexError, "Dimensions of source do not match destination");
         boost::python::throw_error_already_set();
     }
@@ -762,16 +762,16 @@ FixedVArray<T>::SizeHelper::setitem_vector_mask(const FixedArray<int> &mask, con
         throw std::invalid_argument("We don't support setting item masks for masked reference arrays.");
     }
 
-    size_t len = _a.match_dimension(mask);
+    Py_ssize_t len = _a.match_dimension(mask);
     if (size.len() == len)
     {
-        for (size_t i = 0; i < len; ++i)
+        for (Py_ssize_t i = 0; i < len; ++i)
             if (mask[i]) _a._ptr[i*_a._stride].resize(size[i]);
     }
     else
     {
-        size_t count = 0;
-        for (size_t i = 0; i < len; ++i)
+        Py_ssize_t count = 0;
+        for (Py_ssize_t i = 0; i < len; ++i)
             if (mask[i]) count++;
 
         if (size.len() != count) {
@@ -779,7 +779,7 @@ FixedVArray<T>::SizeHelper::setitem_vector_mask(const FixedArray<int> &mask, con
         }
 
         Py_ssize_t sizeIndex = 0;
-        for (size_t i = 0; i < len; ++i)
+        for (Py_ssize_t i = 0; i < len; ++i)
         {
             if (mask[i])
             {

--- a/src/python/PyImath/PyImathMatrix33.cpp
+++ b/src/python/PyImath/PyImathMatrix33.cpp
@@ -1093,7 +1093,7 @@ M33Array_constructor(const FixedArray<T> &a, const FixedArray<T> &b, const Fixed
                      const FixedArray<T> &g, const FixedArray<T> &h, const FixedArray<T> &i)
 {
     MATH_EXC_ON;
-    size_t len = a.len();
+    Py_ssize_t len = a.len();
     if (!( a.len() == len && b.len() == len && c.len() == len && 
            d.len() == len && e.len() == len && f.len() == len && 
            g.len() == len && h.len() == len && i.len() == len))

--- a/src/python/PyImath/PyImathMatrix44.cpp
+++ b/src/python/PyImath/PyImathMatrix44.cpp
@@ -1187,7 +1187,7 @@ M44Array_constructor(const FixedArray<T> &a, const FixedArray<T> &b, const Fixed
                      const FixedArray<T> &m, const FixedArray<T> &n, const FixedArray<T> &o, const FixedArray<T> &p)
 {
     MATH_EXC_ON;
-    size_t len = a.len();
+    Py_ssize_t len = a.len();
     if (!( a.len() == len && b.len() == len && c.len() == len && d.len() == len && 
             e.len() == len && f.len() == len && g.len() == len && h.len() == len && 
             i.len() == len && j.len() == len && k.len() == len && l.len() == len && 


### PR DESCRIPTION
Signed-off-by: Cary Phillips <cary@ilm.com>