### PR TITLE
Set PYTHON_INSTALL_DIR based on Python3_SITEARCH

### DIFF
--- a/src/pybind11/PyBindImath/CMakeLists.txt
+++ b/src/pybind11/PyBindImath/CMakeLists.txt
@@ -127,8 +127,21 @@ if (IMATH_INSTALL)
     # Set the PYTHON_INSTALL_DIR but only if it's not already set,
     # which allows an externally-set value to take effect.
     #
-  
-    set(PYTHON_INSTALL_DIR "lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages")
+    # PYTHON_INSTALL_DIR should be a relative path underneath the 
+    # INSTALL_DIR. Set it to Python3_SITEARCH, relative to the python
+    # system installation.
+    #
+    
+    if (NOT Python3_PREFIX)
+      # if Python3_PREFIX is not set, use the location of the python executable
+      get_filename_component(Python3_PREFIX "${Python3_EXECUTABLE}" DIRECTORY)
+      get_filename_component(Python3_PREFIX "${Python3_PREFIX}" DIRECTORY)
+    endif()
+
+    file(RELATIVE_PATH PYTHON_INSTALL_DIR
+      "${Python3_PREFIX}"
+      "${Python3_SITEARCH}")
+
     message(STATUS "installing ${PYBINDIMATH_MODULE_NAME} to ${PYTHON_INSTALL_DIR}")
 
   else()

--- a/src/pybind11/PyBindImath/CMakeLists.txt
+++ b/src/pybind11/PyBindImath/CMakeLists.txt
@@ -138,9 +138,12 @@ if (IMATH_INSTALL)
       get_filename_component(Python3_PREFIX "${Python3_PREFIX}" DIRECTORY)
     endif()
 
+    # Ensure Python3_SITEARCH is absolute before computing relative path
+    file(REAL_PATH "${Python3_SITEARCH}" Python3_SITEARCH_ABS)
+
     file(RELATIVE_PATH PYTHON_INSTALL_DIR
       "${Python3_PREFIX}"
-      "${Python3_SITEARCH}")
+      "${Python3_SITEARCH_ABS}")
 
     message(STATUS "installing ${PYBINDIMATH_MODULE_NAME} to ${PYTHON_INSTALL_DIR}")
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -19,6 +19,29 @@ if(NOT Boost_FOUND)
     message(FATAL_ERROR "Could not find Boost")
 endif()
 
+if (NOT DEFINED PYTHON_INSTALL_DIR)
+
+  #
+  # Set the PYTHON_INSTALL_DIR but only if it's not already set,
+  # which allows an externally-set value to take effect.
+  #
+  # PYTHON_INSTALL_DIR should be a relative path underneath the 
+  # INSTALL_DIR. Set it to Python3_SITEARCH, relative to the python
+  # system installation.
+  #
+    
+  if (NOT Python3_PREFIX)
+    # if Python3_PREFIX is not set, use the location of the python executable
+    get_filename_component(Python3_PREFIX "${Python3_EXECUTABLE}" DIRECTORY)
+    get_filename_component(Python3_PREFIX "${Python3_PREFIX}" DIRECTORY)
+  endif()
+
+  file(RELATIVE_PATH PYTHON_INSTALL_DIR
+    "${Python3_PREFIX}"
+    "${Python3_SITEARCH}")
+
+endif()
+
 #
 # Python library suffix string. By default, it includes the python
 # version and Imath release number, e.g. "_Python3_12-3_4"

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -36,9 +36,12 @@ if (NOT DEFINED PYTHON_INSTALL_DIR)
     get_filename_component(Python3_PREFIX "${Python3_PREFIX}" DIRECTORY)
   endif()
 
+  # Ensure Python3_SITEARCH is an absolute path
+  get_filename_component(Python3_SITEARCH_ABS "${Python3_SITEARCH}" REALPATH)
+
   file(RELATIVE_PATH PYTHON_INSTALL_DIR
     "${Python3_PREFIX}"
-    "${Python3_SITEARCH}")
+    "${Python3_SITEARCH_ABS}")
 
 endif()
 

--- a/src/python/PyImath/CMakeLists.txt
+++ b/src/python/PyImath/CMakeLists.txt
@@ -206,22 +206,8 @@ add_library(PyImath::Config ALIAS PyImathConfig)
 
 if (IMATH_INSTALL)
 
-  if (NOT DEFINED PYTHON_INSTALL_DIR)
+  message(STATUS "installing ${PYIMATH_MODULE_NAME} module to ${PYTHON_INSTALL_DIR}")
 
-    #
-    # Set the PYTHON_INSTALL_DIR but only if it's not already set,
-    # which allows an externally-set value to take effect.
-    #
-  
-    set(PYTHON_INSTALL_DIR "lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages")
-    message(STATUS "installing ${PYIMATH_MODULE_NAME} module to ${PYTHON_INSTALL_DIR}")
-
-  else()
-
-    message(STATUS "installing ${PYIMATH_MODULE_NAME} module to ${PYTHON_INSTALL_DIR} (set externally)")
-  
-  endif()
-  
   #
   # Install the python module 
   #

--- a/src/python/PyImathNumpy/CMakeLists.txt
+++ b/src/python/PyImathNumpy/CMakeLists.txt
@@ -50,21 +50,7 @@ target_link_libraries(${PYIMATHNUMPY_MODULE}
 
 if (IMATH_INSTALL)
 
-  #
-  # Set the PYTHON_INSTALL_DIR but only if it's not already set,
-  # which allows an externally-set value to take effect.
-  #
-  
-  if (NOT DEFINED PYTHON_INSTALL_DIR)
-
-    set(PYTHON_INSTALL_DIR "lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages")
-    message(STATUS "installing ${PYIMATHNUMPY_MODULE} module to ${PYTHON_INSTALL_DIR}")
-
-  else()
-
-    message(STATUS "installing ${PYIMATHNUMPY_MODULE} module to ${PYTHON_INSTALL_DIR} (set externally)")
-  
-  endif()
+  message(STATUS "installing ${PYIMATHNUMPY_MODULE} module to ${PYTHON_INSTALL_DIR}")
   
   install(TARGETS ${PYIMATHNUMPY_MODULE} LIBRARY DESTINATION ${PYTHON_INSTALL_DIR})
 


### PR DESCRIPTION
Python3_SIETARCH is relative, but PYTHON_INSTALL_DIR is absolute. So strip the Python3_PREFIS from Python3_SITEARCH to form a relative path.

This is preferable to the current hardcoded path, but is also preferable to using an absolute path, as suggested in #523.