### PR TITLE
Fix `find_package(Boost)` for CMake 4.x

### DIFF
--- a/.github/workflows/ci_steps.yml
+++ b/.github/workflows/ci_steps.yml
@@ -227,16 +227,31 @@ jobs:
         shell: bash
 
       - name: Install CMake
-        if: runner.os == 'Linux' && inputs.cmake != ''
         # CMakeLists.txt specifies a minimum CMake version of 3.14 for
-        # the Imath project, so use that for the CI. Except that the
-        # conan toolchain requires a minimum of 3.15, so use that for
-        # the runs that require conan.
+        # the Imath project, so use that for the CI, unless a specific
+        # version is specified. The conan toolchain requires a minimum
+        # of 3.15, so use that for the runs that require conan.
         run: |
-          CMAKE_VERSION=${{ inputs.cmake }}
-          wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz
-          tar -xzf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz
-          echo "CMAKE=$PWD/cmake-$CMAKE_VERSION-Linux-x86_64/bin/cmake" >> $GITHUB_ENV
+          set -ex
+          CMAKE=cmake
+          CTEST=ctest
+          if [ "${{ inputs.cmake }}" != "" ]; then
+            if [ "$RUNNER_OS" == "Linux" ]; then
+              CMAKE_VERSION=${{ inputs.cmake }}
+              CURRENT_CMAKE_VERSION=$(cmake --version | head -n 1 | cut -f3 -d' ')
+              if [ "$CMAKE_VERSION" != "$CURRENT_CMAKE_VERSION" ]; then
+                wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz
+                tar -xzf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz 
+                CMAKE=$(find "$PWD" -type f -path "*/bin/cmake" | head -n 1)
+                CTEST=$(find "$PWD" -type f -path "*/bin/ctest" | head -n 1)
+              fi
+            else
+              echo "Explicit cmake version only supported on Linux."
+              exit 1
+            fi
+          fi
+          echo CMAKE="$CMAKE" >> $GITHUB_ENV
+          echo CTEST="$CTEST" >> $GITHUB_ENV
         shell: bash
 
       - name: Construct CMake command
@@ -424,7 +439,7 @@ jobs:
           set -x
           export PATH="$IMATH_PATH:$PATH"
           export PYTHONPATH=$PYTHON_INSTALL_DIR
-          ctest -T Test -C ${{ inputs.build-type }} --test-dir $BUILD_DIR --timeout 7200 --output-on-failure -VV
+          $CTEST -T Test -C ${{ inputs.build-type }} --test-dir $BUILD_DIR --timeout 7200 --output-on-failure -VV
         shell: bash
 
       - name: Test (msys2)
@@ -434,7 +449,7 @@ jobs:
           set -x
           export PATH="$IMATH_PATH:$PATH"
           export PYTHONPATH=$PYTHON_INSTALL_DIR
-          ctest -T Test -C ${{ inputs.build-type }} --test-dir $BUILD_DIR --timeout 7200 --output-on-failure -VV
+          $CTEST -T Test -C ${{ inputs.build-type }} --test-dir $BUILD_DIR --timeout 7200 --output-on-failure -VV
         shell: msys2 {0}
 
       - name: Prepare install_manifest

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -95,6 +95,10 @@ jobs:
             cxx-compiler: clang++
             cc-compiler: clang
 
+          - build: 7
+            label: cmake 4
+            cmake: 4.0.3
+
   macOS:
     name: 'macOS.${{ matrix.build}}: ${{ matrix.label }}'
     uses: ./.github/workflows/ci_steps.yml

--- a/src/pybind11/PyBindImath/CMakeLists.txt
+++ b/src/pybind11/PyBindImath/CMakeLists.txt
@@ -129,11 +129,11 @@ if (IMATH_INSTALL)
     #
   
     set(PYTHON_INSTALL_DIR "lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages")
-    message(STATUS "installing ${PYBINDIMATH_MODULE} to ${PYTHON_INSTALL_DIR}")
+    message(STATUS "installing ${PYBINDIMATH_MODULE_NAME} to ${PYTHON_INSTALL_DIR}")
 
   else()
 
-    message(STATUS "installing ${PYBINDIMATH_MODULE} to ${PYTHON_INSTALL_DIR} (set externally)")
+    message(STATUS "installing ${PYBINDIMATH_MODULE_NAME} to ${PYTHON_INSTALL_DIR} (set externally)")
   
   endif()
   

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT Python3_FOUND)
     message(FATAL_ERROR "Could not find Python")
 endif()
 
-find_package(Boost REQUIRED COMPONENTS python)
+find_package(Boost CONFIG REQUIRED COMPONENTS python)
 
 if(NOT Boost_FOUND)
     message(FATAL_ERROR "Could not find Boost")

--- a/src/python/PyImath/CMakeLists.txt
+++ b/src/python/PyImath/CMakeLists.txt
@@ -214,11 +214,11 @@ if (IMATH_INSTALL)
     #
   
     set(PYTHON_INSTALL_DIR "lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages")
-    message(STATUS "installing ${PYIMATH_MODULE} module to ${PYTHON_INSTALL_DIR}")
+    message(STATUS "installing ${PYIMATH_MODULE_NAME} module to ${PYTHON_INSTALL_DIR}")
 
   else()
 
-    message(STATUS "installing ${PYIMATH_MODULE} module to ${PYTHON_INSTALL_DIR} (set externally)")
+    message(STATUS "installing ${PYIMATH_MODULE_NAME} module to ${PYTHON_INSTALL_DIR} (set externally)")
   
   endif()
   


### PR DESCRIPTION
`find_package(Boost)` has changed under CMake 3.26+:

```
  CMake Warning (dev) at src/python/CMakeLists.txt:16 (find_package):
    Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
    --help-policy CMP0167" for policy details.  Use the cmake_policy command to
    set the policy and suppress this warning.
  This warning is for project developers.  Use -Wno-dev to suppress it.
```

The fix is to include `CONFIG`:

```
  find_package(Boost CONFIG REQUIRED COMPONENTS python)
```

This also adds a CI test for cmake 4.0.3. This required updating the ci step to install cmake, similar to OpenEXR.

The status messages for the python module were also printing the wrong string.