### PR TITLE
Pin RTD sphinx to 5.3

### DIFF
--- a/website/requirements.txt
+++ b/website/requirements.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) Contributors to the OpenEXR Project.
 
-sphinx >= 5.0
+sphinx == 5.3
 breathe
 sphinx-press-theme


### PR DESCRIPTION
Sphinx handling of `html_logo` and `html_favicon` changed in version 6, but changing to the documented `logo_url` and `favicon_url` still doesn't work for some reason. But Sphinx 5.3 works, so let's pin to that. This will need to get sorted out at some point, when there's a need to move to a newer sphinx.