### PR TITLE
Changed implementation of succ and pred to use std::nextafter.

### DIFF
--- a/src/Imath/ImathFun.cpp
+++ b/src/Imath/ImathFun.cpp
@@ -4,159 +4,32 @@
 //
 
 #include "ImathFun.h"
+#include <cmath>
 
 IMATH_INTERNAL_NAMESPACE_SOURCE_ENTER
 
-float
-succf (float f) IMATH_NOEXCEPT
+float succf(float f) IMATH_NOEXCEPT
 {
-    union
-    {
-        float    f;
-        uint32_t i;
-    } u;
-    u.f = f;
-
-    if (isinf (f) || isnan (f))
-    {
-        // Nan or infinity; don't change value.
-    }
-    else if (u.i == 0x00000000 || u.i == 0x80000000)
-    {
-        // Plus or minus zero.
-
-        u.i = 0x00000001;
-    }
-    else if (u.f > 0)
-    {
-        // Positive float, normalized or denormalized.
-        // Incrementing the largest positive float
-        // produces +infinity.
-
-        ++u.i;
-    }
-    else
-    {
-        // Negative normalized or denormalized float.
-
-        --u.i;
-    }
-
-    return u.f;
+    return isfinite(f) ?
+            std::nextafter(f, std::numeric_limits<float>::infinity()) : f;
 }
 
-float
-predf (float f) IMATH_NOEXCEPT
+float predf(float f) IMATH_NOEXCEPT
 {
-    union
-    {
-        float    f;
-        uint32_t i;
-    } u;
-    u.f = f;
-
-    if (isinf (f) || isnan (f))
-    {
-        // Nan or infinity; don't change value.
-    }
-    else if (u.i == 0x00000000 || u.i == 0x80000000)
-    {
-        // Plus or minus zero.
-
-        u.i = 0x80000001;
-    }
-    else if (u.f > 0)
-    {
-        // Positive float, normalized or denormalized.
-
-        --u.i;
-    }
-    else
-    {
-        // Negative normalized or denormalized float.
-        // Decrementing the largest negative float
-        // produces -infinity.
-
-        ++u.i;
-    }
-
-    return u.f;
+    return isfinite(f) ?
+            std::nextafter(f, -std::numeric_limits<float>::infinity()) : f;
 }
 
-double
-succd (double d) IMATH_NOEXCEPT
+double succd(double d) IMATH_NOEXCEPT
 {
-    union
-    {
-        double   d;
-        uint64_t i;
-    } u;
-    u.d = d;
-
-    if (isinf (d) || isnan (d))
-    {
-        // Nan or infinity; don't change value.
-    }
-    else if (u.i == 0x0000000000000000LL || u.i == 0x8000000000000000LL)
-    {
-        // Plus or minus zero.
-
-        u.i = 0x0000000000000001LL;
-    }
-    else if (u.d > 0)
-    {
-        // Positive double, normalized or denormalized.
-        // Incrementing the largest positive double
-        // produces +infinity.
-
-        ++u.i;
-    }
-    else
-    {
-        // Negative normalized or denormalized double.
-
-        --u.i;
-    }
-
-    return u.d;
+    return isfinite(d) ?
+            std::nextafter(d, std::numeric_limits<double>::infinity()) : d;
 }
 
-double
-predd (double d) IMATH_NOEXCEPT
+double predd(double d) IMATH_NOEXCEPT
 {
-    union
-    {
-        double   d;
-        uint64_t i;
-    } u;
-    u.d = d;
-
-    if ((u.i & 0x7ff0000000000000LL) == 0x7ff0000000000000LL)
-    {
-        // Nan or infinity; don't change value.
-    }
-    else if (u.i == 0x0000000000000000LL || u.i == 0x8000000000000000LL)
-    {
-        // Plus or minus zero.
-
-        u.i = 0x8000000000000001LL;
-    }
-    else if (u.d > 0)
-    {
-        // Positive double, normalized or denormalized.
-
-        --u.i;
-    }
-    else
-    {
-        // Negative normalized or denormalized double.
-        // Decrementing the largest negative double
-        // produces -infinity.
-
-        ++u.i;
-    }
-
-    return u.d;
+    return isfinite(d) ?
+            std::nextafter(d, -std::numeric_limits<double>::infinity()) : d;
 }
 
 IMATH_INTERNAL_NAMESPACE_SOURCE_EXIT


### PR DESCRIPTION
Hey. I didn't really deprecate them because there is no 1:1 equivalent in std. Instead I replaced the implementation to use std::nextafter. All tests pass.