### PR TITLE
add IMATH_CONSTEXPR14 definition

### DIFF
--- a/config/ImathConfig.h.in
+++ b/config/ImathConfig.h.in
@@ -65,6 +65,11 @@
 // clang-format on
 
 //
+// Imath alias for constexpr
+//
+#define IMATH_CONSTEXPR14 constexpr
+
+//
 // Code that depends on the v2 ExcMath mechanism of signal handlers
 // that throw exceptions is incompatible with noexcept, since
 // floating-point overflow and underflow can occur in a wide variety


### PR DESCRIPTION
I have compiling problems saying that IMATH_CONSTEXPR14 is not defined, I think it should be defined in the ImathConfig.h.in.