### PR TITLE
Add custom website footer with ASWF logo and proper copyright

### DIFF
--- a/website/_templates/layout.html
+++ b/website/_templates/layout.html
@@ -1,0 +1,14 @@
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<!-- Copyright Contributors to the OpenEXR Project. -->
+
+{% extends '!layout.html' %}
+
+{% block footer %}
+
+<p><center><img height="30" width="160" src="https://artwork.aswf.io/other/aswf/logo/black/aswf-logo-black.svg" /></center></p>
+
+<p><small><center>Copyright © OpenEXR a Series of LF Projects, LLC. </center></small></p>
+<p><small><center>For web site terms of use, trademark policy and other project policies
+please see <a href="https://lfprojects.org">https://lfprojects.org</a>.</center></small></p>
+
+{% endblock %}

--- a/website/conf.py
+++ b/website/conf.py
@@ -74,7 +74,6 @@ source_suffix = '.rst'
 
 # General information about the project.
 project = 'Imath'
-copyright = '2021, Contributors to the OpenEXR Project'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
This adds the LF-recommended website copyright notice, with an ASWF logo:

Copyright © OpenEXR a Series of LF Projects, LLC.
For web site terms of use, trademark policy and other project policies please see https://lfprojects.org

Sphinx doesn't support fancy, multiline copyright footers, so the suggested alternative is raw html in the layout.html template.

And note that per LF policy, the copyright for website content is different from the copyright for source files.