### PR TITLE
Conditionally include Matrix constructors duplicated by interop declarations

### DIFF
--- a/src/Imath/ImathMatrix.h
+++ b/src/Imath/ImathMatrix.h
@@ -77,13 +77,6 @@ public:
     ///     a a
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (T a) IMATH_NOEXCEPT;
 
-    /// Construct from 2x2 array:
-    ///
-    ///     a[0][0] a[0][1]
-    ///     a[1][0] a[1][1]
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (const T a[2][2])
-        IMATH_NOEXCEPT;
-
     /// Construct from given scalar values:
     ///
     ///     a b
@@ -144,6 +137,13 @@ public:
         return *this;
     }
     /// @}
+#else
+    /// Construct from 2x2 array:
+    ///
+    ///     a[0][0] a[0][1]
+    ///     a[1][0] a[1][1]
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (const T a[2][2])
+        IMATH_NOEXCEPT;
 #endif
 
     /// @{
@@ -407,13 +407,6 @@ public:
     ///     a a a
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (T a) IMATH_NOEXCEPT;
 
-    /// Construct from 3x3 array
-    ///     a[0][0] a[0][1] a[0][2]
-    ///     a[1][0] a[1][1] a[1][2]
-    ///     a[2][0] a[2][1] a[2][2]
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (const T a[3][3])
-        IMATH_NOEXCEPT;
-
     /// Construct from given scalar values
     ///     a b c
     ///     d e f
@@ -494,6 +487,13 @@ public:
         return *this;
     }
     /// @}
+#else
+    /// Construct from 3x3 array
+    ///     a[0][0] a[0][1] a[0][2]
+    ///     a[1][0] a[1][1] a[1][2]
+    ///     a[2][0] a[2][1] a[2][2]
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (const T a[3][3])
+        IMATH_NOEXCEPT;    
 #endif
 
     /// @{
@@ -838,14 +838,6 @@ public:
     ///     a a a a
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (T a) IMATH_NOEXCEPT;
 
-    /// Construct from 4x4 array
-    ///     a[0][0] a[0][1] a[0][2] a[0][3]
-    ///     a[1][0] a[1][1] a[1][2] a[1][3]
-    ///     a[2][0] a[2][1] a[2][2] a[2][3]
-    ///     a[3][0] a[3][1] a[3][2] a[3][3]
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (const T a[4][4])
-        IMATH_NOEXCEPT;
-
     /// Construct from given scalar values
     ///     a b c d
     ///     e f g h
@@ -964,6 +956,14 @@ public:
         return *this;
     }
     /// @}
+#else
+    /// Construct from 4x4 array
+    ///     a[0][0] a[0][1] a[0][2] a[0][3]
+    ///     a[1][0] a[1][1] a[1][2] a[1][3]
+    ///     a[2][0] a[2][1] a[2][2] a[2][3]
+    ///     a[3][0] a[3][1] a[3][2] a[3][3]
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (const T a[4][4])
+        IMATH_NOEXCEPT;
 #endif
 
     /// @{
@@ -1445,6 +1445,8 @@ IMATH_HOSTDEVICE
     x[1][1] = a;
 }
 
+#if !IMATH_FOREIGN_VECTOR_INTEROP
+
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (
     const T a[2][2]) IMATH_NOEXCEPT
@@ -1458,6 +1460,8 @@ IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (
     x[1][0] = a[1][0];
     x[1][1] = a[1][1];
 }
+
+#endif
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (
@@ -2058,6 +2062,8 @@ IMATH_HOSTDEVICE
     x[2][2] = a;
 }
 
+#if !IMATH_FOREIGN_VECTOR_INTEROP
+
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (
     const T a[3][3]) IMATH_NOEXCEPT
@@ -2076,6 +2082,8 @@ IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (
     x[2][1] = a[2][1];
     x[2][2] = a[2][2];
 }
+
+#endif
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (
@@ -3383,6 +3391,8 @@ IMATH_HOSTDEVICE
     x[3][3] = a;
 }
 
+#if !IMATH_FOREIGN_VECTOR_INTEROP
+
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (
     const T a[4][4]) IMATH_NOEXCEPT
@@ -3404,6 +3414,8 @@ IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (
     x[3][2] = a[3][2];
     x[3][3] = a[3][3];
 }
+
+#endif
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (

--- a/src/ImathTest/CMakeLists.txt
+++ b/src/ImathTest/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(ImathTest
   testSize.cpp
   testToFloat.cpp
   testInterop.cpp
+  testNoInterop.cpp
 )
 
 target_link_libraries(ImathTest Imath::Imath)
@@ -118,5 +119,6 @@ define_imath_tests(
   testJacobiEigenSolver
   testFrustumTest
   testInterop
+  testNoInterop
 )
 

--- a/src/ImathTest/main.cpp
+++ b/src/ImathTest/main.cpp
@@ -21,6 +21,7 @@
 #include "testFun.h"
 #include "testFunction.h"
 #include "testInterop.h"
+#include "testNoInterop.h"
 #include "testInterval.h"
 #include "testInvert.h"
 #include "testJacobiEigenSolver.h"
@@ -86,6 +87,7 @@ main (int argc, char* argv[])
     TEST (testJacobiEigenSolver);
     TEST (testFrustumTest);
     TEST (testInterop);
+    TEST (testNoInterop);
     // NB: If you add a test here, make sure to enumerate it in the
     // CMakeLists.txt so it runs as part of the test suite
 

--- a/src/ImathTest/testInterop.cpp
+++ b/src/ImathTest/testInterop.cpp
@@ -20,6 +20,8 @@
 using namespace std;
 using namespace IMATH_INTERNAL_NAMESPACE;
 
+#if IMATH_FOREIGN_VECTOR_INTEROP
+
 // Imath::has_subscript fails for std::vector because its length does not
 // appear to be the length of N elements. Carve out an exception here that
 // allows this to work.
@@ -29,7 +31,6 @@ struct has_subscript<std::vector<T>, T, N> : public std::true_type
 {};
 IMATH_INTERNAL_NAMESPACE_SOURCE_EXIT
 
-#if IMATH_FOREIGN_VECTOR_INTEROP
 
 namespace
 {
@@ -701,9 +702,10 @@ testInteropMx4 ()
 void
 testInterop ()
 {
+#if IMATH_FOREIGN_VECTOR_INTEROP
+    
     cout << "Testing interoperability with foreign types" << endl;
 
-#if IMATH_FOREIGN_VECTOR_INTEROP
     testInteropVec2 ();
     testInteropVec3 ();
     testInteropVec4 ();

--- a/src/ImathTest/testNoInterop.cpp
+++ b/src/ImathTest/testNoInterop.cpp
@@ -16,12 +16,6 @@
 
 using namespace std;
 
-IMATH_EXPORT
-void
-stopper()
-{
-}
-
 void
 testNoInterop ()
 {
@@ -33,10 +27,9 @@ testNoInterop ()
     
     {
         const float a[2][2] = {
-            1.0f, 0.0f,
-            0.0f, 1.0f,
+            { 1.0f, 0.0f },
+            { 0.0f, 1.0f }
         };
-        stopper();
         IMATH_INTERNAL_NAMESPACE::M22f m(a);
         assert (m[0][0] == a[0][0]);
         assert (m[0][1] == a[0][1]);
@@ -46,9 +39,9 @@ testNoInterop ()
     
     {
         const float a[3][3] = {
-            1.0f, 0.0f, 0.0f,
-            0.0f, 1.0f, 0.0f,
-            0.0f, 0.0f, 1.0f, 
+            { 1.0f, 0.0f, 0.0f },
+            { 0.0f, 1.0f, 0.0f },
+            { 0.0f, 0.0f, 1.0f } 
         };
         IMATH_INTERNAL_NAMESPACE::M33f m(a);
         assert (m[0][0] == a[0][0]);
@@ -64,10 +57,10 @@ testNoInterop ()
     
     {
         const float a[4][4] = {
-            1.0f, 0.0f, 0.0f, 0.0f,
-            0.0f, 1.0f, 0.0f, 0.0f,
-            0.0f, 0.0f, 1.0f, 0.0f,
-            0.0f, 0.0f, 0.0f, 1.0f, 
+            { 1.0f, 0.0f, 0.0f, 0.0f },
+            { 0.0f, 1.0f, 0.0f, 0.0f },
+            { 0.0f, 0.0f, 1.0f, 0.0f },
+            { 0.0f, 0.0f, 0.0f, 1.0f } 
         };
         IMATH_INTERNAL_NAMESPACE::M44f m(a);
         assert (m[0][0] == a[0][0]);

--- a/src/ImathTest/testNoInterop.cpp
+++ b/src/ImathTest/testNoInterop.cpp
@@ -1,0 +1,85 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+#ifdef NDEBUG
+#    undef NDEBUG
+#endif
+
+#define IMATH_FOREIGN_VECTOR_INTEROP 0
+
+#include <ImathMatrix.h>
+#include <ImathVec.h>
+#include <cassert>
+#include <iostream>
+
+using namespace std;
+
+IMATH_EXPORT
+void
+stopper()
+{
+}
+
+void
+testNoInterop ()
+{
+    cout << "Testing without interoperability with foreign types" << endl;
+
+    // Construction from a double-indexed array is handled by the
+    // interoperability constructors, unless theyre disabled, in which
+    // there are fallbacks for the simple types.
+    
+    {
+        const float a[2][2] = {
+            1.0f, 0.0f,
+            0.0f, 1.0f,
+        };
+        stopper();
+        IMATH_INTERNAL_NAMESPACE::M22f m(a);
+        assert (m[0][0] == a[0][0]);
+        assert (m[0][1] == a[0][1]);
+        assert (m[1][0] == a[1][0]);
+        assert (m[1][1] == a[1][1]);
+    }
+    
+    {
+        const float a[3][3] = {
+            1.0f, 0.0f, 0.0f,
+            0.0f, 1.0f, 0.0f,
+            0.0f, 0.0f, 1.0f, 
+        };
+        IMATH_INTERNAL_NAMESPACE::M33f m(a);
+        assert (m[0][0] == a[0][0]);
+        assert (m[0][1] == a[0][1]);
+        assert (m[0][2] == a[0][2]);
+        assert (m[1][0] == a[1][0]);
+        assert (m[1][1] == a[1][1]);
+        assert (m[1][2] == a[1][2]);
+        assert (m[2][0] == a[2][0]);
+        assert (m[2][1] == a[2][1]);
+        assert (m[2][2] == a[2][2]);
+    }
+    
+    {
+        const float a[4][4] = {
+            1.0f, 0.0f, 0.0f, 0.0f,
+            0.0f, 1.0f, 0.0f, 0.0f,
+            0.0f, 0.0f, 1.0f, 0.0f,
+            0.0f, 0.0f, 0.0f, 1.0f, 
+        };
+        IMATH_INTERNAL_NAMESPACE::M44f m(a);
+        assert (m[0][0] == a[0][0]);
+        assert (m[0][1] == a[0][1]);
+        assert (m[0][2] == a[0][2]);
+        assert (m[1][0] == a[1][0]);
+        assert (m[1][1] == a[1][1]);
+        assert (m[1][2] == a[1][2]);
+        assert (m[2][0] == a[2][0]);
+        assert (m[2][1] == a[2][1]);
+        assert (m[2][2] == a[2][2]);
+    }
+    
+    cout << "ok\n" << endl;
+}

--- a/src/ImathTest/testNoInterop.h
+++ b/src/ImathTest/testNoInterop.h
@@ -1,0 +1,6 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+void testNoInterop ();


### PR DESCRIPTION
From the code coverage analysis, the ``Matrix44<>(const T a[4][4])``
constructors are overshadowed by the interoperability constructors
that match types with double-index operators, making them dead code. 
This change includes them only if the interoperability constructors are 
disabled at compile time.

It also adds a test to validate compilation with the interoperability
constructors disabled.
