### PR TITLE
Fix undefined behavior in operator[]

### DIFF
--- a/src/Imath/ImathMatrix.h
+++ b/src/Imath/ImathMatrix.h
@@ -1518,14 +1518,14 @@ template <class T>
 IMATH_HOSTDEVICE inline T*
 Matrix22<T>::getValue () IMATH_NOEXCEPT
 {
-    return (T*) &x[0][0];
+    return reinterpret_cast<T*> (this);
 }
 
 template <class T>
 IMATH_HOSTDEVICE inline const T*
 Matrix22<T>::getValue () const IMATH_NOEXCEPT
 {
-    return (const T*) &x[0][0];
+    return reinterpret_cast<const T*> (this);
 }
 
 template <class T>
@@ -2161,14 +2161,14 @@ template <class T>
 IMATH_HOSTDEVICE inline T*
 Matrix33<T>::getValue () IMATH_NOEXCEPT
 {
-    return (T*) &x[0][0];
+    return reinterpret_cast<T*> (this);
 }
 
 template <class T>
 IMATH_HOSTDEVICE inline const T*
 Matrix33<T>::getValue () const IMATH_NOEXCEPT
 {
-    return (const T*) &x[0][0];
+    return reinterpret_cast<const T*> (this);
 }
 
 template <class T>
@@ -3553,14 +3553,14 @@ template <class T>
 IMATH_HOSTDEVICE inline T*
 Matrix44<T>::getValue () IMATH_NOEXCEPT
 {
-    return (T*) &x[0][0];
+    return reinterpret_cast<T*> (this);
 }
 
 template <class T>
 IMATH_HOSTDEVICE inline const T*
 Matrix44<T>::getValue () const IMATH_NOEXCEPT
 {
-    return (const T*) &x[0][0];
+    return reinterpret_cast<const T*> (this);
 }
 
 template <class T>

--- a/src/Imath/ImathShear.h
+++ b/src/Imath/ImathShear.h
@@ -123,9 +123,21 @@ public:
     /// @}
 
     /// Element access
+    ///
+    /// NB: This method of access uses dynamic array accesses which
+    /// can prevent compiler optimizations and force temporaries to be
+    /// stored to the stack and other missed vectorization
+    /// opportunities. Use of direct access to xy, xz, etc when
+    /// possible should be preferred.
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i);
 
     /// Element access
+    ///
+    /// NB: This method of access uses dynamic array accesses which
+    /// can prevent compiler optimizations and force temporaries to be
+    /// stored to the stack and other missed vectorization
+    /// opportunities. Use of direct access to xy, xz, etc when
+    /// possible should be preferred.
     IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const;
 
     /// @{
@@ -332,14 +344,14 @@ template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T&
 Shear6<T>::operator[] (int i)
 {
-    return (&xy)[i]; // NOSONAR - suppress SonarCloud bug report.
+    return reinterpret_cast<T*> (this)[i];
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline const T&
 Shear6<T>::operator[] (int i) const
 {
-    return (&xy)[i]; // NOSONAR - suppress SonarCloud bug report.
+    return reinterpret_cast<const T*> (this)[i];
 }
 
 template <class T>

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -54,9 +54,21 @@ public:
     /// @}
 
     /// Element access by index.
+    ///
+    /// NB: This method of access uses dynamic array accesses which
+    /// can prevent compiler optimizations and force temporaries to be
+    /// stored to the stack and other missed vectorization
+    /// opportunities. Use of direct access to x, y when
+    /// possible should be preferred.
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i) IMATH_NOEXCEPT;
 
     /// Element access by index.
+    ///
+    /// NB: This method of access uses dynamic array accesses which
+    /// can prevent compiler optimizations and force temporaries to be
+    /// stored to the stack and other missed vectorization
+    /// opportunities. Use of direct access to x, y when
+    /// possible should be preferred.
     IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const IMATH_NOEXCEPT;
 
     /// @{
@@ -351,9 +363,21 @@ public:
     /// @}
 
     /// Element access by index.
+    ///
+    /// NB: This method of access uses dynamic array accesses which
+    /// can prevent compiler optimizations and force temporaries to be
+    /// stored to the stack and other missed vectorization
+    /// opportunities. Use of direct access to x, y, z when
+    /// possible should be preferred.
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i) IMATH_NOEXCEPT;
 
     /// Element access by index.
+    ///
+    /// NB: This method of access uses dynamic array accesses which
+    /// can prevent compiler optimizations and force temporaries to be
+    /// stored to the stack and other missed vectorization
+    /// opportunities. Use of direct access to x, y, z when
+    /// possible should be preferred.
     IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const IMATH_NOEXCEPT;
 
     /// @{
@@ -672,9 +696,21 @@ public:
     /// @}
 
     /// Element access by index.
+    ///
+    /// NB: This method of access uses dynamic array accesses which
+    /// can prevent compiler optimizations and force temporaries to be
+    /// stored to the stack and other missed vectorization
+    /// opportunities. Use of direct access to x, y, z, w when
+    /// possible should be preferred.
     IMATH_HOSTDEVICE IMATH_CONSTEXPR14 T& operator[] (int i) IMATH_NOEXCEPT;
 
     /// Element access by index.
+    ///
+    /// NB: This method of access uses dynamic array accesses which
+    /// can prevent compiler optimizations and force temporaries to be
+    /// stored to the stack and other missed vectorization
+    /// opportunities. Use of direct access to x, y, z, w when
+    /// possible should be preferred.
     IMATH_HOSTDEVICE constexpr const T& operator[] (int i) const IMATH_NOEXCEPT;
 
     /// @{
@@ -1186,14 +1222,14 @@ template <class T>
 IMATH_CONSTEXPR14 IMATH_HOSTDEVICE inline T&
 Vec2<T>::operator[] (int i) IMATH_NOEXCEPT
 {
-    return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
+    return reinterpret_cast<T*> (this)[i];
 }
 
 template <class T>
 constexpr IMATH_HOSTDEVICE inline const T&
 Vec2<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
-    return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
+    return reinterpret_cast<const T*> (this)[i];
 }
 
 template <class T> IMATH_HOSTDEVICE inline Vec2<T>::Vec2 () IMATH_NOEXCEPT
@@ -1274,14 +1310,14 @@ template <class T>
 IMATH_HOSTDEVICE inline T*
 Vec2<T>::getValue () IMATH_NOEXCEPT
 {
-    return (T*) &x;
+    return reinterpret_cast<T*> (this);
 }
 
 template <class T>
 IMATH_HOSTDEVICE inline const T*
 Vec2<T>::getValue () const IMATH_NOEXCEPT
 {
-    return (const T*) &x;
+    return reinterpret_cast<const T*> (this);
 }
 
 template <class T>
@@ -1590,14 +1626,14 @@ template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T&
 Vec3<T>::operator[] (int i) IMATH_NOEXCEPT
 {
-    return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
+    return reinterpret_cast<T*> (this)[i];
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline const T&
 Vec3<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
-    return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
+    return reinterpret_cast<const T*> (this)[i];
 }
 
 template <class T> IMATH_HOSTDEVICE inline Vec3<T>::Vec3 () IMATH_NOEXCEPT
@@ -1720,14 +1756,14 @@ template <class T>
 IMATH_HOSTDEVICE inline T*
 Vec3<T>::getValue () IMATH_NOEXCEPT
 {
-    return (T*) &x;
+    return reinterpret_cast<T*> (this);
 }
 
 template <class T>
 IMATH_HOSTDEVICE inline const T*
 Vec3<T>::getValue () const IMATH_NOEXCEPT
 {
-    return (const T*) &x;
+    return reinterpret_cast<const T*> (this);
 }
 
 template <class T>
@@ -2063,14 +2099,14 @@ template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline T&
 Vec4<T>::operator[] (int i) IMATH_NOEXCEPT
 {
-    return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
+    return reinterpret_cast<T*> (this)[i];
 }
 
 template <class T>
 IMATH_HOSTDEVICE constexpr inline const T&
 Vec4<T>::operator[] (int i) const IMATH_NOEXCEPT
 {
-    return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
+    return reinterpret_cast<const T*> (this)[i];
 }
 
 template <class T> IMATH_HOSTDEVICE inline Vec4<T>::Vec4 () IMATH_NOEXCEPT


### PR DESCRIPTION
If you take the address of a member, the pointer is only valid within the size of that member, such that accesses past that (i.e. to get to y or z of a vec3) are undefined behavior. by using this with a reinterpret cast, that tells the compiler the pointer space contains all values, and so avoids that. However, this may prevent other optimizations, so a larger change is recommended.

Addresses #446, thanks to @AlexMWells for the analysis