### PR TITLE
Add nanobind Python bindings

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -217,6 +217,36 @@ jobs:
             pybind11: 'ON'
             python-desc: python3.11
             vfx-cy: 2024
+
+          # -------------------------------------------------------------------
+          # nanobind and python together
+          # -------------------------------------------------------------------
+          - build: 10
+            build-type: Release
+            build-shared: 'ON'
+            cxx-standard: 17
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: gcc11.2.1
+            python: 'ON'
+            nanobind: 'ON'
+            python-desc: python3.11
+            vfx-cy: 2024
+
+          # -------------------------------------------------------------------
+          # nanobind w/o python
+          # -------------------------------------------------------------------
+          - build: 11
+            build-type: Release
+            build-shared: 'ON'
+            cxx-standard: 17
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: gcc11.2.1
+            python: 'OFF'
+            nanobind: 'ON'
+            python-desc: python3.11
+            vfx-cy: 2024
     env:
       CXX: ${{ matrix.cxx-compiler }}
       CC: ${{ matrix.cc-compiler }}
@@ -241,6 +271,7 @@ jobs:
                 -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} \
                 -DPYTHON=${{ matrix.python }} \
                 -DPYBIND11=${{ matrix.pybind11 }} \
+                -DNANOBIND=${{ matrix.nanobind }} \
                 -DUSE_PYTHON2=${{ matrix.use-python2 }}
         working-directory: _build
       - name: Build
@@ -288,6 +319,10 @@ jobs:
           if [[ "${{ matrix.pybind11 }}" == "ON" ]]; then
               export PYTHONPATH=`find ../_install -name 'pybindimath.*.so' | xargs dirname`
               python -c "import pybindimath;print(pybindimath.__version__)"
+          fi
+          if [[ "${{ matrix.nanobind }}" == "ON" ]]; then
+              export PYTHONPATH=`find ../_install -name 'nanobindimath.*.so' | xargs dirname`
+              python -c "import nanobindimath;print(nanobindimath.__version__)"
           fi
         shell: bash
         working-directory: _build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,11 @@ if (PYBIND11)
   add_subdirectory(src/pybind11)
 endif()
 
+option(NANOBIND "Set ON to compile nanobind PyImath bindings")
+if (NANOBIND)
+  add_subdirectory(src/nanobind)
+endif()
+
 option(BUILD_WEBSITE "Set ON to build the readthedocs website source")
 if (BUILD_WEBSITE AND NOT IMATH_IS_SUBPROJECT)
   add_subdirectory(website)
@@ -119,4 +124,3 @@ endif()
 if(NOT IMATH_IS_SUBPROJECT)
   include(cmake/clang-format.cmake)
 endif()
-

--- a/src/nanobind/CMakeLists.txt
+++ b/src/nanobind/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+
+set(NANOBINDIMATH_OVERRIDE_PYTHON_INSTALL_DIR "" CACHE STRING "Override the install location for imath.so and imathnumpy.so modules")
+
+########################
+## Build related options
+
+# Suffix to append to root name, this helps with version management
+# but can be turned off if you don't care, or otherwise customized
+#
+set(NANOBINDIMATH_LIB_SUFFIX "-${IMATH_VERSION_API}" CACHE STRING "String added to the end of all the libraries")
+# This provides a root for the unique name of the library based on
+# the version of python being compiled for
+set(NANOBINDIMATH_LIB_PYTHONVER_ROOT "_Python" CACHE STRING "String added as a root to the identifier of the python version in the libraries")
+
+add_subdirectory(NanobindImath)

--- a/src/nanobind/NanobindImath/CMakeLists.txt
+++ b/src/nanobind/NanobindImath/CMakeLists.txt
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+
+find_package(Python REQUIRED COMPONENTS Interpreter Development)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+find_package(nanobind REQUIRED)
+
+#
+# Source/headers
+#
+
+set(NANOBINDIMATH_SOURCES
+    NanobindImathBox.cpp
+    NanobindImathVec.cpp
+)
+
+set(NANOBINDIMATH_HEADERS
+    NanobindImathExport.h
+    NanobindImath.h
+)
+
+#
+# shared library, e.g. libNanobindImath_Python3_11-3_2.so.30.3.2.0
+#
+
+set(NANOBINDIMATH_LIBRARY NanobindImath)
+
+add_library(${NANOBINDIMATH_LIBRARY} SHARED ${NANOBINDIMATH_SOURCES})
+
+nanobind_build_library(nanobind-static)
+
+target_link_libraries(${NANOBINDIMATH_LIBRARY} PRIVATE Imath::Imath nanobind-static)
+
+# Set include directories
+target_include_directories(${NANOBINDIMATH_LIBRARY} PRIVATE ${Python3_INCLUDE_DIRS} ${Imath_INCLUDE_DIRS})
+
+if(NOT "${NANOBINDIMATH_LIB_PYTHONVER_ROOT}" STREQUAL "")
+  set(pythonver_root "${NANOBINDIMATH_LIB_PYTHONVER_ROOT}${Python3_VERSION_MAJOR}_${Python3_VERSION_MINOR}")
+  message("pythonver_root ${NANOBINDIMATH_LIB_PYTHONVER_ROOT}${Python3_VERSION_MAJOR}_${Python3_VERSION_MINOR}")
+endif()
+
+if(BUILD_SHARED_LIBS)
+  # This creates the so-versioned library symlinks
+  set_target_properties(${NANOBINDIMATH_LIBRARY} PROPERTIES
+    SOVERSION ${IMATH_LIB_SOVERSION}
+    VERSION ${IMATH_LIB_VERSION}
+    OUTPUT_NAME "${NANOBINDIMATH_CURLIB_OUTROOT}${NANOBINDIMATH_LIBRARY}${pythonver_root}${NANOBINDIMATH_LIB_SUFFIX}"
+  )
+endif()
+
+#
+# python module, e.g. nanobindimath.cpython-311-x86_64-linux-gnu.so
+#
+
+set(NANOBINDIMATH_MODULE nanobindimath)
+
+nanobind_add_module(nanobindimath MODULE nanobindimathmodule.cpp $<TARGET_OBJECTS:${NANOBINDIMATH_LIBRARY}>)
+
+target_link_libraries(${NANOBINDIMATH_MODULE} PRIVATE Imath::Imath)
+
+if(SKBUILD)
+  set(PYTHON_INSTALL_DIR ${SKBUILD_PLATLIB_DIR})
+else()
+  set(PYTHON_INSTALL_DIR "lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages")
+endif()
+
+if (IMATH_INSTALL)
+
+  # module
+
+  install(TARGETS ${NANOBINDIMATH_MODULE} DESTINATION ${PYTHON_INSTALL_DIR} COMPONENT python)
+
+  # shared library
+
+  install(TARGETS ${NANOBINDIMATH_LIBRARY}
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+  if(BUILD_SHARED_LIBS AND (NOT "${IMATH_LIB_SUFFIX}" STREQUAL "") AND IMATH_INSTALL_SYM_LINK)
+
+    # create symlinks for the shared object so versions
+
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
+    set(verlibname ${CMAKE_SHARED_LIBRARY_PREFIX}${NANOBINDIMATH_LIBRARY}${pythonver_root}${IMATH_LIB_SUFFIX}${CMAKE_${uppercase_CMAKE_BUILD_TYPE}_POSTFIX}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    set(baselibname ${CMAKE_SHARED_LIBRARY_PREFIX}${NANOBINDIMATH_LIBRARY}${pythonver_root}${CMAKE_${uppercase_CMAKE_BUILD_TYPE}_POSTFIX}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    file(CREATE_LINK ${verlibname} ${CMAKE_CURRENT_BINARY_DIR}/${baselibname} SYMBOLIC)
+    if(WIN32)
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${baselibname} DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+      install(CODE "message(STATUS \"Creating symlink ${CMAKE_INSTALL_FULL_BINDIR}/${baselibname} -> ${verlibname}\")")
+    else()
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${baselibname} DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
+      install(CODE "message(STATUS \"Creating symlink ${CMAKE_INSTALL_FULL_LIBDIR}/${baselibname} -> ${verlibname}\")")
+    endif()
+  endif()
+
+  # pkgconfig
+
+  set(pcinfile NanobindImath.pc.in)
+  set(prefix ${CMAKE_INSTALL_PREFIX})
+  set(exec_prefix "\${prefix}")
+  set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+  set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+  string(REPLACE ".in" "" pcout ${pcinfile})
+  configure_file(${pcinfile} ${CMAKE_CURRENT_BINARY_DIR}/${pcout} @ONLY)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${pcout} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+endif()

--- a/src/nanobind/NanobindImath/NanobindImath.h
+++ b/src/nanobind/NanobindImath/NanobindImath.h
@@ -1,0 +1,22 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+// clang-format off
+
+#include <nanobind/nanobind.h>
+#include <nanobind/operators.h>
+#include "NanobindImathExport.h"
+
+#ifndef _NanobindImath_h_
+#define _NanobindImath_h_
+
+namespace NanobindImath {
+
+NANOBINDIMATH_EXPORT void register_imath_vec(nanobind::module_& m);
+NANOBINDIMATH_EXPORT void register_imath_box(nanobind::module_& m);
+
+}
+
+#endif

--- a/src/nanobind/NanobindImath/NanobindImath.pc.in
+++ b/src/nanobind/NanobindImath/NanobindImath.pc.in
@@ -1,0 +1,17 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+pythonver=@pythonver_root@
+
+Name: NanobindImath
+Description: nanobind-based python bindings for the Imath libraries
+Version: @IMATH_VERSION@
+Libs: -L${libdir} -lImath${libsuffix} -lNanobindImath${pythonver$}${libsuffix}
+
+Cflags: -I${includedir} -I${includedir}/Imath

--- a/src/nanobind/NanobindImath/NanobindImathBox.cpp
+++ b/src/nanobind/NanobindImath/NanobindImathBox.cpp
@@ -1,0 +1,60 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+#include "NanobindImath.h"
+#include <ImathBox.h>
+
+namespace NanobindImath {
+
+template <class T, class V>
+void register_box(nanobind::class_<T>& c)
+{
+    c.def(nanobind::init<>())
+    .def(nanobind::init<const V &>())
+    .def(nanobind::init<const V &, const V &>())
+    .def(nanobind::self == nanobind::self)
+    .def(nanobind::self != nanobind::self)
+    .def("makeEmpty", &T::makeEmpty, "makeEmpty() make the box empty")
+    .def("makeInfinite", &T::makeInfinite, "makeInfinite() make the box cover all space")
+    .def_rw("min", &T::min)
+    .def_rw("max", &T::max)
+    .def("extendBy", nanobind::overload_cast<const T &>(&T::extendBy), "extendBy(point) extend the box by a box")
+    .def("extendBy", nanobind::overload_cast<const V &>(&T::extendBy), "extendBy(point) extend the box by a point")
+    .def("size", &T::size, "size() size of the box")
+    .def("center", &T::center, "center() center of the box")
+    .def("intersects",nanobind::overload_cast<const V &>(&T::extendBy), "intersects(point) returns true if the box intersects the given point")
+    .def("intersects",nanobind::overload_cast<const T &>(&T::extendBy), "intersects(box) returns true if the box intersects the given box")
+    .def("majorAxis",&T::majorAxis, "majorAxis() major axis of the box")
+    .def("isEmpty",&T::isEmpty, "isEmpty() returns true if the box is empty")
+    .def("isInfinite",&T::isInfinite, "isInfinite() returns true if the box covers all space")
+    .def("hasVolume",&T::hasVolume, "hasVolume() returns true if the box has volume");
+
+}
+
+template <class T, class V>
+void register_box2(nanobind::module_& m, const char * name)
+{
+    nanobind::class_<T> c(m, name);
+    register_box<T, V>(c);
+}
+
+template <class T, class V>
+void register_box3(nanobind::module_& m, const char * name)
+{
+    nanobind::class_<T> c(m, name);
+    register_box<T, V>(c);
+}
+
+void register_imath_box(nanobind::module_& m)
+{
+    register_box2<Imath::Box2d, Imath::V2d>(m, "Box2d");
+    register_box2<Imath::Box2f, Imath::V2f>(m, "Box2f");
+
+    register_box3<Imath::Box3d, Imath::V3d>(m, "Box3d");
+    register_box3<Imath::Box3f, Imath::V3f>(m, "Box3f");
+
+}
+
+}

--- a/src/nanobind/NanobindImath/NanobindImathExport.h
+++ b/src/nanobind/NanobindImath/NanobindImathExport.h
@@ -1,0 +1,28 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+// clang-format off
+
+#ifndef NANOBINDIMATHEXPORT_H
+#define NANOBINDIMATHEXPORT_H
+
+#if defined(IMATH_DLL)
+    #if defined(PLATFORM_VISIBILITY_AVAILABLE)
+        #define NANOBINDIMATH_EXPORT __attribute__((visibility("default")))
+        #define NANOBINDIMATH_EXPORT __attribute__((visibility("default")))
+    #elif defined(_MSC_VER)
+        #if defined(NANOBINDIMATH_BUILD)
+            #define NANOBINDIMATH_EXPORT __declspec(dllexport)
+        #else
+            #define NANOBINDIMATH_EXPORT __declspec(dllimport)
+        #endif
+    #else
+        #define NANOBINDIMATH_EXPORT
+    #endif
+#else
+    #define NANOBINDIMATH_EXPORT
+#endif
+
+#endif // #ifndef NANOBINDIMATHEXPORT_H

--- a/src/nanobind/NanobindImath/NanobindImathVec.cpp
+++ b/src/nanobind/NanobindImath/NanobindImathVec.cpp
@@ -1,0 +1,127 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+#include "NanobindImath.h"
+#include <ImathVec.h>
+#include <ImathVecAlgo.h>
+
+namespace NanobindImath {
+
+template <class T>
+void register_vec(nanobind::class_<T>& c)
+{
+    c.def(nanobind::self == nanobind::self)
+    .def(nanobind::self != nanobind::self)
+    .def(nanobind::self + nanobind::self)
+    .def(nanobind::self += nanobind::self)
+    .def(nanobind::self * nanobind::self)
+    .def(nanobind::self * int())
+    .def(nanobind::self * float())
+    .def(nanobind::self * double())
+    .def(nanobind::self *= nanobind::self)
+    .def(nanobind::self *= int())
+    .def(nanobind::self *= float())
+    .def(nanobind::self *= double())
+    .def(nanobind::self / nanobind::self)
+    .def(nanobind::self / int())
+    .def(nanobind::self / float())
+    .def(nanobind::self / double())
+    .def(nanobind::self /= nanobind::self)
+    .def(nanobind::self /= int())
+    .def(nanobind::self /= float())
+    .def(nanobind::self /= double())
+    .def(nanobind::self - nanobind::self)
+    .def(nanobind::self -= nanobind::self)
+    .def(nanobind::self ^ nanobind::self)
+    .def(-nanobind::self)
+    .def_static("baseTypeEpsilon", &T::baseTypeEpsilon,"baseTypeEpsilon() epsilon value of the base type of the vector")
+    .def_static("baseTypeMax", &T::baseTypeMax,"baseTypeMax() max value of the base type of the vector")
+    .def_static("baseTypeLowest", &T::baseTypeLowest,"baseTypeLowest() largest negative value of the base type of the vector")
+    .def_static("baseTypeSmallest", &T::baseTypeSmallest,"baseTypeSmallest() smallest value of the base type of the vector")
+    .def("dot", &T::dot, "v1.dot(v2) inner product of the two vectors")
+    .def("dimensions", &T::dimensions, "dimensions() number of dimensions in the vector")
+    .def("equalWithAbsError", &T::equalWithAbsError, "v1.equalWithAbsError(v2) true if the elements of v1 and v2 are the same with an absolute error of no more than e, i.e., abs(v1[i] - v2[i]) <= e")
+    .def("equalWithRelError", &T::equalWithRelError, "v1.equalWithRelError(v2) true if the elements of v1 and v2 are the same with a relative error of no more than e, i.e., abs(v1[i] - v2[i]) <= e * abs(v1[i])")
+    .def("length", &T::length, "length() magnitude of the vector")
+    .def("length2", &T::length2,"length2() square magnitude of the vector")
+    .def("negate", &T::negate)
+    .def("normalize", &T::normalize, "v.normalize() destructively normalizes v and returns a reference to it")
+    .def("normalizeExc", &T::normalizeExc, "v.normalizeExc() destructively normalizes V and returns a reference to it, throwing an exception if length() == 0")
+    .def("normalizeNonNull",  &T::normalizeNonNull, "v.normalizeNonNull() destructively normalizes V and returns a reference to it, faster if length() != 0")
+    .def("normalized", &T::normalized, "v.normalized() returns a normalized copy of v")
+    .def("normalizedExc", &T::normalizedExc, "v.normalizedExc() returns a normalized copy of v, throwing an exception if length() == 0")
+    .def("normalizedNonNull", &T::normalizedNonNull, "v.normalizedNonNull() returns a normalized copy of v, faster if lngth() != 0")
+
+    // things from ImathVecAlgo
+    .def("closestVertex", &IMATH_NAMESPACE::closestVertex<T>)
+    .def("orthogonal", &IMATH_NAMESPACE::orthogonal<T>)
+    .def("project", &IMATH_NAMESPACE::project<T>)
+    .def("reflect", &IMATH_NAMESPACE::reflect<T>)
+    ;
+}
+
+template <class T, class S>
+void register_vec2(nanobind::module_& m, const char * name)
+{
+    // no %=
+
+    nanobind::class_<T> c(m, name);
+    c.def(nanobind::init<>())
+    .def(nanobind::init<S>())
+    .def(nanobind::init<S, S>())
+    .def(nanobind::self % nanobind::self)
+    .def("cross", &T::cross, "v1.cross(v2) right handed cross product")
+    .def_rw("x", &T::x)
+    .def_rw("y", &T::y);
+
+    register_vec<T>(c);
+}
+
+template <class T, class S>
+void register_vec3(nanobind::module_& m, const char * name)
+{
+    nanobind::class_<T> c(m, name);
+    c.def(nanobind::init<>())
+    .def(nanobind::init<S>())
+    .def(nanobind::init<S, S, S>())
+    .def(nanobind::self % nanobind::self)
+    .def(nanobind::self %= nanobind::self)
+    .def("cross", &T::cross, "v1.cross(v2) right handed cross product")
+    .def_rw("x", &T::x)
+    .def_rw("y", &T::y)
+    .def_rw("z", &T::z);
+
+    register_vec<T>(c);
+}
+
+template <class T, class S>
+void register_vec4(nanobind::module_& m, const char * name)
+{
+    // Does a cross product not exist for Vec4? if not then thats why there is no % %= cross
+    nanobind::class_<T> c(m, name);
+    c.def(nanobind::init<>())
+    .def(nanobind::init<S>())
+    .def(nanobind::init<S, S, S, S>())
+    .def_rw("x", &T::x)
+    .def_rw("y", &T::y)
+    .def_rw("z", &T::z)
+    .def_rw("w", &T::z);
+
+    register_vec<T>(c);
+}
+
+void register_imath_vec(nanobind::module_& m)
+{
+    register_vec2<Imath::V2d, double>(m, "V2d");
+    register_vec2<Imath::V2f, float>(m, "V2f");
+
+    register_vec3<Imath::V3d, double>(m, "V3d");
+    register_vec3<Imath::V3f, float>(m, "V3f");
+
+    register_vec4<Imath::V4d, double>(m, "V4d");
+    register_vec4<Imath::V4f, float>(m, "V4f");
+}
+
+}

--- a/src/nanobind/NanobindImath/nanobindimathmodule.cpp
+++ b/src/nanobind/NanobindImath/nanobindimathmodule.cpp
@@ -1,0 +1,74 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+#include "NanobindImath.h"
+#include <ImathEuler.h>
+
+NB_MODULE(nanobindimath, m)
+{
+    m.doc() = "NanobindImath module";
+    m.attr("__version__") = IMATH_VERSION_STRING;
+
+    NanobindImath::register_imath_vec(m);
+    NanobindImath::register_imath_box(m);
+
+    //
+    // Initialize constants
+    //
+    nanobind::enum_<IMATH_NAMESPACE::Eulerf::Order>(m, "Order")
+        .value("EULER_XYZ", IMATH_NAMESPACE::Eulerf::XYZ)
+        .value("EULER_XZY", IMATH_NAMESPACE::Eulerf::XZY)
+        .value("EULER_YZX", IMATH_NAMESPACE::Eulerf::YZX)
+        .value("EULER_YXZ", IMATH_NAMESPACE::Eulerf::YXZ)
+        .value("EULER_ZXY", IMATH_NAMESPACE::Eulerf::ZXY)
+        .value("EULER_ZYX", IMATH_NAMESPACE::Eulerf::ZYX)
+        .value("EULER_XZX", IMATH_NAMESPACE::Eulerf::XZX)
+        .value("EULER_XYX", IMATH_NAMESPACE::Eulerf::XYX)
+        .value("EULER_YXY", IMATH_NAMESPACE::Eulerf::YXY)
+        .value("EULER_YZY", IMATH_NAMESPACE::Eulerf::YZY)
+        .value("EULER_ZYZ", IMATH_NAMESPACE::Eulerf::ZYZ)
+        .value("EULER_ZXZ", IMATH_NAMESPACE::Eulerf::ZXZ)
+        .value("EULER_XYZr", IMATH_NAMESPACE::Eulerf::XYZr)
+        .value("EULER_XZYr", IMATH_NAMESPACE::Eulerf::XZYr)
+        .value("EULER_YZXr", IMATH_NAMESPACE::Eulerf::YZXr)
+        .value("EULER_YXZr", IMATH_NAMESPACE::Eulerf::YXZr)
+        .value("EULER_ZXYr", IMATH_NAMESPACE::Eulerf::ZXYr)
+        .value("EULER_ZYXr", IMATH_NAMESPACE::Eulerf::ZYXr)
+        .value("EULER_XZXr", IMATH_NAMESPACE::Eulerf::XZXr)
+        .value("EULER_XYXr", IMATH_NAMESPACE::Eulerf::XYXr)
+        .value("EULER_YXYr", IMATH_NAMESPACE::Eulerf::YXYr)
+        .value("EULER_YZYr", IMATH_NAMESPACE::Eulerf::YZYr)
+        .value("EULER_ZYZr", IMATH_NAMESPACE::Eulerf::ZYZr)
+        .value("EULER_ZXZr", IMATH_NAMESPACE::Eulerf::ZXZr)
+        .export_values();
+
+    nanobind::enum_<IMATH_NAMESPACE::Eulerf::Axis>(m, "Axis")
+        .value("EULER_X_AXIS", IMATH_NAMESPACE::Eulerf::X)
+        .value("EULER_Y_AXIS", IMATH_NAMESPACE::Eulerf::Y)
+        .value("EULER_Z_AXIS", IMATH_NAMESPACE::Eulerf::Z)
+        .export_values();
+
+    nanobind::enum_<IMATH_NAMESPACE::Eulerf::InputLayout>(m, "InputLayout")
+        .value("EULER_IJKLayout", IMATH_NAMESPACE::Eulerf::IJKLayout)
+        .value("EULER_XYZLayout", IMATH_NAMESPACE::Eulerf::XYZLayout)
+        .export_values();
+
+
+    m.attr("INT_MIN")      = std::numeric_limits<int>::min();
+    m.attr("INT_MAX")      = std::numeric_limits<int>::max();
+    m.attr("INT_LOWEST")   = std::numeric_limits<int>::lowest();
+    m.attr("INT_EPS")      = std::numeric_limits<int>::epsilon();
+
+    m.attr("FLT_MIN")      = std::numeric_limits<float>::min();
+    m.attr("FLT_MAX")      = std::numeric_limits<float>::max();
+    m.attr("FLT_LOWEST")   = std::numeric_limits<float>::lowest();
+    m.attr("FLT_EPS")      = std::numeric_limits<float>::epsilon();
+
+    m.attr("DBL_MIN")      = std::numeric_limits<double>::min();
+    m.attr("DBL_MAX")      = std::numeric_limits<double>::max();
+    m.attr("DBL_LOWEST")   = std::numeric_limits<double>::lowest();
+    m.attr("DBL_EPS")      = std::numeric_limits<double>::epsilon();
+
+}


### PR DESCRIPTION
Closes #433

This PR adds a new target, `NanobindImath` for the `nanobind` version of the `pybind11` bindings. To build the `nanobind` bindings, the `-DNANOBIND` CMake option must be `'ON'`. `pybind11` bindings are still available.

As expected, `nanobind` is almost entirely compatible with the previous `pybind11` bindings with only a few differences:
- The `def_readwrite` member function is renamed to `def_rw`
- The `module` type is renamed to `module_`. Probably so it doesn't collide with the C++20 modules keywords.
- In CMake, calling `nanobind_build_library(nanobind-static)` is necessary to build a static library for the `libNanobindImath...` shared library to link with.

I couldn't test compilation time/runtime performance very reliably, but the resulting binaries are significantly smaller.

Less than half the size for the python module:
```
356K    lib/python3.12/site-packages/nanobindimath.cpython-312-x86_64-linux-gnu.so
740K    lib/python3.12/site-packages/pybindimath.cpython-312-x86_64-linux-gnu.so
```

And less than 1/10 of the size for the shared library.
```
88K     lib/libNanobindImath_Python3_12-3_2.so.30.3.2.0
1016K   lib/libPyBindImath_Python3_12-3_2.so.30.3.2.0
```

Both the `nanobind` and `pybind11` bindings are fairly small compared to the Boost bindings, so these size ratios may not scale linearly, but I think it's promising.