### PR TITLE
Update legacy Windows CI job from vfx2022 to vfx2023

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -203,8 +203,8 @@ jobs:
             cxx-standard: 14
 
           - build: 5
-            label: vfx2022
-            os: windows-2019
+            label: vfx2023
+            os: windows-2022
             IMATH_TEST_PYTHON: 'OFF' # TODO: "import imath" fails on Windows, please help find why!
             IMATH_TEST_PYBIND11: 'OFF' # TODO: "import pybindimath" fails on Windows, please help find why!
 


### PR DESCRIPTION
GitHub is deprecating windows-2019 runner, so drop coverage for VFX 2022.