### PR TITLE
fix the macro switching half floating-point format implementation.

### DIFF
--- a/src/Imath/half.h
+++ b/src/Imath/half.h
@@ -979,7 +979,7 @@ IMATH_EXPORT void printBits (std::ostream& os, float f);
 IMATH_EXPORT void printBits (char c[19], IMATH_INTERNAL_NAMESPACE::half h);
 IMATH_EXPORT void printBits (char c[35], float f);
 
-#    ifndef __CUDACC__
+#    if !defined(__CUDACC__) && !defined(__CUDA_FP16_HPP__)
 using half = IMATH_INTERNAL_NAMESPACE::half;
 #    else
 #        include <cuda_fp16.h>


### PR DESCRIPTION
Hello,

I have been facing a problem conflicting two type alias `half` that are declared in Imath and [Thrust](https://github.com/NVIDIA/thrust) with CUDA.
`__CUDACC__` is defined when compiling CUDA source files, but Thrust with CUDA uses cuda_fp16.hpp in CUDA in host source files. So, two implementation of `half` conflict in host source files.
I added the condition determining whether using CUDA or not to the include guard of cuda_fp16.hpp. This prevents `half` from being re-defined by Imath when using Thrust with CUDA.