### PR TITLE
Add python bindings for M22f, M22d, M33f, M33d and associated tests

### DIFF
--- a/src/pybind11/PyBindImath/CMakeLists.txt
+++ b/src/pybind11/PyBindImath/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PYBINDIMATH_SOURCES
     PyBindImathFun.cpp
     PyBindImathBox.cpp
     PyBindImathVec.cpp
+    PyBindImathMatrix.cpp
     PyBindImathPlane.cpp
     PyBindImathLine.cpp
     PyBindImathQuat.cpp

--- a/src/pybind11/PyBindImath/PyBindImath.h
+++ b/src/pybind11/PyBindImath/PyBindImath.h
@@ -20,6 +20,7 @@ namespace PyBindImath {
 PYBINDIMATH_EXPORT void register_imath_fun(pybind11::module& m);
 
 PYBINDIMATH_EXPORT void register_imath_vec(pybind11::module& m);
+PYBINDIMATH_EXPORT void register_imath_matrix(pybind11::module& m);
 PYBINDIMATH_EXPORT void register_imath_box(pybind11::module& m);
 PYBINDIMATH_EXPORT void register_imath_plane(pybind11::module& m);
 PYBINDIMATH_EXPORT void register_imath_line(pybind11::module& m);

--- a/src/pybind11/PyBindImath/PyBindImathMatrix.cpp
+++ b/src/pybind11/PyBindImath/PyBindImathMatrix.cpp
@@ -1,0 +1,359 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+#include "PyBindImath.h"
+#include "PyBindImathVec.h"
+#include <ImathMatrix.h>
+#include <ImathMatrixAlgo.h>
+
+namespace py = pybind11;
+using namespace IMATH_NAMESPACE;
+
+namespace {
+
+template <class Matrix>
+std::string
+repr(const char* name, const Matrix& m)
+{
+    typedef typename Matrix::BaseType T;
+
+    std::stringstream s;
+
+    if constexpr (std::is_same_v<T, float>) {
+        s.precision(9);
+    } else if constexpr (std::is_same_v<T, double>) {
+        s.precision(17);
+    }
+    s << std::fixed;
+    s << name << "(";
+    const int n = static_cast<int>(m.dimensions());
+    int k = n * n;
+    for (int x=0; x<n; x++)
+        for (int y=0; y<n; y++)
+        {
+            s << m[x][y];
+            if (--k > 0)
+                s << ", ";
+        }
+    s << ")";
+    return s.str();
+}
+
+template <class Matrix>
+static bool
+lessThan(const Matrix& mat1, const Matrix& mat2)
+{
+    const int n = static_cast<int>(mat1.dimensions());
+    for (int x=0; x<n; x++)
+        for (int y=0; y<n; y++)
+            if(mat1[x][y] > mat2[x][y])
+                return false;
+    
+    return mat1 != mat2;
+}
+
+template <class M>
+class RowProxy {
+  public:
+    using T = typename M::BaseType;
+    
+    RowProxy(T* r) : row(r) {}
+
+    T& operator[](size_t col)
+    {
+        if (col >= M::dimensions())
+            throw py::index_error();
+        return row[col];
+    }
+
+  private:
+
+    T* row;
+};
+
+template <template <class> class M, class T>
+py::class_<M<T>>
+register_matrix(py::class_<M<T>>& m, const char* name)
+{
+    using Matrix = M<T>;
+
+    auto ri = py::return_value_policy::reference_internal;
+
+    return m.def("__repr__", [name](const Matrix& self) { return repr(name, self); })
+        .def(py::init([](){return Matrix();}))
+        .def(py::init<T>())
+        .def(py::init<const Matrix&>())
+        .def("__getitem__", [](Matrix& self, size_t i) {
+            return RowProxy<Matrix>(self[i]);
+        })
+        .def("__len__", [](const Matrix& self) {
+            return self.dimensions();
+        })
+
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+        .def("__lt__", &lessThan<Matrix>)
+        .def("__le__", [](const Matrix& a, const Matrix& b) { return !lessThan(b, a); })
+        .def("__gt__", [](const Matrix& a, const Matrix& b) { return lessThan(b, a); })
+        .def("__ge__", [](const Matrix& a, const Matrix& b) { return !lessThan(a, b); })
+        .def("equalWithAbsError", [](Matrix& self, const Matrix& other, double e) {
+            return self.equalWithAbsError(other, typename Matrix::BaseType(e));
+        })
+        .def("equalWithRelError", [](Matrix& self, const Matrix& other, double e) {
+            return self.equalWithRelError(other, typename Matrix::BaseType(e));
+        })
+
+        .def("__iadd__", [](Matrix &self, const M<float>& other) -> const Matrix& { return self += Matrix(other); }, ri)
+        .def("__iadd__", [](Matrix &self, const M<double>& other) -> const Matrix& { return self += Matrix(other); }, ri)
+        .def("__iadd__", [](Matrix &self, T v) -> const Matrix& { return self += v; }, ri)
+        .def("__add__", [](const Matrix &self, const Matrix &other) { return self + other; })
+        .def("__add__", [](const Matrix &self, T v) { return self + v; })
+        .def("__radd__", [](const Matrix &self, T v) { return Matrix(v) + self; })
+
+        .def("__isub__", [](Matrix &self, const M<float>& other) -> const Matrix& { return self -= Matrix(other); }, ri)
+        .def("__isub__", [](Matrix &self, const M<double>& other) -> const Matrix& { return self -= Matrix(other); }, ri)
+        .def("__isub__", [](Matrix &self, T v) -> const Matrix& { return self -= v; }, ri)
+        .def("__sub__", [](const Matrix &self, const Matrix &other) { return self - other; })
+        .def("__sub__", [](const Matrix &self, T v) { return self - v; })
+        .def("__rsub__", [](const Matrix &self, T v) { return Matrix(v) - self; })
+
+        .def("negate", [](Matrix &self) -> const Matrix& { return self = -self; }, ri)
+        .def("__neg__", [](Matrix &self) -> const Matrix& { return self = -self; }, ri)
+
+        .def("__imul__", [](Matrix &self, const M<float>& other) -> const Matrix& { return self *= Matrix(other); }, ri)
+        .def("__imul__", [](Matrix &self, const M<double>& other) -> const Matrix& { return self *= Matrix(other); }, ri)
+        .def("__imul__", [](Matrix &self, T v) -> const Matrix& { return self *= v; }, ri)
+        .def("__mul__", [](const Matrix &self, const M<float> &other) { return self * Matrix(other); })
+        .def("__mul__", [](const Matrix &self, const M<double> &other) { return self * Matrix(other); })
+        .def("__mul__", [](const Matrix &self, T v) { return self * v; })
+        .def("__rmul__", [](const Matrix &self, const M<float> &other) { return Matrix(other) * self; })
+        .def("__rmul__", [](const Matrix &self, const M<double> &other) { return Matrix(other) * self; })
+        .def("__rmul__", [](const Matrix &self, T v) { return self * v; })
+
+        .def("__idiv__", [](Matrix &self, T v) -> const Matrix& { return self /= v; }, ri)
+        .def("__div__", [](const Matrix &self, T v) { return self / v; })
+        .def("__itruediv__", [](Matrix &self, T v) -> const Matrix& { return self /= v; }, ri)
+        .def("__truediv__", [](const Matrix &self, T v) { return self / v; })
+
+        .def("makeIdentity", &Matrix::makeIdentity)
+
+        .def("setValue", [](Matrix& self, const Matrix& o) { return self.setValue(o); }, ri, "setValue")
+
+        .def("transpose", &Matrix::transpose,ri,"transpose() transpose this matrix")
+        .def("transposed", &Matrix::transposed,"transposed() return a transposed copy of this matrix")
+        .def("invert", [](Matrix& self) { return self.invert(); }, ri) 
+        .def("inverse", [](Matrix& self) { return self.inverse(); }, ri) 
+        .def("determinant", &Matrix::determinant,"determinant() return the determinant of this matrix")
+
+        .def_static("baseTypeEpsilon", &Matrix::baseTypeEpsilon,"baseTypeEpsilon() epsilon value of the base type of the matrix")
+        .def_static("baseTypeMax", &Matrix::baseTypeMax,"baseTypeMax() max value of the base type of the matrix")
+        .def_static("baseTypeLowest", &Matrix::baseTypeLowest,"baseTypeLowest() largest negative value of the base type of the matrix")
+        .def_static("baseTypeSmallest", &Matrix::baseTypeSmallest,"baseTypeSmallest() smallest value of the base type of the matrix")
+        ;
+    
+}
+    
+template <class T>
+py::class_<Matrix22<T>>
+register_matrix22(py::module& module, const char * name)
+{
+    using Matrix = Matrix22<T>;
+    auto ri = py::return_value_policy::reference_internal;
+
+    py::class_<Matrix> m(module, name);
+    m.def(py::init<T,T,T,T>())
+        .def(py::init([](std::tuple<T, T> row0, std::tuple<T, T> row1) {
+            return Matrix(std::get<0>(row0), std::get<1>(row0),
+                          std::get<0>(row1), std::get<1>(row1));
+        }))
+        .def("multDirMatrix", [](const Matrix& self, const py::object& src, Vec2<T>& dst) {
+            self.multDirMatrix(vecFromObject<Vec2<T>>(src), dst); }, "mult matrix")
+        .def("multDirMatrix", [](const Matrix& self, const py::object& src) {
+            Vec2<T> dst; self.multDirMatrix(vecFromObject<Vec2<T>>(src), dst); return dst; }, "mult matrix")
+        .def("extractEuler", [](const Matrix& self, Vec2<T>& dst) { T rot; extractEuler(self, rot); dst[0] = rot; return dst; }, ri)
+
+        .def("rotate", [](Matrix& self, T r) { return self.rotate(r); }, ri, "rotate matrix")
+        .def("setRotation", [](Matrix& self, T r) { return self.setRotation(r); }, ri, "setRotation(s)")
+
+        .def("scale", [](Matrix& self, const py::object& s) { return self.scale(vecFromObject<Vec2<T>>(s)); }, ri, "rotate matrix")
+        .def("setScale", [](Matrix& self, T s) { return self.setScale(s); }, ri, "setScale(s)")
+        .def("setScale", [](Matrix& self, const py::object& s) { return self.setScale(vecFromObject<Vec2<T>>(s)); }, ri, "setScale(s)")
+        ;
+    
+    register_matrix<Matrix22, T>(m, name);
+    return py::cast<py::class_<Matrix>>(m);
+}
+
+template <class Matrix>
+py::tuple
+jacobiEigensolve(const Matrix& m)
+{
+    typedef typename Matrix::BaseType T;
+    typedef typename Matrix::BaseVecType Vec;
+
+    // For the C++ version, we just assume that the passed-in matrix is
+    // symmetric, but we assume that many of our script users are less
+    // sophisticated and might get tripped up by this.  Also, the cost
+    // of doing this check is likely miniscule compared to the Pythonic
+    // overhead.
+
+    // Give a fairly generous tolerance to account for possible epsilon drift:
+    const int d = Matrix::dimensions();
+    const T tol = std::sqrt(std::numeric_limits<T>::epsilon());
+    for (int i = 0; i < d; ++i)
+    {
+        for (int j = i+1; j < d; ++j)
+        {
+            const T Aij = m[i][j],
+                    Aji = m[j][i];
+            if (std::abs(Aij - Aji) >= tol){
+              throw std::invalid_argument
+              ("Symmetric eigensolve requires a symmetric matrix (matrix[i][j] == matrix[j][i]).");
+            }
+        }
+    }
+
+    Matrix tmp = m;
+    Matrix Q;
+    Vec S;
+    jacobiEigenSolver (tmp, S, Q);
+    return py::make_tuple (Q, S);
+}
+
+
+template <class T>
+py::class_<Matrix33<T>>
+register_matrix33(py::module& module, const char * name)
+{
+    using Matrix = Matrix33<T>;
+    auto ri = py::return_value_policy::reference_internal;
+
+    py::class_<Matrix> m(module, name);
+    m.def(py::init<T,T,T,T,T,T,T,T,T>())
+        .def(py::init([](std::tuple<T, T, T> row0, std::tuple<T, T, T> row1, std::tuple<T, T, T> row2) {
+            return Matrix(std::get<0>(row0), std::get<1>(row0), std::get<2>(row0),
+                               std::get<0>(row1), std::get<1>(row1), std::get<2>(row1),
+                               std::get<0>(row2), std::get<1>(row2), std::get<2>(row2));
+        }))
+        .def("multDirMatrix", [](const Matrix& self, const py::object& src, Vec2<T>& dst) {
+            self.multDirMatrix(vecFromObject<Vec2<T>>(src), dst); }, "mult matrix")
+        .def("multDirMatrix", [](const Matrix& self, const py::object& src) {
+            Vec2<T> dst; self.multDirMatrix(vecFromObject<Vec2<T>>(src), dst); return dst; }, "mult matrix")
+        .def("multVecMatrix", [](const Matrix& self, const py::object& src, Vec2<T>& dst) {
+            self.multVecMatrix(vecFromObject<Vec2<T>>(src), dst); }, "mult matrix")
+        .def("multVecMatrix", [](const Matrix& self, const py::object& src) {
+            Vec2<T> dst; self.multVecMatrix(vecFromObject<Vec2<T>>(src), dst); return dst; }, "mult matrix")
+
+        .def("rotate", [](Matrix& self, T r) { return self.rotate(r); }, ri, "rotate matrix")
+        .def("setRotation", [](Matrix& self, T r) { return self.setRotation(r); }, ri, "setRotation(s)")
+
+        .def("setTranslation", [](Matrix& self, const py::object& t) { return self.setTranslation(vecFromObject<Vec2<T>>(t)); }, ri, "setTranslation(s)")
+        .def("translate", [](Matrix& self, const py::object& t) { return self.translate(vecFromObject<Vec2<T>>(t)); }, ri, "translate matrix")
+        .def("translation", &Matrix::translation, "translation()")
+
+        .def("scale", [](Matrix& self, const py::object& s) { return self.scale(vecFromObject<Vec2<T>>(s)); }, ri, "rotate matrix")
+        .def("setScale", [](Matrix& self, T s) { return self.setScale(s); }, ri, "setScale(s)")
+        .def("setScale", [](Matrix& self, const py::object& s) { return self.setScale(vecFromObject<Vec2<T>>(s)); }, ri, "setScale(s)")
+
+        .def("shear", [](Matrix& self, T s) { return self.shear(s); }, ri, "setShear")
+        .def("shear", [](Matrix& self, const Vec2<T>& s) { return self.shear(s); }, ri, "setShear")
+        .def("shear", [](Matrix& self, const py::list& s) { return self.shear(vecFromObject<Vec2<T>>(s)); }, ri, "setShear")
+        .def("shear", [](Matrix& self, const py::tuple& s) { return self.shear(vecFromObject<Vec2<T>>(s)); }, ri, "setShear")
+
+        .def("setShear", [](Matrix& self, T s) { return self.setShear(s); }, ri, "setShear")
+        .def("setShear", [](Matrix& self, const Vec2<T>& s) { return self.setShear(s); }, ri, "setShear")
+        .def("setShear", [](Matrix& self, const py::list& s) { return self.setShear(vecFromObject<Vec2<T>>(s)); }, ri, "setShear")
+        .def("setShear", [](Matrix& self, const py::tuple& s) { return self.setShear(vecFromObject<Vec2<T>>(s)); }, ri, "setShear")
+
+        .def("gjInvert", [](Matrix& self) { return self.gjInvert(); }, ri) 
+        .def("gjInverse", [](Matrix& self) { return self.gjInverse(); }, ri) 
+        .def("minorOf", &Matrix::minorOf,"minorOf() return the matrix minor of the (row,col) element of this matrix")
+        .def("fastMinor", &Matrix::fastMinor,"fastMinor() return the matrix minor using the specified rows and columns of this matrix")
+
+        .def("removeScaling", [](Matrix& self, int exc) { return removeScaling(self, exc); }, py::arg("exc")=1, ri)
+        .def("removeScalingAndShear", [](Matrix& self, int exc) { return removeScalingAndShear(self, exc); }, py::arg("exc")=1, ri)
+
+        .def("sansScaling", [](const Matrix& self, int exc) { return sansScaling(self, exc); }, py::arg("exc")=1, ri)
+        .def("sansScalingAndShear", [](const Matrix& self, int exc) { return sansScalingAndShear(self, exc); }, py::arg("exc")=1, ri)
+
+        .def("extractAndRemoveScalingAndShear", [](Matrix& self, Vec2<T>& dstScl, Vec2<T>& dstShr, int exc) 
+             {
+                 T dstShrTmp;
+                 extractAndRemoveScalingAndShear(self, dstScl, dstShrTmp, exc);
+                 dstShr.setValue(dstShrTmp, T(0));
+             }, py::arg("dstScl"), py::arg("dstShr"), py::arg("exc") = 1)
+        .def("extractEuler", [](const Matrix& self, Vec2<T>& dstObj)
+            {
+                T dst;
+                extractEuler(self, dst);
+                dstObj.setValue(dst, T (0));
+            })
+        .def("extractSHRT", [](const Matrix& self, Vec2<T> &s, Vec2<T> &h, Vec2<T> &r, Vec2<T> &t, int exc)
+            {
+                T hTmp, rTmp;
+                int b = extractSHRT(self, s, hTmp, rTmp, t, exc);
+                h.setValue(hTmp, T (0));
+                r.setValue(rTmp, T (0));
+                return b;
+            }, py::arg("s"), py::arg("h"), py::arg("r"), py::arg("t"), py::arg("exc") = 1)
+        .def("extractScaling", [](const Matrix& self, Vec2<T> &dst, int exc) { extractScaling(self, dst, exc); }, py::arg("dst"), py::arg("exc") = 1)
+
+        .def("outerProduct", [](Matrix& self, Vec3<T>& a, Vec3<T>& b) { self = outerProduct(a, b); })
+        .def("extractScalingAndShear", [](Matrix& self, Vec2<T> &dstScl, Vec2<T> &dstShr, int exc)
+            {
+                T dstShrTmp;
+                extractScalingAndShear(self, dstScl, dstShrTmp, exc);
+                dstShr.setValue(dstShrTmp, T (0));
+            }, py::arg("dstScl"), py::arg("dstShr"), py::arg("exc") = 1)
+        .def("singularValueDecomposition", [](const Matrix33<T>& m, bool forcePositiveDeterminant = false)
+            {
+                Matrix U, V;
+                Vec3<T> S;
+                jacobiSVD (m, U, S, V, std::numeric_limits<T>::epsilon(), forcePositiveDeterminant);
+                return py::make_tuple (U, S, V);
+            })
+        .def("symmetricEigensolve", &jacobiEigensolve<Matrix>) 
+        ;
+    
+    register_matrix<Matrix33, T>(m, name);
+    return py::cast<py::class_<Matrix33<T>>>(m);
+}
+
+template <class M>
+void
+register_rowproxy(py::module& module, const char* name)
+{
+    using T = typename M::BaseType;
+
+    py::class_<RowProxy<M>>(module, name, py::module_local())
+        .def("__getitem__", [](RowProxy<M>& r, size_t i) -> T& {
+            return r[i];
+        })
+        .def("__setitem__", [](RowProxy<M>& r, size_t i, T val) {
+            r[i] = val;
+        });
+}
+    
+} // namespace
+
+namespace PyBindImath {
+
+void
+register_imath_matrix(py::module& module)
+{
+    register_rowproxy<M22f>(module, "RowProxy22f");
+    register_rowproxy<M22d>(module, "RowProxy22d");
+    register_rowproxy<M33f>(module, "RowProxy33f");
+    register_rowproxy<M33d>(module, "RowProxy33d");
+        
+    auto m22f = register_matrix22<float>(module, "M22f");
+    auto m22d = register_matrix22<double>(module, "M22d");
+
+    auto m33f = register_matrix33<float>(module, "M33f");
+    auto m33d = register_matrix33<double>(module, "M33d");
+}
+
+} // namespace PyBindImath
+

--- a/src/pybind11/PyBindImath/PyBindImathMatrix.cpp
+++ b/src/pybind11/PyBindImath/PyBindImathMatrix.cpp
@@ -21,9 +21,9 @@ repr(const char* name, const Matrix& m)
 
     std::stringstream s;
 
-    if (std::is_same_v<T, float>) {
+    if (std::is_same<T, float>::value) {
         s.precision(9);
-    } else if (std::is_same_v<T, double>) {
+    } else if (std::is_same<T, double>::value) {
         s.precision(17);
     }
     s << std::fixed;

--- a/src/pybind11/PyBindImath/PyBindImathMatrix.cpp
+++ b/src/pybind11/PyBindImath/PyBindImathMatrix.cpp
@@ -21,9 +21,9 @@ repr(const char* name, const Matrix& m)
 
     std::stringstream s;
 
-    if constexpr (std::is_same_v<T, float>) {
+    if (std::is_same_v<T, float>) {
         s.precision(9);
-    } else if constexpr (std::is_same_v<T, double>) {
+    } else if (std::is_same_v<T, double>) {
         s.precision(17);
     }
     s << std::fixed;

--- a/src/pybind11/PyBindImath/PyBindImathVec.h
+++ b/src/pybind11/PyBindImath/PyBindImathVec.h
@@ -1,0 +1,111 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+#include <ImathNamespace.h>
+
+namespace py = pybind11;
+
+using namespace IMATH_NAMESPACE;
+
+namespace {
+
+//
+// Convert the given tuple to a Vec, to support:
+//
+//   v = V2i(1,2) + (3,4)
+//
+
+template <class Vec>
+Vec
+vecFromTuple(const py::tuple& t)
+{
+    typedef typename Vec::BaseType T;
+
+    if (t.size() != Vec::dimensions())
+    {
+        std::stringstream s;
+        s << "tuple must have exactly " << Vec::dimensions() << " elements";
+        throw py::value_error(s.str());
+    }
+
+    Vec v;
+    switch (Vec::dimensions())
+    {
+    case 4:
+        v[3] = t[3].cast<T>();
+        // fall through for 2,1,0...
+    case 3:
+        v[2] = t[2].cast<T>();
+        // fall through for 1,0...
+    case 2:
+    default:
+        v[1] = t[1].cast<T>();
+        v[0] = t[0].cast<T>();
+        break;
+    }
+    return v;
+}
+
+//
+// Convert the given list to a Vec, to support:
+//
+//   v = V2i(1,2) + [3,4]
+//
+
+template <class Vec>
+Vec
+vecFromList(const py::list& l)
+{
+    typedef typename Vec::BaseType T;
+
+    if (l.size() != Vec::dimensions())
+    {
+        std::stringstream s;
+        s << "list must have exactly " << Vec::dimensions() << " elements";
+        throw py::value_error(s.str());
+    }
+
+    Vec v;
+    switch (Vec::dimensions())
+    {
+    case 4:
+        v[3] = l[3].cast<T>();
+        // fall through for 2,1,0...
+    case 3:
+        v[2] = l[2].cast<T>();
+    case 2:
+    default:
+        // fall through for 1,0...
+        v[1] = l[1].cast<T>();
+        v[0] = l[0].cast<T>();
+        break;
+    }
+    return v;
+}
+
+template <class Vec>
+Vec
+vecFromObject(const py::object& o)
+{
+    typedef typename Vec::BaseType T;
+    
+    auto vecType = py::type::of<Vec>();
+    if (py::isinstance(o, vecType))
+        return o.cast<Vec>();
+    if (py::isinstance<py::list>(o)) 
+        return vecFromList<Vec>(o.cast<py::list>());
+    if (py::isinstance<py::tuple>(o)) 
+        return vecFromList<Vec>(o.cast<py::tuple>());
+    if (py::isinstance<py::int_>(o)) 
+        return Vec(T(o.cast<int>()));
+    if (py::isinstance<py::float_>(o)) 
+        return Vec(T(o.cast<float>()));
+
+    std::stringstream s;
+    s << "invalid vector: " << py::str(o);
+    throw py::value_error(s.str());
+}
+
+} // namespace

--- a/src/pybind11/PyBindImath/pybindimathmodule.cpp
+++ b/src/pybind11/PyBindImath/pybindimathmodule.cpp
@@ -13,6 +13,7 @@ PYBIND11_MODULE(pybindimath, m)
 
     PyBindImath::register_imath_fun(m);
     PyBindImath::register_imath_vec(m);
+    PyBindImath::register_imath_matrix(m);
     PyBindImath::register_imath_box(m);
     PyBindImath::register_imath_plane(m);
     PyBindImath::register_imath_line(m);

--- a/src/pybind11/PyBindImathTest/pyBindImathTest.py
+++ b/src/pybind11/PyBindImathTest/pyBindImathTest.py
@@ -15,6 +15,9 @@ import math
 import string, traceback, sys
 import random
 
+import pybindimath
+print(f"import {pybindimath.__file__}")
+
 testList = []
 
 # -----------------------------------------------------------------
@@ -4893,17 +4896,17 @@ def testM22x (Mat, Vec):
     v2 = Vec()
 
     m4.multDirMatrix(v1,v2)
-    assert v2.equalWithAbsError((0, 1), v2.baseTypeEpsilon())
+    assert v2.equalWithAbsError((0, 1), float(v2.baseTypeEpsilon()))
     v2 = m4.multDirMatrix(v1)
     assert v2.equalWithAbsError((0, 1), v2.baseTypeEpsilon())
-    v1a = V2fArray(1)
-    v1a[:] = V2f(v1)
-    v2a = m4.multDirMatrix(v1a)
-    assert v2a[0].equalWithAbsError((0, 1), v2a[0].baseTypeEpsilon())
-    v1a = V2dArray(1)
-    v1a[:] = V2d(v1)
-    v2a = m4.multDirMatrix(v1a)
-    assert v2a[0].equalWithAbsError((0, 1), v2a[0].baseTypeEpsilon())
+#    v1a = V2fArray(1)
+#    v1a[:] = V2f(v1)
+#    v2a = m4.multDirMatrix(v1a)
+#    assert v2a[0].equalWithAbsError(Vec(0, 1), v2a[0].baseTypeEpsilon())
+#    v1a = V2dArray(1)
+#    v1a[:] = V2d(v1)
+#    v2a = m4.multDirMatrix(v1a)
+#    assert v2a[0].equalWithAbsError((0, 1), v2a[0].baseTypeEpsilon())
     
     # Division.
 
@@ -5026,7 +5029,7 @@ def testM22 ():
     print ("M22d")
     testM22x (M22d, V2d)
 
-#testList.append (('testM22',testM22))
+testList.append (('testM22',testM22))
 
 
 # -------------------------------------------------------------------------
@@ -5242,28 +5245,28 @@ def testM33x (Mat, Vec, Vec3):
     assert v2.equalWithAbsError((1, 3), v2.baseTypeEpsilon())
     v2 = m4.multVecMatrix(v1)
     assert v2.equalWithAbsError((1, 3), v2.baseTypeEpsilon())
-    v1a = V2fArray(1)
-    v1a[:] = V2f(v1)
-    v2a = m4.multVecMatrix(v1a)
-    assert v2a[0].equalWithAbsError((1, 3), v2a[0].baseTypeEpsilon())
-    v1a = V2dArray(1)
-    v1a[:] = V2d(v1)
-    v2a = m4.multVecMatrix(v1a)
-    assert v2a[0].equalWithAbsError((1, 3), v2a[0].baseTypeEpsilon())
+#    v1a = V2fArray(1)
+#    v1a[:] = V2f(v1)
+#    v2a = m4.multVecMatrix(v1a)
+#    assert v2a[0].equalWithAbsError((1, 3), v2a[0].baseTypeEpsilon())
+#    v1a = V2dArray(1)
+#    v1a[:] = V2d(v1)
+#    v2a = m4.multVecMatrix(v1a)
+#    assert v2a[0].equalWithAbsError((1, 3), v2a[0].baseTypeEpsilon())
     
 
     m4.multDirMatrix(v1,v2)
     assert v2.equalWithAbsError((0, 1), v2.baseTypeEpsilon())
     v2 = m4.multDirMatrix(v1)
     assert v2.equalWithAbsError((0, 1), v2.baseTypeEpsilon())
-    v1a = V2fArray(1)
-    v1a[:] = V2f(v1)
-    v2a = m4.multDirMatrix(v1a)
-    assert v2a[0].equalWithAbsError((0, 1), v2a[0].baseTypeEpsilon())
-    v1a = V2dArray(1)
-    v1a[:] = V2d(v1)
-    v2a = m4.multDirMatrix(v1a)
-    assert v2a[0].equalWithAbsError((0, 1), v2a[0].baseTypeEpsilon())
+#    v1a = V2fArray(1)
+#    v1a[:] = V2f(v1)
+#    v2a = m4.multDirMatrix(v1a)
+#    assert v2a[0].equalWithAbsError((0, 1), v2a[0].baseTypeEpsilon())
+#    v1a = V2dArray(1)
+#    v1a[:] = V2d(v1)
+#    v2a = m4.multDirMatrix(v1a)
+#    assert v2a[0].equalWithAbsError((0, 1), v2a[0].baseTypeEpsilon())
     
     # Division.
 
@@ -5658,7 +5661,7 @@ def testM33 ():
     print ("M33d")
     testM33x (M33d, V2d, V3d)
 
-#testList.append (('testM33',testM33))
+testList.append (('testM33',testM33))
 
 
 # -------------------------------------------------------------------------
@@ -5884,27 +5887,27 @@ def testM44x (Mat, Vec):
     assert v2.equalWithAbsError((1, 3, 0), v2.baseTypeEpsilon())
     v2 = m4.multVecMatrix(v1)
     assert v2.equalWithAbsError((1, 3, 0), v2.baseTypeEpsilon())
-    v1a = V3fArray(1)
-    v1a[:] = V3f(v1)
-    v2a = m4.multVecMatrix(v1a)
-    assert v2a[0].equalWithAbsError((1, 3, 0), v2a[0].baseTypeEpsilon())
-    v1a = V3dArray(1)
-    v1a[:] = V3d(v1)
-    v2a = m4.multVecMatrix(v1a)
-    assert v2a[0].equalWithAbsError((1, 3, 0), v2a[0].baseTypeEpsilon())
+#    v1a = V3fArray(1)
+#    v1a[:] = V3f(v1)
+#    v2a = m4.multVecMatrix(v1a)
+#    assert v2a[0].equalWithAbsError((1, 3, 0), v2a[0].baseTypeEpsilon())
+#    v1a = V3dArray(1)
+#    v1a[:] = V3d(v1)
+#    v2a = m4.multVecMatrix(v1a)
+#    assert v2a[0].equalWithAbsError((1, 3, 0), v2a[0].baseTypeEpsilon())
     
     m4.multDirMatrix(v1,v2)
     assert v2.equalWithAbsError((0, 1, 0), v2.baseTypeEpsilon())
     v2 = m4.multDirMatrix(v1)
     assert v2.equalWithAbsError((0, 1, 0), v2.baseTypeEpsilon())
-    v1a = V3fArray(1)
-    v1a[:] = V3f(v1)
-    v2a = m4.multDirMatrix(v1a)
-    assert v2a[0].equalWithAbsError((0, 1, 0), v2a[0].baseTypeEpsilon())
-    v1a = V3dArray(1)
-    v1a[:] = V3d(v1)
-    v2a = m4.multDirMatrix(v1a)
-    assert v2a[0].equalWithAbsError((0, 1, 0), v2a[0].baseTypeEpsilon())
+#    v1a = V3fArray(1)
+#    v1a[:] = V3f(v1)
+#    v2a = m4.multDirMatrix(v1a)
+#    assert v2a[0].equalWithAbsError((0, 1, 0), v2a[0].baseTypeEpsilon())
+#    v1a = V3dArray(1)
+#    v1a[:] = V3d(v1)
+#    v2a = m4.multDirMatrix(v1a)
+#    assert v2a[0].equalWithAbsError((0, 1, 0), v2a[0].baseTypeEpsilon())
     
     # Division.
 


### PR DESCRIPTION
This activates the tests for the Matrix22 and Matrix33 classes, float and double.

This does not include Matrix44, but that should slot in directly.

Note it does _not_ include the associated array classes, those are TBD.