### PR TITLE
Remove MACOSX_RPATH forcing

### DIFF
--- a/config/ImathSetup.cmake
+++ b/config/ImathSetup.cmake
@@ -81,9 +81,6 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 # Add the automatically determined parts of the rpath which point to
 # directories outside the build tree to the install RPATH
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-if(APPLE)
-  set(CMAKE_MACOSX_RPATH ON)
-endif()
 
 # If the user sets an install rpath then just use that, or otherwise
 # set one for them.


### PR DESCRIPTION
With cmake 3.0.0, CMP0042 applies and the default value of MACOSX_RPATH is true, this block is not needed  anymore.

Setting this is a bad practice because in some cases one needs to disabled it.