### PR TITLE
IMATH_EXPORT for Rand32::nextf()

### DIFF
--- a/src/Imath/ImathRandom.h
+++ b/src/Imath/ImathRandom.h
@@ -29,7 +29,7 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 /// Fast random-number generator that generates
 /// a uniformly distributed sequence with a period
 /// length of 2^32.
-class IMATH_EXPORT Rand32
+class Rand32
 {
 public:
     /// Constructor, given a seed
@@ -45,7 +45,7 @@ public:
     IMATH_HOSTDEVICE unsigned long int nexti ();
 
     /// Get the next value in the sequence (range: [0 ... 1[)
-    IMATH_HOSTDEVICE float nextf ();
+    IMATH_HOSTDEVICE IMATH_EXPORT float nextf ();
 
     /// Get the next value in the sequence (range [rangeMin ... rangeMax[)
     IMATH_HOSTDEVICE float nextf (float rangeMin, float rangeMax);


### PR DESCRIPTION
Export just the one non-line method, not the entire class.

Hopefully, this addresses #311.