### PR TITLE
Add missing IMATH_HOSTDEVICE to Matrix33<T>::invert(bool)

### DIFF
--- a/src/Imath/ImathMatrix.h
+++ b/src/Imath/ImathMatrix.h
@@ -2828,7 +2828,7 @@ Matrix33<T>::gjInverse () const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_CONSTEXPR14 inline const Matrix33<T>&
+IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline const Matrix33<T>&
 Matrix33<T>::invert (bool singExc)
 {
     *this = inverse (singExc);


### PR DESCRIPTION
PR #198 added IMATH_HOSTDEVICE to the RB-3.1 branch, and PR #202 cherry-picked the change into main, but that cherry-pick somehow lost the IMATH_HOSTDEVICE on Matrix33<T>::invert(bool).

I discovered this some time ago but forgot to fix it at the time.