### PR TITLE
Export Imath from a build tree.

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -69,12 +69,12 @@ endif()
 
 include(CMakePackageConfigHelpers)
 
-configure_package_config_file(ImathConfig.cmake.in
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/ImathConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
 
-write_basic_package_version_file("${PROJECT_NAME}ConfigVersion.cmake"
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
   VERSION ${IMATH_VERSION}
   COMPATIBILITY SameMajorVersion
 )
@@ -89,4 +89,9 @@ install(EXPORT ${PROJECT_NAME}
   FILE ${PROJECT_NAME}Targets.cmake
   NAMESPACE ${PROJECT_NAME}::
   EXPORT_LINK_INTERFACE_LIBRARIES
+)
+
+export(EXPORT ${PROJECT_NAME}
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake"
+  NAMESPACE ${PROJECT_NAME}::
 )


### PR DESCRIPTION
Hello,

I encountered an error saying that `Imath` wasn't in any export set when adding Imath and Alembic by `add_subdirectory()`, so I made a change exporting Imath from a build tree and making each file path of `ImathConfig.cmake.in` and `ImathConfigVersion.cmake` exact.
However, this PR requires the following code
https://github.com/AcademySoftwareFoundation/Imath/blob/4d4e01c8c9fb9b9dbbefa2e135b21778c9cd331e/CMakeLists.txt#L58
and I can't understand the reason. So, if anyone have a better way, please feel free to tell me.