### PR TITLE
IMATH_INSTALL_PKG_CONFIG is on by default, even on Windows

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -58,8 +58,9 @@ if(IMATH_INSTALL_PKG_CONFIG)
     )
   endfunction()
   imath_pkg_config_help(Imath.pc.in)
+  message(STATUS "Imath pkg-config generation enabled")
 else()
-  message(STATUS "pkg-config generation disabled")
+  message(STATUS "Imath pkg-config generation disabled")
 endif()
 
 #

--- a/config/ImathSetup.cmake
+++ b/config/ImathSetup.cmake
@@ -38,12 +38,11 @@ set(IMATH_PACKAGE_NAME "Imath ${IMATH_VERSION}${IMATH_VERSION_RELEASE_TYPE}" CAC
 
 # Whether to generate and install a pkg-config file Imath.pc on
 if(WIN32)
-  option(IMATH_INSTALL_PKG_CONFIG "Install Imath.pc file" OFF)
   option(IMATH_INSTALL_SYM_LINK "Create symbolic links for shared objects" OFF)
 else()
-  option(IMATH_INSTALL_PKG_CONFIG "Install Imath.pc file" ON)
   option(IMATH_INSTALL_SYM_LINK "Create symbolic links for shared objects" ON)
 endif()
+option(IMATH_INSTALL_PKG_CONFIG "Install Imath.pc file" ON)
 
 #
 # Build related options


### PR DESCRIPTION
Similar to
https://github.com/AcademySoftwareFoundation/openexr/pull/1541, there seems to be no downside to generating the Imath.pc file even on windows, so for consistency, apply the same default to all platforms.