### PR TITLE
Check return status of extractSHRT in computeRSMatrix

### DIFF
--- a/src/Imath/ImathMatrixAlgo.h
+++ b/src/Imath/ImathMatrixAlgo.h
@@ -1125,7 +1125,8 @@ computeRSMatrix (
     const Matrix44<T>& B)
 {
     Vec3<T> as, ah, ar, at;
-    extractSHRT (A, as, ah, ar, at);
+    if (!extractSHRT (A, as, ah, ar, at))
+        throw std::domain_error ("degenerate A matrix in computeRSMatrix");
 
     Vec3<T> bs, bh, br, bt;
     if (!extractSHRT (B, bs, bh, br, bt))


### PR DESCRIPTION
Technically it's not necessary since extractSHRT will throw since the exc argument is implicitly true, but without testing the result, it generates a compiler warning.