### PR TITLE
Bump required cmake to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenEXR Project.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.14)
 
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/website/install.rst
+++ b/website/install.rst
@@ -51,7 +51,7 @@ Prerequisites
 
 Make sure these are installed on your system before building Imath:
 
-* Imath requires CMake version 3.12 or newer
+* Imath requires CMake version 3.14 or newer
 * C++ compiler that supports C++11
 
 The instructions that follow describe building Imath with CMake.


### PR DESCRIPTION
This should have gone into PR #366, since `file(CREATE_LINK)` was introduced in cmake 3.14, not sure how it slipped through the CI.