### PR TITLE
Fix handling of /EHsc flag

### DIFF
--- a/config/LibraryDefine.cmake
+++ b/config/LibraryDefine.cmake
@@ -16,7 +16,7 @@ function(IMATH_DEFINE_LIBRARY libname)
   cmake_parse_arguments(IMATH_CURLIB "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   if (MSVC)
-    set(_imath_extra_flags "/EHsc")
+    set(_imath_extra_flags "$<$<COMPILE_LANGUAGE:CXX>:/EHsc>")
   endif()
   set(objlib ${libname})
   add_library(${objlib}
@@ -64,7 +64,7 @@ function(IMATH_DEFINE_LIBRARY libname)
       target_compile_definitions(${objlib} PUBLIC IMATH_USE_DEFAULT_VISIBILITY)
   endif()
   if (_imath_extra_flags)
-    target_compile_options(${objlib} PUBLIC ${_imath_extra_flags})
+    target_compile_options(${objlib} PRIVATE ${_imath_extra_flags})
   endif()
   set_property(TARGET ${objlib} PROPERTY PUBLIC_HEADER ${IMATH_CURLIB_HEADERS})
 


### PR DESCRIPTION
This flag is now specified via a generator expression, so it is only applied to C++ compilation, not CUDA.

This also makes the flag PRIVATE, not PUBLIC. It should not affect dependant projects, so it should not be a part of the public interface.

Resolves #476