### PR TITLE
Fix coverage analysis for .c files

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright Contributors to the OpenEXR Project.
+# Copyright (c) Contributors to the OpenEXR Project.
 #
 # GitHub Actions workflow file
 # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
@@ -19,13 +19,13 @@ jobs:
   # ---------------------------------------------------------------------------
 
   linux_sonarcloud:
-    name: 'SonarCloud Linux CentOS 7 VFX CY2021 <GCC 6.3.1>'
+    name: 'SonarCloud Linux CentOS 7 VFX CY2022 <GCC 9.3.1>'
     # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
     runs-on: ubuntu-latest
     container:
       # DockerHub: https://hub.docker.com/u/aswf
       # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
-      image: aswf/ci-openexr:2021
+      image: aswf/ci-openexr:2022
     env:
       CXX: g++
       CC: gcc
@@ -35,14 +35,13 @@ jobs:
       - name: Setup container
         run: sudo rm -rf /usr/local/lib64/cmake/glew
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: Create build directories
         run: |
           mkdir _install
           mkdir _build
-        shell: bash
       - name: Configure
         run: |
           cmake .. \
@@ -51,6 +50,8 @@ jobs:
                 -DCMAKE_CXX_STANDARD=14 \
                 -DCMAKE_CXX_FLAGS="-g -O0 -fprofile-arcs -ftest-coverage" \
                 -DCMAKE_CXX_OUTPUT_EXTENSION_REPLACE=ON \
+                -DCMAKE_C_FLAGS="-g -O0 -fprofile-arcs -ftest-coverage" \
+                -DCMAKE_C_OUTPUT_EXTENSION_REPLACE=ON \
                 -DCMAKE_EXE_LINKER_FLAGS="-lgcov" \
                 -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
                 -DBUILD_SHARED_LIBS='OFF' \
@@ -82,13 +83,13 @@ jobs:
   #  Valgrind memcheck test
   # ------------------------------------------------------------------------------
   linux_valgrind:
-    name: 'Valgrind Linux CentOS 7 VFX CY2021 <GCC 6.3.1>'
+    name: 'Valgrind Linux CentOS 7 VFX CY2022 <GCC 9.3.1>'
     # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
     runs-on: ubuntu-latest
     container:
       # DockerHub: https://hub.docker.com/u/aswf
       # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
-      image: aswf/ci-openexr:2021
+      image: aswf/ci-openexr:2022
     env:
       CXX: g++
       CC: gcc
@@ -98,7 +99,7 @@ jobs:
       - name: Setup container
         run: sudo rm -rf /usr/local/lib64/cmake/glew
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: Create build directories
@@ -118,8 +119,6 @@ jobs:
                 -DCMAKE_CXX_STANDARD=14 \
                 -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
                 -DBUILD_SHARED_LIBS='OFF' \
-                -DOPENEXR_BUILD_UTILS='ON' \
-                -DOPENEXR_RUN_FUZZ_TESTS='OFF' \
                 -DPYTHON='ON'
         working-directory: _build
       - name: Build

--- a/share/ci/scripts/linux/run_gcov.sh
+++ b/share/ci/scripts/linux/run_gcov.sh
@@ -1,17 +1,35 @@
-!/usr/bin/env bash
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
 
 set -ex
 
-mkdir _coverage
-cd _coverage
+if [ $# -gt 0 ]
+then
+   build=$1
+else
+   build=`pwd`/'_build'
+fi
+   
+coverage="$build/_coverage"
 
-# The sed command below converts from:
-#   ../_build/src/OpenEXR/CMakeFiles/OpenColorIO.dir/ops/Exponent.gcno
-# to:
-#   ../src/OpenEXR/ops/Exponent.cpp
+mkdir -p $coverage
+cd $coverage
 
-for g in $(find ../_build -name "*.gcno" -type f); do
-    gcov -l -p -o $(dirname "$g") $(echo "$g" | sed -e 's/\/_build\//\//' -e 's/\.gcno/\.cpp/' -e 's/\/CMakeFiles.*\.dir\//\//')
+for gcno in $(find $build -name "*.gcno" -type f); do
+
+    # Identify the original source file (.cpp or .c) from the .gcno
+    # file by examining the .o.d Makefile dependency file. The source
+    # file should be the second line in the .o.d file.
+    
+    # gcno = $build/src/bin/exrheader/CMakeFiles/exrheader.dir/main.gcno
+    object_directory=$(dirname "$gcno") # $build/src/bin/exrheader/CMakeFiles/exrheader.dir
+    source_base=$(basename "$gcno" ".gcno") # $build/src/bin/exrheader/CMakeFiles/exrheader.dir/main
+    dependency_file=$object_directory/$source_base.o.d # $build/src/bin/exrheader/CMakeFiles/exrheader.dir/main.o.d
+    source_file=$(head -2 $dependency_file | tail -1 | sed -e 's/ //' -e 's/ \\//') 
+    gcov -l -p -o $object_directory $source_file 
 done
 
-cd ..
+
+

--- a/share/ci/scripts/linux/run_gcov.sh
+++ b/share/ci/scripts/linux/run_gcov.sh
@@ -7,9 +7,9 @@ set -ex
 
 if [ $# -gt 0 ]
 then
-   build=$1
+   build=$1  # use explicity-provided build directory
 else
-   build=`pwd`/'_build'
+   build=`pwd`/'_build'  # from with CI, use the _build subdirectory
 fi
    
 coverage="$build/_coverage"
@@ -20,15 +20,23 @@ cd $coverage
 for gcno in $(find $build -name "*.gcno" -type f); do
 
     # Identify the original source file (.cpp or .c) from the .gcno
-    # file by examining the .o.d Makefile dependency file. The source
+    # file by examining the .o.d make dependency file. The source
     # file should be the second line in the .o.d file.
     
     # gcno = $build/src/bin/exrheader/CMakeFiles/exrheader.dir/main.gcno
-    object_directory=$(dirname "$gcno") # $build/src/bin/exrheader/CMakeFiles/exrheader.dir
-    source_base=$(basename "$gcno" ".gcno") # $build/src/bin/exrheader/CMakeFiles/exrheader.dir/main
-    dependency_file=$object_directory/$source_base.o.d # $build/src/bin/exrheader/CMakeFiles/exrheader.dir/main.o.d
-    source_file=$(head -2 $dependency_file | tail -1 | sed -e 's/ //' -e 's/ \\//') 
-    gcov -l -p -o $object_directory $source_file 
+    # object_directory = $build/src/bin/exrheader/CMakeFiles/exrheader.dir
+    # source_base = $build/src/bin/exrheader/CMakeFiles/exrheader.dir/main
+    # dependenty_file = $build/src/bin/exrheader/CMakeFiles/exrheader.dir/main.o.d
+
+    object_directory=$(dirname "$gcno")
+    source_base=$(basename "$gcno" ".gcno")
+    dependency_file=$object_directory/$source_base.o.d
+
+    if [ -f "$dependency_file" ]; then
+
+        source_file=$(head -2 $dependency_file | tail -1 | sed -e 's/ //' -e 's/ \\//') 
+        gcov -l -p -o $object_directory $source_file 
+    fi
 done
 
 

--- a/src/ImathTest/CMakeLists.txt
+++ b/src/ImathTest/CMakeLists.txt
@@ -75,6 +75,7 @@ set_target_properties(ImathHalfPerfTest PROPERTIES
 RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 target_link_libraries(ImathHalfPerfTest Imath::Imath)
+add_test(NAME Imath.half_perf_test COMMAND $<TARGET_FILE:ImathHalfPerfTest>)
 
 function(DEFINE_IMATH_TESTS)
   foreach(curtest IN LISTS ARGN)


### PR DESCRIPTION
Looks like the coverage analysis has been completely missing .c files.

- Set CMAKE_C_FLAGS/CMAKE_C_OUTPUT_EXTENSION_REPLACE just like CXX

- Fix run_gcov.sh to deduce the source file by examining the .o.d file rather than simply replacing .gcno with .cpp, which misses .c files

- Add ImathHalfPerfTest to the test suite