### PR TITLE
Fixed redundant PYIMATH_EXPORTS causing compile issues on Windows Clang

### DIFF
--- a/src/python/PyImath/PyImathStringTable.cpp
+++ b/src/python/PyImath/PyImathStringTable.cpp
@@ -89,8 +89,8 @@ StringTableT<T>::hasStringIndex(const StringTableIndex &s) const
 }
 
 namespace {
-template class PYIMATH_EXPORT StringTableDetailT<std::string>;
-template class PYIMATH_EXPORT StringTableDetailT<std::wstring>;
+template class StringTableDetailT<std::string>;
+template class StringTableDetailT<std::wstring>;
 }
 
 template class PYIMATH_EXPORT StringTableT<std::string>;

--- a/src/python/PyImath/PyImathUtil.h
+++ b/src/python/PyImath/PyImathUtil.h
@@ -40,10 +40,10 @@ class PyAcquireLock
     PYIMATH_EXPORT PyAcquireLock();
     PYIMATH_EXPORT ~PyAcquireLock();
 
-    PYIMATH_EXPORT PyAcquireLock(const PyAcquireLock& other) = delete;
-    PYIMATH_EXPORT PyAcquireLock & operator = (PyAcquireLock& other) = delete;
-    PYIMATH_EXPORT PyAcquireLock(PyAcquireLock&& other) = delete;
-    PYIMATH_EXPORT PyAcquireLock & operator = (PyAcquireLock&& other) = delete;
+    PyAcquireLock(const PyAcquireLock& other) = delete;
+    PyAcquireLock & operator = (PyAcquireLock& other) = delete;
+    PyAcquireLock(PyAcquireLock&& other) = delete;
+    PyAcquireLock & operator = (PyAcquireLock&& other) = delete;
     
   private:
     PyGILState_STATE _gstate;
@@ -64,10 +64,10 @@ class PyReleaseLock
   public:
     PYIMATH_EXPORT PyReleaseLock();
     PYIMATH_EXPORT ~PyReleaseLock();
-    PYIMATH_EXPORT PyReleaseLock(const PyReleaseLock& other) = delete;
-    PYIMATH_EXPORT PyReleaseLock & operator = (PyReleaseLock& other) = delete;
-    PYIMATH_EXPORT PyReleaseLock(PyReleaseLock&& other) = delete;
-    PYIMATH_EXPORT PyReleaseLock & operator = (PyReleaseLock&& other) = delete;
+    PyReleaseLock(const PyReleaseLock& other) = delete;
+    PyReleaseLock & operator = (PyReleaseLock& other) = delete;
+    PyReleaseLock(PyReleaseLock&& other) = delete;
+    PyReleaseLock & operator = (PyReleaseLock&& other) = delete;
 
   private:
     PyThreadState *_save;


### PR DESCRIPTION
Some of the code for the python bindings declares `__declspec(export)` on code without external linkage. MSVC behavior is to ignore these declarations, but they cause Clang on Windows to error out. This PR removes `PYIMATH_EXPORT` declarations on deleted functions in `PyImathUtil.h` and in an anonymous namespace in `PyImathStringTable.cpp`.

PyImathTest_Python3 and PyImathTestC tests fail in my environment, but that's unrelated to these changes.