### PR TITLE
Define BOOST_BIND_GLOBAL_PLACEHOLDERS to suppress pragma message

### DIFF
--- a/src/python/PyImath/PyImathAutovectorize.h
+++ b/src/python/PyImath/PyImathAutovectorize.h
@@ -10,6 +10,7 @@
 #define _PyImathAutovectorize_h_
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/mpl/size.hpp>
 #include <boost/mpl/pop_front.hpp>

--- a/src/python/PyImath/PyImathBasicTypes.cpp
+++ b/src/python/PyImath/PyImathBasicTypes.cpp
@@ -6,6 +6,7 @@
 // clang-format off
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include "PyImath.h"
 #include "PyImathExport.h"

--- a/src/python/PyImath/PyImathBox.h
+++ b/src/python/PyImath/PyImathBox.h
@@ -9,6 +9,7 @@
 #define _PyImathBox_h_
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <ImathBox.h>
 #include "PyImathVec.h"

--- a/src/python/PyImath/PyImathBoxArrayImpl.h
+++ b/src/python/PyImath/PyImathBoxArrayImpl.h
@@ -15,6 +15,7 @@
 //
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathBufferProtocol.h
+++ b/src/python/PyImath/PyImathBufferProtocol.h
@@ -8,6 +8,7 @@
 #ifndef _PyImathBufferProtocol_h_
 #define _PyImathBufferProtocol_h_
 
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 
 namespace PyImath {

--- a/src/python/PyImath/PyImathColor.h
+++ b/src/python/PyImath/PyImathColor.h
@@ -9,6 +9,7 @@
 #define _PyImathColor3_h_
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <ImathColor.h>
 #include "PyImath.h"

--- a/src/python/PyImath/PyImathColor3.cpp
+++ b/src/python/PyImath/PyImathColor3.cpp
@@ -12,6 +12,7 @@
 //
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathColor3ArrayImpl.h
+++ b/src/python/PyImath/PyImathColor3ArrayImpl.h
@@ -15,6 +15,7 @@
 //
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathColor4.cpp
+++ b/src/python/PyImath/PyImathColor4.cpp
@@ -6,6 +6,7 @@
 // clang-format off
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathColor4Array2DImpl.h
+++ b/src/python/PyImath/PyImathColor4Array2DImpl.h
@@ -15,6 +15,7 @@
 //
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathColor4ArrayImpl.h
+++ b/src/python/PyImath/PyImathColor4ArrayImpl.h
@@ -15,6 +15,7 @@
 //
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathDecorators.h
+++ b/src/python/PyImath/PyImathDecorators.h
@@ -8,6 +8,7 @@
 #ifndef INCLUDED_PYIMATH_DECORATORS_H
 #define INCLUDED_PYIMATH_DECORATORS_H
 
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 
 namespace PyImath

--- a/src/python/PyImath/PyImathEuler.cpp
+++ b/src/python/PyImath/PyImathEuler.cpp
@@ -6,6 +6,7 @@
 // clang-format off
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathEuler.h
+++ b/src/python/PyImath/PyImathEuler.h
@@ -9,6 +9,7 @@
 #define _PyImathEuler_h_
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <ImathEuler.h>
 #include <ImathVec.h>

--- a/src/python/PyImath/PyImathFixedArray.h
+++ b/src/python/PyImath/PyImathFixedArray.h
@@ -8,6 +8,7 @@
 #ifndef _PyImathFixedArray_h_
 #define _PyImathFixedArray_h_
 
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/operators.hpp>
 #include <boost/shared_array.hpp>

--- a/src/python/PyImath/PyImathFixedArray2D.h
+++ b/src/python/PyImath/PyImathFixedArray2D.h
@@ -8,6 +8,7 @@
 #ifndef _PyImathFixedArray2D_h_
 #define _PyImathFixedArray2D_h_
 
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/operators.hpp>
 #include <boost/shared_array.hpp>

--- a/src/python/PyImath/PyImathFixedMatrix.h
+++ b/src/python/PyImath/PyImathFixedMatrix.h
@@ -8,6 +8,7 @@
 #ifndef _PyImathFixedMatrix_h_
 #define _PyImathFixedMatrix_h_
 
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <iostream>
 #include "PyImathFixedArray.h"

--- a/src/python/PyImath/PyImathFixedVArray.cpp
+++ b/src/python/PyImath/PyImathFixedVArray.cpp
@@ -6,6 +6,7 @@
 // clang-format off
 
 
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/shared_array.hpp>
 #include <boost/any.hpp>

--- a/src/python/PyImath/PyImathFixedVArray.h
+++ b/src/python/PyImath/PyImathFixedVArray.h
@@ -8,6 +8,7 @@
 #ifndef _PyImathFixedVArray_h_
 #define _PyImathFixedVArray_h_
 
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/any.hpp>
 #include <vector>

--- a/src/python/PyImath/PyImathFrustum.cpp
+++ b/src/python/PyImath/PyImathFrustum.cpp
@@ -6,6 +6,7 @@
 // clang-format off
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/format.hpp>
 #include "PyImath.h"

--- a/src/python/PyImath/PyImathFrustum.h
+++ b/src/python/PyImath/PyImathFrustum.h
@@ -9,6 +9,7 @@
 #define _PyImathFrustum_h_
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <ImathFrustum.h>
 #include <ImathFrustumTest.h>

--- a/src/python/PyImath/PyImathFun.cpp
+++ b/src/python/PyImath/PyImathFun.cpp
@@ -6,6 +6,7 @@
 // clang-format off
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathLine.cpp
+++ b/src/python/PyImath/PyImathLine.cpp
@@ -6,6 +6,7 @@
 // clang-format off
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathLine.h
+++ b/src/python/PyImath/PyImathLine.h
@@ -9,6 +9,7 @@
 #define _PyImathLine_h_
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <ImathLine.h>
 #include "PyImath.h"

--- a/src/python/PyImath/PyImathMatrix.h
+++ b/src/python/PyImath/PyImathMatrix.h
@@ -9,6 +9,7 @@
 #define _PyImathMatrix_h_
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <ImathMatrix.h>
 #include <ImathMatrixAlgo.h>

--- a/src/python/PyImath/PyImathMatrix22.cpp
+++ b/src/python/PyImath/PyImathMatrix22.cpp
@@ -8,6 +8,7 @@
 #define BOOST_PYTHON_MAX_ARITY 17
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathMatrix33.cpp
+++ b/src/python/PyImath/PyImathMatrix33.cpp
@@ -8,6 +8,7 @@
 #define BOOST_PYTHON_MAX_ARITY 17
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathMatrix44.cpp
+++ b/src/python/PyImath/PyImathMatrix44.cpp
@@ -8,6 +8,7 @@
 #define BOOST_PYTHON_MAX_ARITY 17
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathPlane.cpp
+++ b/src/python/PyImath/PyImathPlane.cpp
@@ -6,6 +6,7 @@
 // clang-format off
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathPlane.h
+++ b/src/python/PyImath/PyImathPlane.h
@@ -9,6 +9,7 @@
 #define _PyImathPlane_h_
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <ImathPlane.h>
 #include "PyImath.h"

--- a/src/python/PyImath/PyImathQuat.cpp
+++ b/src/python/PyImath/PyImathQuat.cpp
@@ -6,6 +6,7 @@
 // clang-format off
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathQuat.h
+++ b/src/python/PyImath/PyImathQuat.h
@@ -9,6 +9,7 @@
 #define _PyImathQuat_h_
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <ImathQuat.h>
 #include <ImathVec.h>

--- a/src/python/PyImath/PyImathRandom.cpp
+++ b/src/python/PyImath/PyImathRandom.cpp
@@ -6,6 +6,7 @@
 // clang-format off
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/format.hpp>
 #include <boost/python/make_constructor.hpp>

--- a/src/python/PyImath/PyImathRandom.h
+++ b/src/python/PyImath/PyImathRandom.h
@@ -9,6 +9,7 @@
 #define _PyImathRandom_h_
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <ImathRandom.h>
 #include "PyImathExport.h"

--- a/src/python/PyImath/PyImathShear.cpp
+++ b/src/python/PyImath/PyImathShear.cpp
@@ -6,6 +6,7 @@
 // clang-format off
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathShear.h
+++ b/src/python/PyImath/PyImathShear.h
@@ -9,6 +9,7 @@
 #define _PyImathShear_h_
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <ImathShear.h>
 

--- a/src/python/PyImath/PyImathUtil.cpp
+++ b/src/python/PyImath/PyImathUtil.cpp
@@ -5,6 +5,7 @@
 
 // clang-format off
 
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <pystate.h>
 #include "PyImathUtil.h"

--- a/src/python/PyImath/PyImathVec.h
+++ b/src/python/PyImath/PyImathVec.h
@@ -9,6 +9,7 @@
 #define _PyImathVec_h_
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <ImathVec.h>
 #include "PyImath.h"

--- a/src/python/PyImath/PyImathVec2Impl.h
+++ b/src/python/PyImath/PyImathVec2Impl.h
@@ -15,6 +15,7 @@
 //
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathVec3ArrayImpl.h
+++ b/src/python/PyImath/PyImathVec3ArrayImpl.h
@@ -15,6 +15,7 @@
 //
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathVec3Impl.h
+++ b/src/python/PyImath/PyImathVec3Impl.h
@@ -15,6 +15,7 @@
 //
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathVec4ArrayImpl.h
+++ b/src/python/PyImath/PyImathVec4ArrayImpl.h
@@ -15,6 +15,7 @@
 //
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/PyImathVec4Impl.h
+++ b/src/python/PyImath/PyImathVec4Impl.h
@@ -15,6 +15,7 @@
 //
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>

--- a/src/python/PyImath/imathmodule.cpp
+++ b/src/python/PyImath/imathmodule.cpp
@@ -6,6 +6,7 @@
 // clang-format off
 
 #include <Python.h>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/format.hpp>


### PR DESCRIPTION
Boost (prior to 1.77?) reports the following message when including `<boost/python.hpp>`:

    /usr/include/boost/bind.hpp:36:1: note: #pragma message: The
    practice of declaring the Bind placeholders (_1, _2, ...) in the
    global namespace is deprecated. Please use <boost/bind/bind.hpp> +
    using namespace boost::placeholders, or define
    BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.

The PyImath code doesn't use this feature, so the message is meaningless but it clutters the output. This #define suppresses it.

There is still one boost pragma message coming from the `#include <boost/python.hpp>`, but I don't see an easy way to suppress it:

    /usr/include/boost/detail/iterator.hpp:13:1: note: #pragma
    message: This header is deprecated. Use <iterator> instead.

Signed-off-by: Cary Phillips <cary@ilm.com>