### PR TITLE
Expand epsilon bounds for m44x pyImath test

### DIFF
--- a/src/python/PyImathTest/pyImathTest.in
+++ b/src/python/PyImathTest/pyImathTest.in
@@ -6241,7 +6241,7 @@ def testM44x (Mat, Vec):
 
     b = m.extractSHRT(sInq, hInq, rInq, tInq)
 
-    assert sInq.equalWithAbsError(s, sInq.baseTypeEpsilon())
+    assert sInq.equalWithAbsError(s, 2 * sInq.baseTypeEpsilon())
     assert hInq.equalWithAbsError(h, hInq.baseTypeEpsilon())
     assert rInq.equalWithAbsError((0, 0, -a), 2 * rInq.baseTypeEpsilon())
     assert tInq.equalWithAbsError(t, tInq.baseTypeEpsilon())


### PR DESCRIPTION
Extends epsilon bounds for extracted scale vector comparison to allow up to one representable value of deviation in precision. This matches behavior in the M33x tests.