### PR TITLE
Fix calling default constructor to use uniform initialization.

### DIFF
--- a/src/Imath/ImathTypeTraits.h
+++ b/src/Imath/ImathTypeTraits.h
@@ -85,8 +85,8 @@ private:
     // Valid only if .x, .y exist and are the right type: return a Yes.
     template <
         typename C,
-        IMATH_ENABLE_IF (std::is_same<decltype (C ().x), Base>::value),
-        IMATH_ENABLE_IF (std::is_same<decltype (C ().y), Base>::value)>
+        IMATH_ENABLE_IF (std::is_same<decltype (C {}.x), Base>::value),
+        IMATH_ENABLE_IF (std::is_same<decltype (C {}.y), Base>::value)>
     static Yes& test (int);
 
     // Fallback, default to returning a No.
@@ -113,9 +113,9 @@ private:
     // Valid only if .x, .y, .z exist and are the right type: return a Yes.
     template <
         typename C,
-        IMATH_ENABLE_IF (std::is_same<decltype (C ().x), Base>::value),
-        IMATH_ENABLE_IF (std::is_same<decltype (C ().y), Base>::value),
-        IMATH_ENABLE_IF (std::is_same<decltype (C ().z), Base>::value)>
+        IMATH_ENABLE_IF (std::is_same<decltype (C {}.x), Base>::value),
+        IMATH_ENABLE_IF (std::is_same<decltype (C {}.y), Base>::value),
+        IMATH_ENABLE_IF (std::is_same<decltype (C {}.z), Base>::value)>
     static Yes& test (int);
 
     // Fallback, default to returning a No.
@@ -142,10 +142,10 @@ private:
     // Valid only if .x, .y, .z, .w exist and are the right type: return a Yes.
     template <
         typename C,
-        IMATH_ENABLE_IF (std::is_same<decltype (C ().x), Base>::value),
-        IMATH_ENABLE_IF (std::is_same<decltype (C ().y), Base>::value),
-        IMATH_ENABLE_IF (std::is_same<decltype (C ().z), Base>::value),
-        IMATH_ENABLE_IF (std::is_same<decltype (C ().w), Base>::value)>
+        IMATH_ENABLE_IF (std::is_same<decltype (C {}.x), Base>::value),
+        IMATH_ENABLE_IF (std::is_same<decltype (C {}.y), Base>::value),
+        IMATH_ENABLE_IF (std::is_same<decltype (C {}.z), Base>::value),
+        IMATH_ENABLE_IF (std::is_same<decltype (C {}.w), Base>::value)>
     static Yes& test (int);
 
     // Fallback, default to returning a No.
@@ -173,7 +173,7 @@ private:
     template <
         typename C,
         IMATH_ENABLE_IF (std::is_same<
-                         typename std::decay<decltype (C ()[0])>::type,
+                         typename std::decay<decltype (C {}[0])>::type,
                          Base>::value)>
     static Yes& test (int);
 
@@ -208,7 +208,7 @@ private:
     template <
         typename C,
         IMATH_ENABLE_IF (std::is_same<
-                         typename std::decay<decltype (C ()[0][0])>::type,
+                         typename std::decay<decltype (C {}[0][0])>::type,
                          Base>::value)>
     static Yes& test (int);
 


### PR DESCRIPTION
Hello,

I faced an error that let `C` be a template parameter, `C()` is interpreted as a function call when `C` is a type alias.
So, I replaced all ambiguous expression `C()` to uniform initialization `C{}`.
Could you please merge this PR?