### PR TITLE
Update sigstore release signing action

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -57,9 +57,11 @@ jobs:
         uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: ${{ env.IMATH_TARBALL }}
+          upload-signing-artifacts: false
+          release-signing-artifacts: false
 
       - name: Upload release archive
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload ${{ github.ref_name }} ${IMATH_TARBALL} ${IMATH_TARBALL}.sigstore
+        run: gh release upload ${{ github.ref_name }} ${IMATH_TARBALL} ${IMATH_TARBALL}.sigstore.json
 


### PR DESCRIPTION
The default behavior of sigstore/gh-action-sigstore-python has changed. Disable the automatic uploading of signed artifacts, since this now includes artifacts named with just the tag, without the "Imath-" prefix.

Also, the signature file now has a .json suffix.