### PR TITLE
Add subscript operator optimizations, remove usage

### DIFF
--- a/src/Imath/ImathBox.h
+++ b/src/Imath/ImathBox.h
@@ -150,6 +150,9 @@ typedef Box<V2i> Box2i;
 /// 2D box of base type `int64_t`.
 typedef Box<V2i64> Box2i64;
 
+/// 2D box of base type `half`.
+typedef Box<V2h> Box2h;
+
 /// 2D box of base type `float`.
 typedef Box<V2f> Box2f;
 
@@ -164,6 +167,9 @@ typedef Box<V3i> Box3i;
 
 /// 3D box of base type `int64_t`.
 typedef Box<V3i64> Box3i64;
+
+/// 3D box of base type `half`.
+typedef Box<V3h> Box3h;
 
 /// 3D box of base type `float`.
 typedef Box<V3f> Box3f;
@@ -515,48 +521,36 @@ template <class T>
 IMATH_HOSTDEVICE inline void
 Box<Vec2<T>>::extendBy (const Vec2<T>& point) IMATH_NOEXCEPT
 {
-    if (point[0] < min[0]) min[0] = point[0];
-
-    if (point[0] > max[0]) max[0] = point[0];
-
-    if (point[1] < min[1]) min[1] = point[1];
-
-    if (point[1] > max[1]) max[1] = point[1];
+    min.x = std::min (min.x, point.x);
+    max.x = std::max (max.x, point.x);
+    min.y = std::min (min.y, point.y);
+    max.y = std::max (max.y, point.y);
 }
 
 template <class T>
 IMATH_HOSTDEVICE inline void
 Box<Vec2<T>>::extendBy (const Box<Vec2<T>>& box) IMATH_NOEXCEPT
 {
-    if (box.min[0] < min[0]) min[0] = box.min[0];
-
-    if (box.max[0] > max[0]) max[0] = box.max[0];
-
-    if (box.min[1] < min[1]) min[1] = box.min[1];
-
-    if (box.max[1] > max[1]) max[1] = box.max[1];
+    min.x = std::min (min.x, box.min.x);
+    max.x = std::max (max.x, box.max.x);
+    min.y = std::min (min.y, box.min.y);
+    max.y = std::max (max.y, box.max.y);
 }
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T>>::intersects (const Vec2<T>& point) const IMATH_NOEXCEPT
 {
-    if (point[0] < min[0] || point[0] > max[0] || point[1] < min[1] ||
-        point[1] > max[1])
-        return false;
-
-    return true;
+    return (point.x >= min.x) && (point.x <= max.x) &&
+           (point.y >= min.y) && (point.y <= max.y);
 }
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T>>::intersects (const Box<Vec2<T>>& box) const IMATH_NOEXCEPT
 {
-    if (box.max[0] < min[0] || box.min[0] > max[0] || box.max[1] < min[1] ||
-        box.min[1] > max[1])
-        return false;
-
-    return true;
+    return (box.min.x <= max.x) && (box.max.x >= min.x) &&
+           (box.min.y <= max.y) && (box.max.y >= min.y);
 }
 
 template <class T>
@@ -579,19 +573,17 @@ template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T>>::isEmpty () const IMATH_NOEXCEPT
 {
-    if (max[0] < min[0] || max[1] < min[1]) return true;
-
-    return false;
+    return (max.x < min.x || max.y < min.y);
 }
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T>>::isInfinite () const IMATH_NOEXCEPT
 {
-    if (min[0] != std::numeric_limits<T>::lowest () ||
-        max[0] != std::numeric_limits<T>::max () ||
-        min[1] != std::numeric_limits<T>::lowest () ||
-        max[1] != std::numeric_limits<T>::max ())
+    if (min.x != std::numeric_limits<T>::lowest () ||
+        max.x != std::numeric_limits<T>::max () ||
+        min.y != std::numeric_limits<T>::lowest () ||
+        max.y != std::numeric_limits<T>::max ())
         return false;
 
     return true;
@@ -601,7 +593,7 @@ template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec2<T>>::hasVolume () const IMATH_NOEXCEPT
 {
-    if (max[0] <= min[0] || max[1] <= min[1]) return false;
+    if (max.x <= min.x || max.y <= min.y) return false;
 
     return true;
 }
@@ -610,12 +602,9 @@ template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline unsigned int
 Box<Vec2<T>>::majorAxis () const IMATH_NOEXCEPT
 {
-    unsigned int major = 0;
-    Vec2<T>      s     = size ();
+    Vec2<T> s = size ();
 
-    if (s[1] > s[major]) major = 1;
-
-    return major;
+    return (s.x >= s.y) ? 0 : 1;
 }
 
 ///
@@ -769,56 +758,42 @@ template <class T>
 IMATH_HOSTDEVICE inline void
 Box<Vec3<T>>::extendBy (const Vec3<T>& point) IMATH_NOEXCEPT
 {
-    if (point[0] < min[0]) min[0] = point[0];
-
-    if (point[0] > max[0]) max[0] = point[0];
-
-    if (point[1] < min[1]) min[1] = point[1];
-
-    if (point[1] > max[1]) max[1] = point[1];
-
-    if (point[2] < min[2]) min[2] = point[2];
-
-    if (point[2] > max[2]) max[2] = point[2];
+    min.x = std::min (min.x, point.x);
+    min.y = std::min (min.y, point.y);
+    min.z = std::min (min.z, point.z);
+    max.x = std::max (max.x, point.x);
+    max.y = std::max (max.y, point.y);
+    max.z = std::max (max.z, point.z);
 }
 
 template <class T>
 IMATH_HOSTDEVICE inline void
 Box<Vec3<T>>::extendBy (const Box<Vec3<T>>& box) IMATH_NOEXCEPT
 {
-    if (box.min[0] < min[0]) min[0] = box.min[0];
-
-    if (box.max[0] > max[0]) max[0] = box.max[0];
-
-    if (box.min[1] < min[1]) min[1] = box.min[1];
-
-    if (box.max[1] > max[1]) max[1] = box.max[1];
-
-    if (box.min[2] < min[2]) min[2] = box.min[2];
-
-    if (box.max[2] > max[2]) max[2] = box.max[2];
+    min.x = std::min (min.x, box.min.x);
+    min.y = std::min (min.y, box.min.y);
+    min.z = std::min (min.z, box.min.z);
+    max.x = std::max (max.x, box.max.x);
+    max.y = std::max (max.y, box.max.y);
+    max.z = std::max (max.z, box.max.z);
 }
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T>>::intersects (const Vec3<T>& point) const IMATH_NOEXCEPT
 {
-    if (point[0] < min[0] || point[0] > max[0] || point[1] < min[1] ||
-        point[1] > max[1] || point[2] < min[2] || point[2] > max[2])
-        return false;
-
-    return true;
+    return (point.x >= min.x) && (point.x <= max.x) &&
+           (point.y >= min.y) && (point.y <= max.y) &&
+           (point.z >= min.z) && (point.z <= max.z);
 }
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T>>::intersects (const Box<Vec3<T>>& box) const IMATH_NOEXCEPT
 {
-    if (box.max[0] < min[0] || box.min[0] > max[0] || box.max[1] < min[1] ||
-        box.min[1] > max[1] || box.max[2] < min[2] || box.min[2] > max[2])
-        return false;
-
-    return true;
+    return (box.min.x <= max.x) && (box.max.x >= min.x) &&
+           (box.min.y <= max.y) && (box.max.y >= min.y) &&
+           (box.min.z <= max.z) && (box.max.z >= min.z);
 }
 
 template <class T>
@@ -841,21 +816,19 @@ template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T>>::isEmpty () const IMATH_NOEXCEPT
 {
-    if (max[0] < min[0] || max[1] < min[1] || max[2] < min[2]) return true;
-
-    return false;
+    return (max.x < min.x || max.y < min.y || max.z < min.z);
 }
 
 template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T>>::isInfinite () const IMATH_NOEXCEPT
 {
-    if (min[0] != std::numeric_limits<T>::lowest () ||
-        max[0] != std::numeric_limits<T>::max () ||
-        min[1] != std::numeric_limits<T>::lowest () ||
-        max[1] != std::numeric_limits<T>::max () ||
-        min[2] != std::numeric_limits<T>::lowest () ||
-        max[2] != std::numeric_limits<T>::max ())
+    if (min.x != std::numeric_limits<T>::lowest () ||
+        max.x != std::numeric_limits<T>::max () ||
+        min.y != std::numeric_limits<T>::lowest () ||
+        max.y != std::numeric_limits<T>::max () ||
+        min.z != std::numeric_limits<T>::lowest () ||
+        max.z != std::numeric_limits<T>::max ())
         return false;
 
     return true;
@@ -865,7 +838,7 @@ template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline bool
 Box<Vec3<T>>::hasVolume () const IMATH_NOEXCEPT
 {
-    if (max[0] <= min[0] || max[1] <= min[1] || max[2] <= min[2]) return false;
+    if (max.x <= min.x || max.y <= min.y || max.z <= min.z) return false;
 
     return true;
 }
@@ -874,14 +847,11 @@ template <class T>
 IMATH_HOSTDEVICE IMATH_CONSTEXPR14 inline unsigned int
 Box<Vec3<T>>::majorAxis () const IMATH_NOEXCEPT
 {
-    unsigned int major = 0;
-    Vec3<T>      s     = size ();
+    Vec3<T> s = size ();
 
-    if (s[1] > s[major]) major = 1;
-
-    if (s[2] > s[major]) major = 2;
-
-    return major;
+    if (s.x >= s.y)
+        return (s.x >= s.z) ? 0 : 2;
+    return (s.y >= s.z) ? 1 : 2;
 }
 
 IMATH_INTERNAL_NAMESPACE_HEADER_EXIT

--- a/src/Imath/ImathEuler.h
+++ b/src/Imath/ImathEuler.h
@@ -877,18 +877,16 @@ IMATH_HOSTDEVICE Quat<T>
     if (_initialRepeated)
     {
         a[i] = cj * (cs + sc);
-        a[j] = sj * (cc + ss) *
-               parity, // NOSONAR - suppress SonarCloud bug report.
-            a[k] = sj * (cs - sc);
-        q.r      = cj * (cc - ss);
+        a[j] = sj * (cc + ss) * parity;
+        a[k] = sj * (cs - sc);
+        q.r  = cj * (cc - ss);
     }
     else
     {
-        a[i] = cj * sc - sj * cs,
-        a[j] = (cj * ss + sj * cc) *
-               parity, // NOSONAR - suppress SonarCloud bug report.
-            a[k] = cj * cs - sj * sc;
-        q.r      = cj * cc + sj * ss;
+        a[i] = cj * sc - sj * cs;
+        a[j] = (cj * ss + sj * cc) * parity;
+        a[k] = cj * cs - sj * sc;
+        q.r  = cj * cc + sj * ss;
     }
 
     q.v = a;
@@ -984,9 +982,9 @@ Euler<T>::simpleXYZRotation (Vec3<T>& xyzRot, const Vec3<T>& targetXyzRot)
     IMATH_NOEXCEPT
 {
     Vec3<T> d = xyzRot - targetXyzRot;
-    xyzRot[0] = targetXyzRot[0] + angleMod (d[0]);
-    xyzRot[1] = targetXyzRot[1] + angleMod (d[1]);
-    xyzRot[2] = targetXyzRot[2] + angleMod (d[2]);
+    xyzRot.x = targetXyzRot.x + angleMod (d.x);
+    xyzRot.y = targetXyzRot.y + angleMod (d.y);
+    xyzRot.z = targetXyzRot.z + angleMod (d.z);
 }
 
 template <class T>

--- a/src/Imath/ImathFrame.h
+++ b/src/Imath/ImathFrame.h
@@ -89,10 +89,11 @@ Matrix44<T> constexpr firstFrame (
     n.normalize ();
     if (n.length () == 0.0f)
     {
-        int i = fabs (t[0]) < fabs (t[1]) ? 0 : 1;
-        if (fabs (t[2]) < fabs (t[i])) i = 2;
-
         Vec3<T> v (0.0, 0.0, 0.0);
+
+        int i = fabs (t.x) < fabs (t.y) ? 0 : 1;
+        if (fabs (t.z) < fabs (t[i])) i = 2;
+
         v[i] = 1.0;
         n    = t.cross (v);
         n.normalize ();
@@ -102,18 +103,21 @@ Matrix44<T> constexpr firstFrame (
 
     Matrix44<T> M;
 
-    M[0][0] = t[0];
-    M[0][1] = t[1];
-    M[0][2] = t[2];
-    M[0][3] = 0.0, M[1][0] = n[0];
-    M[1][1] = n[1];
-    M[1][2] = n[2];
-    M[1][3] = 0.0, M[2][0] = b[0];
-    M[2][1] = b[1];
-    M[2][2] = b[2];
-    M[2][3] = 0.0, M[3][0] = pi[0];
-    M[3][1] = pi[1];
-    M[3][2] = pi[2];
+    M[0][0] = t.x;
+    M[0][1] = t.y;
+    M[0][2] = t.z;
+    M[0][3] = 0.0;
+    M[1][0] = n.x;
+    M[1][1] = n.y;
+    M[1][2] = n.z;
+    M[1][3] = 0.0;
+    M[2][0] = b.x;
+    M[2][1] = b.y;
+    M[2][2] = b.z;
+    M[2][3] = 0.0;
+    M[3][0] = pi.x;
+    M[3][1] = pi.y;
+    M[3][2] = pi.z;
     M[3][3] = 1.0;
 
     return M;

--- a/src/Imath/ImathMatrixAlgo.cpp
+++ b/src/Imath/ImathMatrixAlgo.cpp
@@ -834,10 +834,10 @@ twoSidedJacobiSVD (
 
     // The off-diagonal entries are (effectively) 0, so whatever's left on the
     // diagonal are the singular values:
-    S[0] = A[0][0];
-    S[1] = A[1][1];
-    S[2] = A[2][2];
-    S[3] = A[3][3];
+    S.x = A[0][0];
+    S.y = A[1][1];
+    S.z = A[2][2];
+    S.w = A[3][3];
 
     // Nothing thus far has guaranteed that the singular values are positive,
     // so let's go back through and flip them if not (since by contract we are
@@ -901,14 +901,14 @@ twoSidedJacobiSVD (
         {
             for (int i = 0; i < 4; ++i)
                 U[i][3] = -U[i][3];
-            S[3] = -S[3];
+            S.w = -S.w;
         }
 
         if (V.determinant () < 0)
         {
             for (int i = 0; i < 4; ++i)
                 V[i][3] = -V[i][3];
-            S[3] = -S[3];
+            S.w = -S.w;
         }
     }
 }

--- a/src/Imath/ImathMatrixAlgo.h
+++ b/src/Imath/ImathMatrixAlgo.h
@@ -1247,8 +1247,8 @@ extractAndRemoveScalingAndShear (
     T maxVal = 0;
     for (int i = 0; i < 2; i++)
         for (int j = 0; j < 2; j++)
-            if (IMATH_INTERNAL_NAMESPACE::abs (row[i][j]) > maxVal)
-                maxVal = IMATH_INTERNAL_NAMESPACE::abs (row[i][j]);
+            if (IMATH_INTERNAL_NAMESPACE::abs (mat[i][j]) > maxVal)
+                maxVal = IMATH_INTERNAL_NAMESPACE::abs (mat[i][j]);
 
     //
     // We normalize the 2x2 matrix here.
@@ -1299,11 +1299,11 @@ extractAndRemoveScalingAndShear (
     // Check for a coordinate system flip. If the determinant
     // is -1, then flip the rotation matrix and adjust the scale(Y)
     // and shear(XY) factors to compensate.
-    if (row[0][0] * row[1][1] - row[0][1] * row[1][0] < 0)
+    if (row[0].x * row[1].y - row[0].y * row[1].x < 0)
     {
-        row[1][0] *= -1;
-        row[1][1] *= -1;
-        scl[1] *= -1;
+        row[1].x *= -1;
+        row[1].y *= -1;
+        scl.y *= -1;
         shr *= -1;
     }
 
@@ -1311,8 +1311,8 @@ extractAndRemoveScalingAndShear (
     // The upper 2x2 matrix in mat is now a rotation matrix.
     for (int i = 0; i < 2; i++)
     {
-        mat[i][0] = row[i][0];
-        mat[i][1] = row[i][1];
+        mat[i][0] = row[i].x;
+        mat[i][1] = row[i].y;
     }
 
     scl *= maxVal;

--- a/src/Imath/ImathPlatform.h
+++ b/src/Imath/ImathPlatform.h
@@ -25,7 +25,9 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 //
 // Helpful macros for checking which C++ standard we are compiling with.
 //
-#    if (__cplusplus >= 202002L)
+#    if (__cplusplus >= 202302L)
+#        define IMATH_CPLUSPLUS_VERSION 23
+#    elif (__cplusplus >= 202002L)
 #        define IMATH_CPLUSPLUS_VERSION 20
 #    elif (__cplusplus >= 201703L)
 #        define IMATH_CPLUSPLUS_VERSION 17

--- a/src/python/PyImath/PyImathFixedArray.h
+++ b/src/python/PyImath/PyImathFixedArray.h
@@ -15,6 +15,7 @@
 #include <boost/any.hpp>
 #include <iostream>
 #include "PyImathUtil.h"
+#include "ImathVec.h"
 
 //
 // Note: when PyImath from the v2 release of OpenEXR depended on Iex,
@@ -292,7 +293,7 @@ class FixedArray
           _unmaskedLength(other._unmaskedLength)
     {
     }
-        
+
     const FixedArray &
     operator = (const FixedArray &other)
     {
@@ -357,7 +358,7 @@ class FixedArray
             start = i; end = i+1; step = 1; slicelength = 1;
         } else {
             PyErr_SetString(PyExc_TypeError, "Object is not a slice");
-	    boost::python::throw_error_already_set();
+            boost::python::throw_error_already_set();
         }
     }
 
@@ -830,6 +831,27 @@ template <class Container, class Data>
 struct IndexAccessDefault {
     typedef Data & result_type;
     static Data & apply(Container &c, size_t i) { return c[i]; }
+};
+
+template <class Data>
+struct IndexAccessDefault<IMATH_INTERNAL_NAMESPACE::Vec2<Data>, Data> {
+    using Container = IMATH_INTERNAL_NAMESPACE::Vec2<Data>;
+    typedef Data & result_type;
+    static Data & apply(Container &c, size_t i) { return *(c.getValue () + i); }
+};
+
+template <class Data>
+struct IndexAccessDefault<IMATH_INTERNAL_NAMESPACE::Vec3<Data>, Data> {
+    using Container = IMATH_INTERNAL_NAMESPACE::Vec3<Data>;
+    typedef Data & result_type;
+    static Data & apply(Container &c, size_t i) { return *(c.getValue () + i); }
+};
+
+template <class Data>
+struct IndexAccessDefault<IMATH_INTERNAL_NAMESPACE::Vec4<Data>, Data> {
+    using Container = IMATH_INTERNAL_NAMESPACE::Vec4<Data>;
+    typedef Data & result_type;
+    static Data & apply(Container &c, size_t i) { return *(c.getValue () + i); }
 };
 
 template <class Container, class Data, int Length, class IndexAccess = IndexAccessDefault<Container,Data> >

--- a/src/python/PyImath/PyImathVec2Impl.h
+++ b/src/python/PyImath/PyImathVec2Impl.h
@@ -1093,7 +1093,7 @@ template <class T,int index>
 static FixedArray<T>
 Vec2Array_get(FixedArray<IMATH_NAMESPACE::Vec2<T> > &va)
 {
-    return FixedArray<T>(&(va.unchecked_index(0)[index]),
+    return FixedArray<T>(va.unchecked_index(0).getValue () + index,
                          va.len(), 2*va.stride(), va.handle(), va.writable());
 }
 

--- a/src/python/PyImathNumpy/imathnumpymodule.cpp
+++ b/src/python/PyImathNumpy/imathnumpymodule.cpp
@@ -93,7 +93,7 @@ arrayToNumpy_vector(T &va)
 
     int type = NumpyTypeFromType<PodType>::typeEnum;
     npy_intp dims[2]{ va.len(), BaseType::dimensions()};
-    PodType *data = &va[0][0];
+    PodType *data = va[0].getValue ();
     PyObject *a = PyArray_SimpleNewFromData(2, dims, type, data);
 
     if (!a)


### PR DESCRIPTION
This is not actually changing much about the vec subscript operators at this point, other than once if consteval is available, accessing with literals / compile time constants will eliminate the dynamic array usage. However, this changes many places where Imath was using subscript operators to just access the vector elements directly, which may allow optimizers to just leave things in registers more

Part of addressing optimizations suggested in #446