### PR TITLE
Fixed redundant PYIMATH_EXPORTS causing compile issues on Windows Clang

### DIFF
--- a/src/python/PyImath/PyImathStringTable.cpp
+++ b/src/python/PyImath/PyImathStringTable.cpp
@@ -89,8 +89,8 @@ StringTableT<T>::hasStringIndex(const StringTableIndex &s) const
 }
 
 namespace {
-template class PYIMATH_EXPORT StringTableDetailT<std::string>;
-template class PYIMATH_EXPORT StringTableDetailT<std::wstring>;
+template class StringTableDetailT<std::string>;
+template class StringTableDetailT<std::wstring>;
 }
 
 template class PYIMATH_EXPORT StringTableT<std::string>;

--- a/src/python/PyImath/PyImathUtil.h
+++ b/src/python/PyImath/PyImathUtil.h
@@ -40,10 +40,10 @@ class PyAcquireLock
     PYIMATH_EXPORT PyAcquireLock();
     PYIMATH_EXPORT ~PyAcquireLock();
 
-    PYIMATH_EXPORT PyAcquireLock(const PyAcquireLock& other) = delete;
-    PYIMATH_EXPORT PyAcquireLock & operator = (PyAcquireLock& other) = delete;
-    PYIMATH_EXPORT PyAcquireLock(PyAcquireLock&& other) = delete;
-    PYIMATH_EXPORT PyAcquireLock & operator = (PyAcquireLock&& other) = delete;
+    PyAcquireLock(const PyAcquireLock& other) = delete;
+    PyAcquireLock & operator = (PyAcquireLock& other) = delete;
+    PyAcquireLock(PyAcquireLock&& other) = delete;
+    PyAcquireLock & operator = (PyAcquireLock&& other) = delete;
     
   private:
     PyGILState_STATE _gstate;
@@ -64,10 +64,10 @@ class PyReleaseLock
   public:
     PYIMATH_EXPORT PyReleaseLock();
     PYIMATH_EXPORT ~PyReleaseLock();
-    PYIMATH_EXPORT PyReleaseLock(const PyReleaseLock& other) = delete;
-    PYIMATH_EXPORT PyReleaseLock & operator = (PyReleaseLock& other) = delete;
-    PYIMATH_EXPORT PyReleaseLock(PyReleaseLock&& other) = delete;
-    PYIMATH_EXPORT PyReleaseLock & operator = (PyReleaseLock&& other) = delete;
+    PyReleaseLock(const PyReleaseLock& other) = delete;
+    PyReleaseLock & operator = (PyReleaseLock& other) = delete;
+    PyReleaseLock(PyReleaseLock&& other) = delete;
+    PyReleaseLock & operator = (PyReleaseLock&& other) = delete;
 
   private:
     PyThreadState *_save;


### PR DESCRIPTION
Compilation of the python bindings fails using Clang on Windows, due to declared `__declspec(import)`'s on code without external linkage. The behavior in MSVC is to throw these declarations away, but Clang will error out. It doesn't cause issues to remove them, as they don't serve a functional purpose -- the changed lines are in an anonymous namespace in `PyImathStringTable.cpp` and on deleted functions in `PyImathUtil.h`. Currently the PyImathTestC and PyImathTest_Python3 tests fail in my environment, though that's unrelated to the changes in this PR.