### PR TITLE
Fix quoting of cmake args in ci_steps.yml

### DIFF
--- a/.github/workflows/ci_steps.yml
+++ b/.github/workflows/ci_steps.yml
@@ -82,20 +82,22 @@ jobs:
           # Construct the cmake command as a variable, so the
           # Configure step below can execute it, but also so we can store
           # in in the install_manifest as a debugging reference
-          CMAKE_ARGS="-B . -S .. \
-                -DCMAKE_INSTALL_PREFIX=../_install \
-                -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} \
-                -DCMAKE_CXX_STANDARD=${{ inputs.cxx-standard }} \
-                -DBUILD_SHARED_LIBS=${{ inputs.BUILD_SHARED_LIBS }} \
-                -DIMATH_INSTALL_PKG_CONFIG=${{ inputs.IMATH_INSTALL_PKG_CONFIG }} \
-                -DBUILD_TESTING=${{ inputs.BUILD_TESTING }} \
-                -DPYTHON=${{ inputs.python }} \
-                -DPYBIND11=${{ inputs.pybind11 }} \
-                -DCMAKE_VERBOSE_MAKEFILE=ON"
+          cmake_args=("-B" "." "-S" "..")
+          cmake_args+=("-DCMAKE_INSTALL_PREFIX=../_install")
+          cmake_args+=("-DCMAKE_BUILD_TYPE=${{ inputs.build-type }}")
+          cmake_args+=("-DCMAKE_CXX_STANDARD=${{ inputs.cxx-standard }}")
+          cmake_args+=("-DBUILD_SHARED_LIBS=${{ inputs.BUILD_SHARED_LIBS }}")
+          cmake_args+=("-DIMATH_INSTALL_PKG_CONFIG=${{ inputs.IMATH_INSTALL_PKG_CONFIG }}")
+          cmake_args+=("-DBUILD_TESTING=${{ inputs.BUILD_TESTING }}")
+          cmake_args+=("-DPYTHON=${{ inputs.python }}")
+          cmake_args+=("-DPYBIND11=${{ inputs.pybind11 }}")
+          cmake_args+=("-DCMAKE_VERBOSE_MAKEFILE=ON")
           if [ -n "${{ inputs.namespace }}" ]; then
-              CMAKE_ARGS="$CMAKE_ARGS -DIMATH_NAMESPACE=${{ inputs.namespace }}"
+              cmake_args+=("-DIMATH_NAMESPACE=${{ inputs.namespace }}")
           fi
-          echo "CMAKE_ARGS=$CMAKE_ARGS" >> $GITHUB_ENV
+
+          quoted_args=$(printf '%q ' "${cmake_args[@]}")
+          echo "CMAKE_ARGS=$quoted_args" >> "$GITHUB_ENV"
 
           # Remove the os version from the manifest name, so it only
           # contains "ubuntu", "macos", or "windows", so the name is,
@@ -107,7 +109,8 @@ jobs:
       - name: Configure, Build, Test
         if: inputs.msystem == ''
         run: |
-          cmake $CMAKE_ARGS
+          cmake --version
+          cmake ${{ env.CMAKE_ARGS }}
           cmake --build . --target install --config ${{ inputs.build-type }}
           if [ "${{ inputs.BUILD_TESTING }}" == "ON" ]; then
             ctest -T Test -C ${{ inputs.build-type }} --timeout 7200 --output-on-failure -VV
@@ -119,7 +122,7 @@ jobs:
         if: inputs.msystem != ''
         run: |
           cmake --version
-          cmake $CMAKE_ARGS
+          cmake ${{ env.CMAKE_ARGS }}
           cmake --build . --target install --config ${{ inputs.build-type }}
           if [ "${{ inputs.BUILD_TESTING }}" == "ON" ]; then
             ctest -T Test -C ${{ inputs.build-type }} --timeout 7200 --output-on-failure -VV
@@ -139,7 +142,7 @@ jobs:
         # and remove the path prefix, so the manifest contains only
         # the local filenames.
         run: |
-          echo "# cmake $CMAKE_ARGS" > "_build/$INSTALL_MANIFEST"
+          echo "# cmake ${{ env.CMAKE_ARGS }}" > "_build/$INSTALL_MANIFEST"
           sort _build/install_manifest.txt | sed -e "s:^.*/_install/::" >> "_build/$INSTALL_MANIFEST"
         shell: bash
 


### PR DESCRIPTION
Collect args into a bash array and then join them into a single string with each entry quoted. This handles arguments with spaces much better.