### PR TITLE
Fix call to _mm_cvtps_ph in half.h

### DIFF
--- a/src/Imath/half.h
+++ b/src/Imath/half.h
@@ -378,7 +378,7 @@ imath_float_to_half (float f)
     // msvc does not seem to have cvtsh_ss :(
     return _mm_extract_epi16 (
         _mm_cvtps_ph (
-            _mm_set_ss (f), (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)),
+            _mm_set_ss (f), (_MM_FROUND_TO_NEAREST_INT)),
         0);
 #    else
     // preserve the fixed rounding mode to nearest


### PR DESCRIPTION
_mm_cvtps_ph doesn't support _MM_FROUND_NO_EXC. On Windows, if this is compiled, you will get the following warning:

`warning C4556: value of intrinsic immediate argument '8' is out of range '0 - 7'`

There is no corresponding instruction, so the flag should be removed.

References:
[https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtps_ph&ig_expand=2244,2221,2220,2221,2252,2220,2221,2220,2221,2221,2107,2252,2107,2107](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtps_ph&ig_expand=2244,2221,2220,2221,2252,2220,2221,2220,2221,2221,2107,2252,2107,2107)
[https://developercommunity.visualstudio.com/t/-mm-cvtps-ph-doesnt-accept-mm-fround-no-exc/1343857](https://developercommunity.visualstudio.com/t/-mm-cvtps-ph-doesnt-accept-mm-fround-no-exc/1343857)