### PR TITLE
Add pybind11 wrappings for Imath::Plane

### DIFF
--- a/src/pybind11/PyBindImath/CMakeLists.txt
+++ b/src/pybind11/PyBindImath/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(pybind11 REQUIRED)
 set(PYBINDIMATH_SOURCES
     PyBindImathBox.cpp
     PyBindImathVec.cpp
+    PyBindImathPlane.cpp
+    PyBindImathLine.cpp
 )
 
 set(PYBINDIMATH_HEADERS

--- a/src/pybind11/PyBindImath/PyBindImath.h
+++ b/src/pybind11/PyBindImath/PyBindImath.h
@@ -19,7 +19,8 @@ namespace PyBindImath {
 
 PYBINDIMATH_EXPORT void register_imath_vec(pybind11::module& m);
 PYBINDIMATH_EXPORT void register_imath_box(pybind11::module& m);
-
+PYBINDIMATH_EXPORT void register_imath_plane(pybind11::module& m);
+PYBINDIMATH_EXPORT void register_imath_line(pybind11::module& m);
 }
 
 #endif

--- a/src/pybind11/PyBindImath/PyBindImathLine.cpp
+++ b/src/pybind11/PyBindImath/PyBindImathLine.cpp
@@ -1,0 +1,30 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+#include "PyBindImath.h"
+#include <ImathLine.h>
+
+
+namespace PyBindImath {
+template <class T, class Q, class S>
+void register_line(pybind11::module& m, const char *name)
+{
+    pybind11::class_<T> c(m, name);    
+    c.def(pybind11::init<>(), "Uninitialized by default")
+    .def(pybind11::init<const Q &, Q &>(), pybind11::arg("point1"), pybind11::arg("point2"), "Initialize with two points. The direction is the difference between the points.")
+    .def("__str__", [](const T &obj) {
+        std::stringstream ss;
+        ss << obj;
+        return ss.str();
+        });
+}
+
+void register_imath_line(pybind11::module &m) 
+{
+    register_line<Imath::Line3f, Imath::V3f, float>(m, "Line3f");
+    register_line<Imath::Line3d, Imath::V3d, double>(m, "Line3d");
+}
+
+}

--- a/src/pybind11/PyBindImath/PyBindImathPlane.cpp
+++ b/src/pybind11/PyBindImath/PyBindImathPlane.cpp
@@ -1,0 +1,53 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+#include "PyBindImath.h"
+#include <ImathPlane.h>
+#include <ImathVec.h>
+#include <ImathLine.h>
+
+namespace PyBindImath {
+
+template <class T, class L, class Q, class S>
+void register_plane(pybind11::module& m, const char *name)
+{
+    pybind11::class_<T> c(m, name);
+    c.def(pybind11::init<>(), "Uninitialized by default")
+    .def(pybind11::init<const Q &, S>(), pybind11::arg("normal"), pybind11::arg("distance"), "Initialize with a normal and distance")
+    .def(pybind11::init<const Q &, const Q &>(), pybind11::arg("point"), pybind11::arg("normal"), "Initialize with a point and a normal")
+    .def(pybind11::init<const Q &, const Q &, const Q &>(), pybind11::arg("point1"), pybind11::arg("point2"), pybind11::arg("point3"), "Initialize with three points")
+    .def_readwrite("normal", &T::normal, "The normal to the plane")
+    .def_readwrite("distance", &T::distance, "The distance from the origin to the plane")
+    .def("set", pybind11::overload_cast<const Q &, S>(&T::set), pybind11::arg("normal"), pybind11::arg("distance"), "Set via a given normal and distance")
+    .def("set", pybind11::overload_cast<const Q &, const Q &>(&T::set), pybind11::arg("point"), pybind11::arg("normal"), "Set via a given point and normal")
+    .def("set", pybind11::overload_cast<const Q &, const Q &, const Q &>(&T::set), pybind11::arg("point1"), pybind11::arg("point2"), pybind11::arg("point3"), "Set via three points")
+    .def("intersect", [](T& self, const L& line) {
+                Q intersection;
+                bool result = self.intersect(line, intersection);
+                return pybind11::make_tuple(result, intersection);
+            }, pybind11::arg("line"), "Determine if a line intersects the plane. Returns a tuple (bool, Vec3). True if the line intersects the plane. Second element is the point of intersection")
+    .def("intersectT", [](T& self, const L& line) {
+                S intersection;
+                bool result = self.intersectT(line, intersection);
+                return pybind11::make_tuple(result, intersection);
+            }, pybind11::arg("line"), "Determine if a line intersects the plane. Returns a tuple (bool, T). True if the line intersects the plane. Second element is the parametric value of the point of intersection")
+    .def("distanceTo", &T::distanceTo, pybind11::arg("point"), "Returns the distance from a point to the plane")
+    .def("reflectPoint", &T::reflectPoint, pybind11::arg("point"), "Reflects the given point around the plane")
+    .def("reflectVector", &T::reflectVector, pybind11::arg("v"), "Reflects the direction vector around the plane")
+    .def("__str__", [](const T &obj) {
+            std::stringstream ss;
+            ss << obj;
+            return ss.str();
+        });
+}
+
+ void register_imath_plane(pybind11::module &m) 
+{
+    register_plane<Imath::Plane3f, Imath::Line3f, Imath::V3f, float>(m, "Plane3f");
+    register_plane<Imath::Plane3d, Imath::Line3d, Imath::V3d, double>(m, "Plane3d");
+}
+
+}
+

--- a/src/pybind11/PyBindImath/pybindimathmodule.cpp
+++ b/src/pybind11/PyBindImath/pybindimathmodule.cpp
@@ -13,6 +13,9 @@ PYBIND11_MODULE(pybindimath, m)
 
     PyBindImath::register_imath_vec(m);
     PyBindImath::register_imath_box(m);
+    PyBindImath::register_imath_plane(m);
+    PyBindImath::register_imath_line(m);
+
 
     //
     // Initialize constants


### PR DESCRIPTION
This is to fix issue #429.

I also added a rudimentary wrapper for Imath::Line, but this is only to allow for Imath::Plane's wrappings to work as a wrapping for Imath::Line didn't exist yet, though Imath::Plane's functions still utilized it. The Imath::Line wrapper currently only supports constructors and the << operator, though other functions could be added later.