### PR TITLE
Remove duplicate ImathConfig ALIAS in cmake config

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -31,8 +31,6 @@ if (IMATH_INSTALL)
   install(TARGETS ImathConfig EXPORT Imath)
 endif()
 
-add_library(Imath::Config ALIAS ImathConfig)
-
 if(IMATH_INSTALL_PKG_CONFIG AND NOT IMATH_BUILD_APPLE_FRAMEWORKS)
 
   # Prepend prefix for includedir only if CMAKE_INSTALL_INCLUDEDIR is relative


### PR DESCRIPTION
A duplicate `add_library(Imath::Config ALIAS ImathConfig)` line slipped in. The other is on line 17.  Older CMake versions seem to ignore this but cmake 4 seems to report it as an error in certain circumstances.