### PR TITLE
cmake - clean up policies covered by min required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,15 +3,6 @@
 
 cmake_minimum_required(VERSION 3.14)
 
-if(POLICY CMP0074)
-  cmake_policy(SET CMP0074 NEW)
-endif()
-
-if(POLICY CMP0077)
-  # enable variables set outside to override options
-  cmake_policy(SET CMP0077 NEW)
-endif()
-
 # Imath version
 
 project(Imath VERSION 3.2.0 LANGUAGES C CXX)


### PR DESCRIPTION
Current `cmake_minimum_required` is 3.14

https://cmake.org/cmake/help/latest/policy/CMP0074.html - introduced in cmake 3.12 https://cmake.org/cmake/help/latest/policy/CMP0077.html - introduced in cmake 3.13

So both policies are always `NEW` by definition and there's no need to set them explicitly.