### PR TITLE
Undo #307, restore array-based Matrix constructors

### DIFF
--- a/src/Imath/ImathMatrix.h
+++ b/src/Imath/ImathMatrix.h
@@ -77,6 +77,11 @@ public:
     ///     a a
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (T a) IMATH_NOEXCEPT;
 
+    /// Construct from 2x2 array:
+    ///
+    ///     a[0][0] a[0][1]
+    ///     a[1][0] a[1][1]
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (const T a[2][2]) IMATH_NOEXCEPT;
     /// Construct from given scalar values:
     ///
     ///     a b
@@ -137,13 +142,6 @@ public:
         return *this;
     }
     /// @}
-#else
-    /// Construct from 2x2 array:
-    ///
-    ///     a[0][0] a[0][1]
-    ///     a[1][0] a[1][1]
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix22 (const T a[2][2])
-        IMATH_NOEXCEPT;
 #endif
 
     /// @{
@@ -407,6 +405,11 @@ public:
     ///     a a a
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (T a) IMATH_NOEXCEPT;
 
+    /// Construct from 3x3 array 
+    ///     a[0][0] a[0][1] a[0][2]
+    ///     a[1][0] a[1][1] a[1][2]
+    ///     a[2][0] a[2][1] a[2][2]
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (const T a[3][3]) IMATH_NOEXCEPT;
     /// Construct from given scalar values
     ///     a b c
     ///     d e f
@@ -487,13 +490,6 @@ public:
         return *this;
     }
     /// @}
-#else
-    /// Construct from 3x3 array
-    ///     a[0][0] a[0][1] a[0][2]
-    ///     a[1][0] a[1][1] a[1][2]
-    ///     a[2][0] a[2][1] a[2][2]
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix33 (const T a[3][3])
-        IMATH_NOEXCEPT;    
 #endif
 
     /// @{
@@ -838,6 +834,12 @@ public:
     ///     a a a a
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (T a) IMATH_NOEXCEPT;
 
+    /// Construct from 4x4 array 
+    ///     a[0][0] a[0][1] a[0][2] a[0][3]
+    ///     a[1][0] a[1][1] a[1][2] a[1][3]
+    ///     a[2][0] a[2][1] a[2][2] a[2][3]
+    ///     a[3][0] a[3][1] a[3][2] a[3][3]
+    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (const T a[4][4]) IMATH_NOEXCEPT;
     /// Construct from given scalar values
     ///     a b c d
     ///     e f g h
@@ -956,14 +958,6 @@ public:
         return *this;
     }
     /// @}
-#else
-    /// Construct from 4x4 array
-    ///     a[0][0] a[0][1] a[0][2] a[0][3]
-    ///     a[1][0] a[1][1] a[1][2] a[1][3]
-    ///     a[2][0] a[2][1] a[2][2] a[2][3]
-    ///     a[3][0] a[3][1] a[3][2] a[3][3]
-    IMATH_HOSTDEVICE IMATH_CONSTEXPR14 Matrix44 (const T a[4][4])
-        IMATH_NOEXCEPT;
 #endif
 
     /// @{
@@ -1445,8 +1439,6 @@ IMATH_HOSTDEVICE
     x[1][1] = a;
 }
 
-#if !IMATH_FOREIGN_VECTOR_INTEROP
-
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (
     const T a[2][2]) IMATH_NOEXCEPT
@@ -1460,8 +1452,6 @@ IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (
     x[1][0] = a[1][0];
     x[1][1] = a[1][1];
 }
-
-#endif
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix22<T>::Matrix22 (
@@ -2062,8 +2052,6 @@ IMATH_HOSTDEVICE
     x[2][2] = a;
 }
 
-#if !IMATH_FOREIGN_VECTOR_INTEROP
-
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (
     const T a[3][3]) IMATH_NOEXCEPT
@@ -2082,8 +2070,6 @@ IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (
     x[2][1] = a[2][1];
     x[2][2] = a[2][2];
 }
-
-#endif
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix33<T>::Matrix33 (
@@ -3391,8 +3377,6 @@ IMATH_HOSTDEVICE
     x[3][3] = a;
 }
 
-#if !IMATH_FOREIGN_VECTOR_INTEROP
-
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (
     const T a[4][4]) IMATH_NOEXCEPT
@@ -3414,8 +3398,6 @@ IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (
     x[3][2] = a[3][2];
     x[3][3] = a[3][3];
 }
-
-#endif
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline Matrix44<T>::Matrix44 (

--- a/src/ImathTest/testMatrix.cpp
+++ b/src/ImathTest/testMatrix.cpp
@@ -35,6 +35,28 @@ using IMATH_INTERNAL_NAMESPACE::Int64;
 //
 
 void
+testMatrix22ArrayConstructor(const float a[2][2])
+{
+    IMATH_INTERNAL_NAMESPACE::M22f m(a);
+    assert(m == IMATH_INTERNAL_NAMESPACE::M22f());
+}
+
+void
+testMatrix33ArrayConstructor(const float a[3][3])
+{
+    IMATH_INTERNAL_NAMESPACE::M33f m(a);
+    assert(m == IMATH_INTERNAL_NAMESPACE::M33f());
+}
+
+void
+testMatrix44ArrayConstructor(const float a[4][4])
+{
+    IMATH_INTERNAL_NAMESPACE::M44f m(a);
+    assert(m == IMATH_INTERNAL_NAMESPACE::M44f());
+}
+
+
+void
 testMatrix ()
 {
     cout << "Testing functions in ImathMatrix.h" << endl;
@@ -70,6 +92,12 @@ testMatrix ()
         test3.makeIdentity ();
         assert (test2 == test3);
 
+        const float a[2][2] = {
+            { 1.0f, 0.0f },
+            { 0.0f, 1.0f }
+        };
+        testMatrix22ArrayConstructor(a);
+        
         m1 = 42;
         assert (m1[0][0] == 42 && m1[0][1] == 42 && m1[1][0] == 42 && m1[1][1] == 42);
 
@@ -118,6 +146,13 @@ testMatrix ()
 
         assert (test5[1][0] == 3.0);
         assert (test5[1][1] == 4.0);
+
+        const float a[3][3] = {
+            { 1.0f, 0.0f, 0.0f },
+            { 0.0f, 1.0f, 0.0f },
+            { 0.0f, 0.0f, 1.0f }
+        };
+        testMatrix33ArrayConstructor(a);
     }
 
     {
@@ -324,6 +359,14 @@ testMatrix ()
         IMATH_INTERNAL_NAMESPACE::M44d test3;
         test3.makeIdentity ();
         assert (test2 == test3);
+
+        const float a[4][4] = {
+            { 1.0f, 0.0f, 0.0f, 0.0f },
+            { 0.0f, 1.0f, 0.0f, 0.0f },
+            { 0.0f, 0.0f, 1.0f, 0.0f },
+            { 0.0f, 0.0f, 0.0f, 1.0f }
+        };
+        testMatrix44ArrayConstructor(a);
 
         //
         // Test non-equality when a NAN is in the same


### PR DESCRIPTION
PR #307 was incorrect, the array-based constructors are, in fact, necessary.  Although constructing a matrix from a 2D-array variable invokes the interop constructor:
```
    const float a[2][2] = {{1,0},{0,1}};
    M22f m(a);
```
constructing a matrix from a 2D array *parameter* uses the array constructor, which #307 thought was never used, because it was never invoked by the test suite:
```
    void foo (const float a[2][2])
    {
        M22f m(a);
    }
```
This restores the constructors and adds a test.