### PR TITLE
Extend test code coverage and add missing python bindings

### DIFF
--- a/src/ImathTest/CMakeLists.txt
+++ b/src/ImathTest/CMakeLists.txt
@@ -75,6 +75,7 @@ set_target_properties(ImathHalfPerfTest PROPERTIES
 RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 target_link_libraries(ImathHalfPerfTest Imath::Imath)
+add_test(NAME Imath.ImathHalfPerfTest COMMAND $<TARGET_FILE:ImathHalfPerfTest>)
 
 function(DEFINE_IMATH_TESTS)
   foreach(curtest IN LISTS ARGN)

--- a/src/ImathTest/CMakeLists.txt
+++ b/src/ImathTest/CMakeLists.txt
@@ -75,7 +75,7 @@ set_target_properties(ImathHalfPerfTest PROPERTIES
 RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 target_link_libraries(ImathHalfPerfTest Imath::Imath)
-add_test(NAME Imath.ImathHalfPerfTest COMMAND $<TARGET_FILE:ImathHalfPerfTest>)
+add_test(NAME Imath.half_perf_test COMMAND $<TARGET_FILE:ImathHalfPerfTest>)
 
 function(DEFINE_IMATH_TESTS)
   foreach(curtest IN LISTS ARGN)

--- a/src/ImathTest/testBox.cpp
+++ b/src/ImathTest/testBox.cpp
@@ -180,6 +180,17 @@ testMakeInfinite (const char* type)
         assert (
             b.min == T (T::baseTypeLowest ()) &&
             b.max == T (T::baseTypeMax ()));
+
+        for (unsigned int i=0; i<b.min.dimensions(); i++)
+        {
+            IMATH_INTERNAL_NAMESPACE::Box<T> c = b;
+            c.max[i] = 0;
+            assert (!c.isInfinite());
+
+            c = b;
+            c.min[i] = 0;
+            assert (!c.isInfinite());
+        }
     }
 
     //

--- a/src/ImathTest/testBoxAlgo.cpp
+++ b/src/ImathTest/testBoxAlgo.cpp
@@ -843,6 +843,19 @@ boxMatrixTransform ()
     assert (approximatelyEqual (b5.min, b6.min, e));
     assert (approximatelyEqual (b5.max, b6.max, e));
     assert (b51 == b5);
+
+    Box3f b7;
+    Box3f r;
+    b7.makeEmpty();
+    assert (b7.isEmpty() && !b7.isInfinite());
+    affineTransform (b7, M, r);
+    assert (r.isEmpty());
+
+    Box3f b8;
+    b8.makeInfinite();
+    assert (b8.isInfinite() && !b8.isEmpty());
+    affineTransform (b8, M, r);
+    assert (r.isInfinite());
 }
 
 void

--- a/src/ImathTest/testColor.cpp
+++ b/src/ImathTest/testColor.cpp
@@ -234,10 +234,10 @@ testColor ()
     
     IMATH_INTERNAL_NAMESPACE::Color4<double> c4d, r4d, tmp4d;
 
-    c4d.r = 1.0d;
-    c4d.g = 1.0d;
-    c4d.b = 1.0d;
-    c4d.a = 1.0d;
+    c4d.r = 1.0;
+    c4d.g = 1.0;
+    c4d.b = 1.0;
+    c4d.a = 1.0;
     tmp4d = rgb2hsv(c4d);
     r4d = hsv2rgb(tmp4d);
     assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.r, c4d.r, 1e-5d));
@@ -245,10 +245,10 @@ testColor ()
     assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.b, c4d.b, 1e-5d));
     assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.a, c4d.a, 1e-5d));
 
-    c4d.r = 1.0d;
-    c4d.g = 1.0d;
-    c4d.b = 0.0d;
-    c4d.a = 0.0d;
+    c4d.r = 1.0;
+    c4d.g = 1.0;
+    c4d.b = 0.0;
+    c4d.a = 0.0;
     tmp4d = rgb2hsv(c4d);
     r4d = hsv2rgb(tmp4d);
     assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.r, c4d.r, 1e-5d));
@@ -260,18 +260,18 @@ testColor ()
     
     IMATH_INTERNAL_NAMESPACE::Color3<double> c3d, r3d, tmp3d;
 
-    c3d.x = 1.0d;
-    c3d.y = 1.0d;
-    c3d.z = 1.0d;
+    c3d.x = 1.0;
+    c3d.y = 1.0;
+    c3d.z = 1.0;
     tmp3d = rgb2hsv(c3d);
     r3d = hsv2rgb(tmp3d);
     assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.x, c3d.x, 1e-5d));
     assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.y, c3d.y, 1e-5d));
     assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.z, c3d.z, 1e-5d));
 
-    c3d.x = 1.0d;
-    c3d.y = 1.0d;
-    c3d.z = 0.0d;
+    c3d.x = 1.0;
+    c3d.y = 1.0;
+    c3d.z = 0.0;
     tmp3d = rgb2hsv(c3d);
     r3d = hsv2rgb(tmp3d);
     assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.x, c3d.x, 1e-5d));

--- a/src/ImathTest/testColor.cpp
+++ b/src/ImathTest/testColor.cpp
@@ -240,10 +240,10 @@ testColor ()
     c4d.a = 1.0;
     tmp4d = rgb2hsv(c4d);
     r4d = hsv2rgb(tmp4d);
-    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.r, c4d.r, 1e-5d));
-    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.g, c4d.g, 1e-5d));
-    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.b, c4d.b, 1e-5d));
-    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.a, c4d.a, 1e-5d));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.r, c4d.r, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.g, c4d.g, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.b, c4d.b, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.a, c4d.a, 1e-5f));
 
     c4d.r = 1.0;
     c4d.g = 1.0;
@@ -251,10 +251,10 @@ testColor ()
     c4d.a = 0.0;
     tmp4d = rgb2hsv(c4d);
     r4d = hsv2rgb(tmp4d);
-    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.r, c4d.r, 1e-5d));
-    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.g, c4d.g, 1e-5d));
-    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.b, c4d.b, 1e-5d));
-    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.a, c4d.a, 1e-5d));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.r, c4d.r, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.g, c4d.g, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.b, c4d.b, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.a, c4d.a, 1e-5f));
 
     // C3d
     
@@ -265,18 +265,18 @@ testColor ()
     c3d.z = 1.0;
     tmp3d = rgb2hsv(c3d);
     r3d = hsv2rgb(tmp3d);
-    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.x, c3d.x, 1e-5d));
-    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.y, c3d.y, 1e-5d));
-    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.z, c3d.z, 1e-5d));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.x, c3d.x, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.y, c3d.y, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.z, c3d.z, 1e-5f));
 
     c3d.x = 1.0;
     c3d.y = 1.0;
     c3d.z = 0.0;
     tmp3d = rgb2hsv(c3d);
     r3d = hsv2rgb(tmp3d);
-    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.x, c3d.x, 1e-5d));
-    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.y, c3d.y, 1e-5d));
-    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.z, c3d.z, 1e-5d));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.x, c3d.x, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.y, c3d.y, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.z, c3d.z, 1e-5f));
     
     cout << "ok\n" << endl;
 }

--- a/src/ImathTest/testColor.cpp
+++ b/src/ImathTest/testColor.cpp
@@ -11,6 +11,7 @@
 #include <ImathColor.h>
 #include <ImathColorAlgo.h>
 #include <ImathMath.h>
+#include <ImathFun.h>
 #include <assert.h>
 #include <iostream>
 
@@ -179,5 +180,103 @@ testColor ()
         std::fabs ((X.b / Y.b) - tmp.b) <= 1e-5f &&
         std::fabs ((X.a / Y.a) - tmp.a) <= 1e-5f);
 
+    cout << "rgb2hsv and hsv2rgb" << endl;
+
+    // C4f
+    
+    IMATH_INTERNAL_NAMESPACE::C4f c4f, r4f, tmp4f;
+
+    c4f.r = 1.0f;
+    c4f.g = 1.0f;
+    c4f.b = 1.0f;
+    c4f.a = 1.0f;
+    tmp4f = rgb2hsv(c4f);
+    r4f = hsv2rgb(tmp4f);
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4f.r, c4f.r, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4f.g, c4f.g, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4f.b, c4f.b, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4f.a, c4f.a, 1e-5f));
+
+    c4f.r = 1.0f;
+    c4f.g = 1.0f;
+    c4f.b = 0.0f;
+    c4f.a = 0.0f;
+    tmp4f = rgb2hsv(c4f);
+    r4f = hsv2rgb(tmp4f);
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4f.r, c4f.r, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4f.g, c4f.g, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4f.b, c4f.b, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4f.a, c4f.a, 1e-5f));
+
+    // C3f
+    
+    IMATH_INTERNAL_NAMESPACE::C3f c3f, r3f, tmp3f;
+
+    c3f.x = 1.0f;
+    c3f.y = 1.0f;
+    c3f.z = 1.0f;
+    tmp3f = rgb2hsv(c3f);
+    r3f = hsv2rgb(tmp3f);
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3f.x, c3f.x, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3f.y, c3f.y, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3f.z, c3f.z, 1e-5f));
+
+    c3f.x = 1.0f;
+    c3f.y = 1.0f;
+    c3f.z = 0.0f;
+    tmp3f = rgb2hsv(c3f);
+    r3f = hsv2rgb(tmp3f);
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3f.x, c3f.x, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3f.y, c3f.y, 1e-5f));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3f.z, c3f.z, 1e-5f));
+
+    // C4d
+    
+    IMATH_INTERNAL_NAMESPACE::Color4<double> c4d, r4d, tmp4d;
+
+    c4d.r = 1.0d;
+    c4d.g = 1.0d;
+    c4d.b = 1.0d;
+    c4d.a = 1.0d;
+    tmp4d = rgb2hsv(c4d);
+    r4d = hsv2rgb(tmp4d);
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.r, c4d.r, 1e-5d));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.g, c4d.g, 1e-5d));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.b, c4d.b, 1e-5d));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.a, c4d.a, 1e-5d));
+
+    c4d.r = 1.0d;
+    c4d.g = 1.0d;
+    c4d.b = 0.0d;
+    c4d.a = 0.0d;
+    tmp4d = rgb2hsv(c4d);
+    r4d = hsv2rgb(tmp4d);
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.r, c4d.r, 1e-5d));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.g, c4d.g, 1e-5d));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.b, c4d.b, 1e-5d));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r4d.a, c4d.a, 1e-5d));
+
+    // C3d
+    
+    IMATH_INTERNAL_NAMESPACE::Color3<double> c3d, r3d, tmp3d;
+
+    c3d.x = 1.0d;
+    c3d.y = 1.0d;
+    c3d.z = 1.0d;
+    tmp3d = rgb2hsv(c3d);
+    r3d = hsv2rgb(tmp3d);
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.x, c3d.x, 1e-5d));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.y, c3d.y, 1e-5d));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.z, c3d.z, 1e-5d));
+
+    c3d.x = 1.0d;
+    c3d.y = 1.0d;
+    c3d.z = 0.0d;
+    tmp3d = rgb2hsv(c3d);
+    r3d = hsv2rgb(tmp3d);
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.x, c3d.x, 1e-5d));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.y, c3d.y, 1e-5d));
+    assert (IMATH_INTERNAL_NAMESPACE::equal (r3d.z, c3d.z, 1e-5d));
+    
     cout << "ok\n" << endl;
 }

--- a/src/ImathTest/testMatrix.cpp
+++ b/src/ImathTest/testMatrix.cpp
@@ -16,6 +16,7 @@
 #include <ImathVec.h>
 #include <assert.h>
 #include <iostream>
+#include <sstream>
 
 // Include ImathForward *after* other headers to validate forward declarations
 #include <ImathForward.h>

--- a/src/ImathTest/testMatrix.cpp
+++ b/src/ImathTest/testMatrix.cpp
@@ -59,7 +59,7 @@ testMatrix ()
         m1[0][0] = 99.0f;
         m1[1][1] = 101.0f;
 
-        IMATH_INTERNAL_NAMESPACE::M22f test (m1);
+        const IMATH_INTERNAL_NAMESPACE::M22f test (m1);
         assert (test == m1);
 
         IMATH_INTERNAL_NAMESPACE::M22f test2;
@@ -68,6 +68,26 @@ testMatrix ()
         IMATH_INTERNAL_NAMESPACE::M22f test3;
         test3.makeIdentity ();
         assert (test2 == test3);
+
+        m1 = 42;
+        assert (m1[0][0] == 42 && m1[0][1] == 42 && m1[1][0] == 42 && m1[1][1] == 42);
+
+        const float* i1 = test.getValue();
+        assert(i1[0] == 99.0f);
+        assert(i1[3] == 101.0f);
+        
+        float* i2 = m1.getValue();
+        assert(i2[0] == 42.0f);
+        assert(i2[1] == 42.0f);
+        assert(i2[2] == 42.0f);
+        assert(i2[3] == 42.0f);
+
+        IMATH_INTERNAL_NAMESPACE::M22f test4;
+        test.getValue(test4);
+        assert (test == test4);
+
+        test4.setTheMatrix(test3);
+        assert(test4 == test3);
     }
 
     {
@@ -147,7 +167,7 @@ testMatrix ()
 
         cout << "M33f constructors and equality operators" << endl;
 
-        IMATH_INTERNAL_NAMESPACE::M33f test (m2);
+        const IMATH_INTERNAL_NAMESPACE::M33f test (m2);
         assert (test == m2);
 
         IMATH_INTERNAL_NAMESPACE::M33f test2;
@@ -156,6 +176,36 @@ testMatrix ()
         IMATH_INTERNAL_NAMESPACE::M33f test3;
         test3.makeIdentity ();
         assert (test2 == test3);
+
+        m1 = 42;
+        assert (m1[0][0] == 42 && m1[0][1] == 42 && m1[0][2] == 42 &&
+                m1[1][0] == 42 && m1[1][1] == 42 && m1[1][2] == 42 &&
+                m1[2][0] == 42 && m1[2][1] == 42 && m1[2][2] == 42);
+
+        const float* i1 = test.getValue();
+        assert (i1[0] == 1.0f  && i1[1] == 4.0f  && i1[2] == 0.0f &&
+                i1[3] == 10.0f && i1[4] == 29.0f && i1[5] == 0.0f &&
+                i1[6] == 0.0f  && i1[7] == 0.0f  && i1[8] == 1.0f);
+        
+        float* i2 = m1.getValue();
+        assert(i2[0] == 42.0f);
+        assert(i2[1] == 42.0f);
+        assert(i2[2] == 42.0f);
+        assert(i2[3] == 42.0f);
+
+        IMATH_INTERNAL_NAMESPACE::M33f test4;
+        test.getValue(test4);
+        assert (test == test4);
+
+        test4.setTheMatrix(test3);
+        assert(test4 == test3);
+
+        IMATH_INTERNAL_NAMESPACE::V3f v(2.0f);
+        IMATH_INTERNAL_NAMESPACE::M33f m(2.0f);
+        v *= m;
+        assert (IMATH_INTERNAL_NAMESPACE::equal(v[0], 12.0f, 0.0001f));
+        assert (IMATH_INTERNAL_NAMESPACE::equal(v[1], 12.0f, 0.0001f));
+        assert (IMATH_INTERNAL_NAMESPACE::equal(v[2], 12.0f, 0.0001f));
     }
 
     {
@@ -323,6 +373,62 @@ testMatrix ()
         assert (test5[3][1] == 14.0);
         assert (test5[3][2] == 15.0);
         assert (test5[3][3] == 16.0);
+    }
+
+    {
+        cout << "M44f *= operators" << endl;
+
+        IMATH_INTERNAL_NAMESPACE::V3f v(2.0f);
+        IMATH_INTERNAL_NAMESPACE::M44f m(2.0f);
+        m.setScale(2.0f);
+        v *= m;
+        assert (IMATH_INTERNAL_NAMESPACE::equal(v[0], 4.0f, 0.0001f));
+        assert (IMATH_INTERNAL_NAMESPACE::equal(v[1], 4.0f, 0.0001f));
+        assert (IMATH_INTERNAL_NAMESPACE::equal(v[2], 4.0f, 0.0001f));
+
+        IMATH_INTERNAL_NAMESPACE::V4f v4f(2.0f);
+        IMATH_INTERNAL_NAMESPACE::V4f v4f2 = v4f * m;
+        
+        assert (IMATH_INTERNAL_NAMESPACE::equal(v4f2[0], 4.0f, 0.0001f));
+        assert (IMATH_INTERNAL_NAMESPACE::equal(v4f2[1], 4.0f, 0.0001f));
+        assert (IMATH_INTERNAL_NAMESPACE::equal(v4f2[2], 4.0f, 0.0001f));
+        assert (IMATH_INTERNAL_NAMESPACE::equal(v4f2[3], 2.0f, 0.0001f));
+
+        v4f *= m;
+        assert (v4f == v4f2);
+        
+        IMATH_INTERNAL_NAMESPACE::M44f a(2.0f);
+        IMATH_INTERNAL_NAMESPACE::M44f b(3.0f);
+        IMATH_INTERNAL_NAMESPACE::M44f c;
+
+        IMATH_INTERNAL_NAMESPACE::M44f::multiply(a, b, c);
+        assert (IMATH_INTERNAL_NAMESPACE::equal(c[0][0], 24.0f, 0.0001f));
+        assert (IMATH_INTERNAL_NAMESPACE::equal(c[1][1], 24.0f, 0.0001f));
+        assert (IMATH_INTERNAL_NAMESPACE::equal(c[2][2], 24.0f, 0.0001f));
+        assert (IMATH_INTERNAL_NAMESPACE::equal(c[3][3], 24.0f, 0.0001f));
+    }
+    
+    cout << "Matrix << operators" << endl;
+    
+    {
+        std::stringstream s;
+        s << IMATH_INTERNAL_NAMESPACE::identity22f;
+        const char v[] = "(  1.000000e+00   0.000000e+00\n   0.000000e+00   1.000000e+00)\n";
+        assert (s.str() == v);
+    }
+        
+    {
+        std::stringstream s;
+        s << IMATH_INTERNAL_NAMESPACE::identity33f;
+        const char v[] = "(  1.000000e+00   0.000000e+00   0.000000e+00\n   0.000000e+00   1.000000e+00   0.000000e+00\n   0.000000e+00   0.000000e+00   1.000000e+00)\n";
+        assert (s.str() == v);
+    }
+
+    {
+        std::stringstream s;
+        s << IMATH_INTERNAL_NAMESPACE::identity44f;
+        const char v[] = "(  1.000000e+00   0.000000e+00   0.000000e+00   0.000000e+00\n   0.000000e+00   1.000000e+00   0.000000e+00   0.000000e+00\n   0.000000e+00   0.000000e+00   1.000000e+00   0.000000e+00\n   0.000000e+00   0.000000e+00   0.000000e+00   1.000000e+00)\n";
+        assert (s.str() == v);
     }
 
     {

--- a/src/python/PyImath/PyImathMatrix22.cpp
+++ b/src/python/PyImath/PyImathMatrix22.cpp
@@ -337,8 +337,7 @@ static const Matrix22<T> &
 setScaleSc22(Matrix22<T> &mat, const T &s)
 {
     MATH_EXC_ON;
-    Vec2<T> sVec(s, s);
-    return mat.setScale(sVec);
+    return mat.setScale(s);
 }
 
 template <class T>

--- a/src/python/PyImath/PyImathMatrix33.cpp
+++ b/src/python/PyImath/PyImathMatrix33.cpp
@@ -463,8 +463,7 @@ static const Matrix33<T> &
 setScaleSc33(Matrix33<T> &mat, const T &s)
 {
     MATH_EXC_ON;
-    Vec2<T> sVec(s, s);
-    return mat.setScale(sVec);
+    return mat.setScale(s);
 }
 
 template <class T>

--- a/src/python/PyImath/PyImathMatrix44.cpp
+++ b/src/python/PyImath/PyImathMatrix44.cpp
@@ -523,8 +523,7 @@ static const Matrix44<T> &
 setScaleSc44(Matrix44<T> &mat, const T &s)
 {
     MATH_EXC_ON;
-    Vec3<T> sVec(s, s, s);
-    return mat.setScale(sVec);
+    return mat.setScale(s);
 }
 
 template <class T>
@@ -559,8 +558,7 @@ static const Matrix44<T> &
 setShearV44(Matrix44<T> &mat, const Vec3<T> &sVec)
 {
     MATH_EXC_ON;
-    IMATH_NAMESPACE::Shear6<T> shear(sVec[0], sVec[1], sVec[2], T (0), T (0), T (0));
-    return mat.setShear(shear);
+    return mat.setShear(sVec);
 }
 
 template <class T>
@@ -582,9 +580,9 @@ setShear44Tuple(Matrix44<T> &mat, const tuple &t)
         s.x = extract<T>(t[0]);
         s.y = extract<T>(t[1]);
         s.z = extract<T>(t[2]);
-        Shear6<T> shear(s);
+//        Shear6<T> shear(s);
         
-        return mat.setShear(shear);
+        return mat.setShear(s);
     }
     else if(t.attr("__len__")() == 6)
     {
@@ -649,6 +647,22 @@ setValue44(Matrix44<T> &mat, const Matrix44<T> &value)
 {
     MATH_EXC_ON;
     mat.setValue(value);
+}
+
+template <class T>
+static void
+setEulerAngles44(Matrix44<T> &mat, const Vec3<T> &value)
+{
+    MATH_EXC_ON;
+    mat.setEulerAngles(value);
+}
+
+template <class T>
+static void
+setAxisAngle44(Matrix44<T> &mat, const Vec3<T> &axis, T angle)
+{
+    MATH_EXC_ON;
+    mat.setAxisAngle(axis, angle);
 }
 
 template <class T>
@@ -1112,6 +1126,8 @@ register_Matrix44()
         .def("setTranslation", &setTranslation44Tuple<T>, return_internal_reference<>(),"setTranslation()")
         .def("setTranslation", &setTranslation44Obj<T>, return_internal_reference<>(),"setTranslation()")
         .def("setValue", &setValue44<T>, "setValue()")
+        .def("setEulerAngles", &setEulerAngles44<T>, "setEulerAngles()")
+        .def("setAxisAngle", &setAxisAngle44<T>, "setAxisAngle()")
         .def("shear", &shearV44<T>, return_internal_reference<>(),"shear()")
         .def("shear", &shearS44<T>, return_internal_reference<>(),"shear()")
         .def("shear", &shear44Tuple<T>, return_internal_reference<>(),"shear()")

--- a/src/python/PyImath/PyImathMatrix44.cpp
+++ b/src/python/PyImath/PyImathMatrix44.cpp
@@ -580,7 +580,6 @@ setShear44Tuple(Matrix44<T> &mat, const tuple &t)
         s.x = extract<T>(t[0]);
         s.y = extract<T>(t[1]);
         s.z = extract<T>(t[2]);
-//        Shear6<T> shear(s);
         
         return mat.setShear(s);
     }

--- a/src/python/PyImathTest/pyImathTest.in
+++ b/src/python/PyImathTest/pyImathTest.in
@@ -4929,7 +4929,7 @@ def testM22 ():
     print ("M22d")
     testM22x (M22d, V2d)
 
-#testList.append (('testM22',testM22))
+testList.append (('testM22',testM22))
 
 
 # -------------------------------------------------------------------------
@@ -6107,6 +6107,20 @@ def testM44x (Mat, Vec):
     m.extractEulerXYZ(v)
     assert v.equalWithAbsError((0, 0, -a), v.baseTypeEpsilon())
 
+    e = Vec(0,0,-a)
+    m.setEulerAngles(e)
+    assert (equal(m[0][0], cos(a), 0.0001))
+    assert (equal(m[0][1], -sin(a), 0.0001))
+    assert (equal(m[1][0], sin(a), 0.0001))
+    assert (equal(m[1][1], cos(a), 0.0001))
+    
+    axis = Vec(0,0,1)
+    m.setAxisAngle(axis,-a)
+    assert (equal(m[0][0], cos(a), 0.0001))
+    assert (equal(m[0][1], -sin(a), 0.0001))
+    assert (equal(m[1][0], sin(a), 0.0001))
+    assert (equal(m[1][1], cos(a), 0.0001))
+
     # Extract scale, shear, rotation, translation.
 
     s = Vec(1, 2, 3)
@@ -6326,6 +6340,12 @@ def testM22xConversions (Mat):
     m2 = M22d (m1)
     assert m2[0][0] == 0 and m2[0][1] == 1
 
+    m2 = M22f(42)
+    assert m2[0][0] == 42 and m2[0][1] == 42
+    
+    m2 = M22d(42)
+    assert m2[0][0] == 42 and m2[0][1] == 42
+    
     # The += operator
 
     m2 = Mat(0,1, 2,3)
@@ -6336,6 +6356,9 @@ def testM22xConversions (Mat):
     m2 += M22d (m1)
     assert m2[0][0] == 0 and m2[0][1] == 2
     
+    m2 += 1
+    assert m2[0][0] == 1 and m2[0][1] == 3
+    
     # The -= operator
 
     m2 = Mat(0,1, 2,3)
@@ -6345,6 +6368,9 @@ def testM22xConversions (Mat):
     m2 = Mat(0,1, 2,3)
     m2 -= M22d (m1)
     assert m2[0][0] == 0 and m2[0][1] == 0
+
+    m2 -= 1
+    assert m2[0][0] == -1 and m2[0][1] == -1
 
     # The *= operator
 
@@ -6357,6 +6383,15 @@ def testM22xConversions (Mat):
     m2 *= M22d (m1)
     assert m2[0][0] == 0*0 + 1*2
     assert m2[0][1] == 0*1 + 1*3
+        
+    m2 *= 10
+    assert m2[0][0] == 20 and m2[0][1] == 30
+    
+    # The /= operator
+
+    m2.makeIdentity()
+    m2 /= 10
+    assert equalWithRelErrorScalar(m2[0][0], 1/10.0, 0.0001)
         
     print ("ok")
     return
@@ -6374,6 +6409,12 @@ def testM33xConversions (Mat):
     m2 = M33d (m1)
     assert m2[0][0] == 0 and m2[0][1] == 1
 
+    m2 = M33f(42)
+    assert m2[0][0] == 42 and m2[0][1] == 42
+    
+    m2 = M33d(42)
+    assert m2[0][0] == 42 and m2[0][1] == 42
+    
     # The += operator
 
     m2 = Mat(0,1,2, 3,4,5, 6,7,8)
@@ -6384,6 +6425,9 @@ def testM33xConversions (Mat):
     m2 += M33d (m1)
     assert m2[0][0] == 0 and m2[0][1] == 2
     
+    m2 += 1
+    assert m2[0][0] == 1 and m2[0][1] == 3
+    
     # The -= operator
 
     m2 = Mat(0,1,2, 3,4,5, 6,7,8)
@@ -6393,6 +6437,9 @@ def testM33xConversions (Mat):
     m2 = Mat(0,1,2, 3,4,5, 6,7,8)
     m2 -= M33d (m1)
     assert m2[0][0] == 0 and m2[0][1] == 0
+
+    m2 -= 1
+    assert m2[0][0] == -1 and m2[0][1] == -1
 
     # The *= operator
 
@@ -6405,6 +6452,15 @@ def testM33xConversions (Mat):
     m2 *= M33d (m1)
     assert m2[0][0] == 0*0 + 1*3 + 2*6
     assert m2[0][1] == 0*1 + 1*4 + 2*7
+        
+    m2 *= 10
+    assert m2[0][0] == (0*0 + 1*3 + 2*6)*10 and m2[0][1] == (0*1 + 1*4 + 2*7)*10
+    
+    # The /= operator
+
+    m2.makeIdentity()
+    m2 /= 10
+    assert equalWithRelErrorScalar(m2[0][0], 1/10.0, 0.0001)
         
     print ("ok")
     return
@@ -6422,6 +6478,12 @@ def testM44xConversions (Mat):
     m2 = M44d (m1)
     assert m2[0][0] == 0 and m2[0][1] == 1 and m2[0][2] == 2
 
+    m2 = M44f(42)
+    assert m2[0][0] == 42 and m2[0][1] == 42
+    
+    m2 = M44d(42)
+    assert m2[0][0] == 42 and m2[0][1] == 42
+    
     # The += operator
 
     m2 = Mat((0,1,2,3), (4,5,6,7), (8,9,10,11), (12,13,14,15))
@@ -6432,6 +6494,9 @@ def testM44xConversions (Mat):
     m2 += M44d (m1)
     assert m2[0][0] == 0 and m2[0][1] == 2
     
+    m2 += 1
+    assert m2[0][0] == 1 and m2[0][1] == 3
+
     # The -= operator
 
     m2 = Mat((0,1,2,3), (4,5,6,7), (8,9,10,11), (12,13,14,15))
@@ -6442,6 +6507,9 @@ def testM44xConversions (Mat):
     m2 -= M44d (m1)
     assert m2[0][0] == 0 and m2[0][1] == 0
     
+    m2 -= 1
+    assert m2[0][0] == -1 and m2[0][1] == -1
+
     # The *= operator
 
     m2 = Mat((0,1,2,3), (4,5,6,7), (8,9,10,11), (12,13,14,15))
@@ -6454,6 +6522,15 @@ def testM44xConversions (Mat):
     assert m2[0][0] == 0*0 + 1*4 + 2*8 + 3*12
     assert m2[0][1] == 0*1 + 1*5 + 2*9 + 3*13
                 
+    m2 *= 10
+    assert m2[0][0] == (0*0 + 1*4 + 2*8 + 3*12)*10 and m2[0][1] == (0*1 + 1*5 + 2*9 + 3*13)*10
+    
+    # The /= operator
+
+    m2.makeIdentity()
+    m2 /= 10
+    assert equalWithRelErrorScalar(m2[0][0], 1/10.0, 0.0001)
+        
     print ("ok")
     return
 
@@ -6483,7 +6560,7 @@ def testM22xM44xConversion (MatA, MatB):
 def testMatConversions ():
 
     print ("M22f")
-#    testM22xConversions (M22f)
+    testM22xConversions (M22f)
     print ("M22d")
     testM22xConversions (M22d)
 


### PR DESCRIPTION
- Add ImathHalfPerfTest as a test (it was built but not executed)
- Box<T>::isInfinite() tests
- Box<T>::affineTransform() tests with empty+infinite boxes
- rgb2hsv/hsv2rgb
- Add test code to python test for various matrix operators that were not covered
- Matrix22 tests were commented out for some unknown reason. 
- In Matrix22 and Matrix33, the python bindings now call setScale(s)
  directly rather than calling setScale(Vec(s)). The behavior is the
  same, but this ensures the scalar version of the method gets test coverage.
- In Matrix44:
  * Call setScale(s) in place of setScale(Vec(s)), same as above.
  * Similarly, call setShear(s) in place of setShear(Shear(s)). Same
    behavior, better test.
  * Add bindings for setEulerAngles() and setAxisAngles(), and
    associated tests. The test suite relies heavily on the bindings, 
    so the bulk of the library testing is in python.