### PR TITLE
ImathFun.cpp: add std:: to isfinite in remaining cases

### DIFF
--- a/src/Imath/ImathFun.cpp
+++ b/src/Imath/ImathFun.cpp
@@ -10,13 +10,13 @@ IMATH_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 float succf(float f) IMATH_NOEXCEPT
 {
-    return isfinite(f) ?
+    return std::isfinite(f) ?
             std::nextafter(f, std::numeric_limits<float>::infinity()) : f;
 }
 
 float predf(float f) IMATH_NOEXCEPT
 {
-    return isfinite(f) ?
+    return std::isfinite(f) ?
             std::nextafter(f, -std::numeric_limits<float>::infinity()) : f;
 }
 


### PR DESCRIPTION
A follow-up to https://github.com/AcademySoftwareFoundation/Imath/pull/368
Fixes: https://github.com/AcademySoftwareFoundation/Imath/issues/367