### PR TITLE
Add ABI tags to the built Python modules

### DIFF
--- a/.github/workflows/ci_steps.yml
+++ b/.github/workflows/ci_steps.yml
@@ -425,7 +425,7 @@ jobs:
           set -x
 
           # debugging code to help confirm the dlls are in the path
-          #IMATH_PYD=$(cygpath -u "$PYTHON_INSTALL_DIR/imath.pyd")
+          #IMATH_PYD=$(cygpath -u "$PYTHON_INSTALL_DIR/imath.cp39-win_amd64.pyd")
           #if [[ -f "$IMATH_PYD" ]]; then
           #    objdump -p "$IMATH_PYD" | grep 'DLL Name'
           #fi

--- a/share/ci/install_manifest/install_manifest.linux.1.txt
+++ b/share/ci/install_manifest/install_manifest.linux.1.txt
@@ -103,6 +103,6 @@ lib/libPyImath_Python$PYTHONMAJOR_$PYTHONMINOR-$MAJOR_$MINOR.so.$SOVERSION.$MAJO
 lib/pkgconfig/Imath.pc
 lib/pkgconfig/PyBindImath.pc
 lib/pkgconfig/PyImath.pc
-python/imath.so
-python/imathnumpy.so
+python/imath.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so
+python/imathnumpy.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so
 python/pybindimath.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so

--- a/share/ci/install_manifest/install_manifest.linux.2.txt
+++ b/share/ci/install_manifest/install_manifest.linux.2.txt
@@ -104,6 +104,6 @@ lib/libPyImath_d.so
 lib/pkgconfig/Imath.pc
 lib/pkgconfig/PyBindImath.pc
 lib/pkgconfig/PyImath.pc
-python/imath.so
-python/imathnumpy.so
+python/imath.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so
+python/imathnumpy.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so
 python/pybindimath.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so

--- a/share/ci/install_manifest/install_manifest.linux.3.txt
+++ b/share/ci/install_manifest/install_manifest.linux.3.txt
@@ -94,6 +94,6 @@ lib/libPyImath_Python$PYTHONMAJOR_$PYTHONMINOR-$MAJOR_$MINOR.a
 lib/pkgconfig/Imath.pc
 lib/pkgconfig/PyBindImath.pc
 lib/pkgconfig/PyImath.pc
-python/imath.so
-python/imathnumpy.so
+python/imath.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so
+python/imathnumpy.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so
 python/pybindimath.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so

--- a/share/ci/install_manifest/install_manifest.linux.5.txt
+++ b/share/ci/install_manifest/install_manifest.linux.5.txt
@@ -103,6 +103,6 @@ lib/libPyImath.so
 lib/pkgconfig/Imath.pc
 lib/pkgconfig/PyBindImath.pc
 lib/pkgconfig/PyImath.pc
-python/imath.so
-python/imathnumpy.so
+python/imath.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so
+python/imathnumpy.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so
 python/pybindimath.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so

--- a/share/ci/install_manifest/install_manifest.linux.6.txt
+++ b/share/ci/install_manifest/install_manifest.linux.6.txt
@@ -103,6 +103,6 @@ lib/libPyImath_Python$PYTHONMAJOR_$PYTHONMINOR-$MAJOR_$MINOR.so.$SOVERSION.$MAJO
 lib/pkgconfig/Imath.pc
 lib/pkgconfig/PyBindImath.pc
 lib/pkgconfig/PyImath.pc
-python/imath.so
-python/imathnumpy.so
+python/imath.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so
+python/imathnumpy.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so
 python/pybindimath.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so

--- a/share/ci/install_manifest/install_manifest.linux.7.txt
+++ b/share/ci/install_manifest/install_manifest.linux.7.txt
@@ -103,6 +103,6 @@ lib/libPyImath_Python$PYTHONMAJOR_$PYTHONMINOR-$MAJOR_$MINOR.so.$SOVERSION.$MAJO
 lib/pkgconfig/Imath.pc
 lib/pkgconfig/PyBindImath.pc
 lib/pkgconfig/PyImath.pc
-python/imath.so
-python/imathnumpy.so
+python/imath.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so
+python/imathnumpy.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so
 python/pybindimath.cpython-$PYTHONMAJOR$PYTHONMINOR-x86_64-linux-gnu.so

--- a/share/ci/install_manifest/install_manifest.macos.1.txt
+++ b/share/ci/install_manifest/install_manifest.macos.1.txt
@@ -103,6 +103,6 @@ lib/libPyImath_Python$PYTHONMAJOR_$PYTHONMINOR-$MAJOR_$MINOR.dylib
 lib/pkgconfig/Imath.pc
 lib/pkgconfig/PyBindImath.pc
 lib/pkgconfig/PyImath.pc
-python/imath.so
-python/imathnumpy.so
+python/imath.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so
+python/imathnumpy.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so
 python/pybindimath.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so

--- a/share/ci/install_manifest/install_manifest.macos.2.txt
+++ b/share/ci/install_manifest/install_manifest.macos.2.txt
@@ -103,6 +103,6 @@ lib/libPyImath_d.dylib
 lib/pkgconfig/Imath.pc
 lib/pkgconfig/PyBindImath.pc
 lib/pkgconfig/PyImath.pc
-python/imath.so
-python/imathnumpy.so
+python/imath.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so
+python/imathnumpy.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so
 python/pybindimath.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so

--- a/share/ci/install_manifest/install_manifest.macos.3.txt
+++ b/share/ci/install_manifest/install_manifest.macos.3.txt
@@ -94,6 +94,6 @@ lib/libPyImath_Python$PYTHONMAJOR_$PYTHONMINOR-$MAJOR_$MINOR.a
 lib/pkgconfig/Imath.pc
 lib/pkgconfig/PyBindImath.pc
 lib/pkgconfig/PyImath.pc
-python/imath.so
-python/imathnumpy.so
+python/imath.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so
+python/imathnumpy.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so
 python/pybindimath.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so

--- a/share/ci/install_manifest/install_manifest.macos.5.txt
+++ b/share/ci/install_manifest/install_manifest.macos.5.txt
@@ -103,6 +103,6 @@ lib/libPyImath_Python$PYTHONMAJOR_$PYTHONMINOR-$MAJOR_$MINOR.dylib
 lib/pkgconfig/Imath.pc
 lib/pkgconfig/PyBindImath.pc
 lib/pkgconfig/PyImath.pc
-python/imath.so
-python/imathnumpy.so
+python/imath.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so
+python/imathnumpy.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so
 python/pybindimath.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so

--- a/share/ci/install_manifest/install_manifest.macos.6.txt
+++ b/share/ci/install_manifest/install_manifest.macos.6.txt
@@ -103,6 +103,6 @@ lib/libPyImath_Python$PYTHONMAJOR_$PYTHONMINOR-$MAJOR_$MINOR.dylib
 lib/pkgconfig/Imath.pc
 lib/pkgconfig/PyBindImath.pc
 lib/pkgconfig/PyImath.pc
-python/imath.so
-python/imathnumpy.so
+python/imath.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so
+python/imathnumpy.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so
 python/pybindimath.cpython-$PYTHONMAJOR$PYTHONMINOR-darwin.so

--- a/share/ci/install_manifest/install_manifest.windows.1.txt
+++ b/share/ci/install_manifest/install_manifest.windows.1.txt
@@ -100,6 +100,6 @@ lib/cmake/Imath/PyImathTargets.cmake
 lib/pkgconfig/Imath.pc
 lib/pkgconfig/PyBindImath.pc
 lib/pkgconfig/PyImath.pc
-python/imath.pyd
-python/imathnumpy.pyd
+python/imath.cp$PYTHONMAJOR$PYTHONMINOR-win_amd64.pyd
+python/imathnumpy.cp$PYTHONMAJOR$PYTHONMINOR-win_amd64.pyd
 python/pybindimath.cp$PYTHONMAJOR$PYTHONMINOR-win_amd64.pyd

--- a/share/ci/install_manifest/install_manifest.windows.3.txt
+++ b/share/ci/install_manifest/install_manifest.windows.3.txt
@@ -94,6 +94,6 @@ lib/cmake/Imath/PyImathTargets.cmake
 lib/pkgconfig/Imath.pc
 lib/pkgconfig/PyBindImath.pc
 lib/pkgconfig/PyImath.pc
-python/imath.pyd
-python/imathnumpy.pyd
+python/imath.cp$PYTHONMAJOR$PYTHONMINOR-win_amd64.pyd
+python/imathnumpy.cp$PYTHONMAJOR$PYTHONMINOR-win_amd64.pyd
 python/pybindimath.cp$PYTHONMAJOR$PYTHONMINOR-win_amd64.pyd

--- a/share/ci/install_manifest/install_manifest.windows.5.txt
+++ b/share/ci/install_manifest/install_manifest.windows.5.txt
@@ -100,6 +100,6 @@ lib/cmake/Imath/PyImathTargets.cmake
 lib/pkgconfig/Imath.pc
 lib/pkgconfig/PyBindImath.pc
 lib/pkgconfig/PyImath.pc
-python/imath.pyd
-python/imathnumpy.pyd
+python/imath.cp$PYTHONMAJOR$PYTHONMINOR-win_amd64.pyd
+python/imathnumpy.cp$PYTHONMAJOR$PYTHONMINOR-win_amd64.pyd
 python/pybindimath.cp$PYTHONMAJOR$PYTHONMINOR-win_amd64.pyd

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -33,6 +33,19 @@ set(PYIMATH_LIB_SUFFIX
 set(PYIMATH_OUTPUT_SUBDIR Imath CACHE STRING "Destination sub-folder of the path for install of PyImath headers")
 
 #
+# Python extension suffix.
+# In cmake 3.17+ `Python_add_library` will handle this automatically
+# and then this code can be removed.
+#
+
+# Example suffix is '.cp311-win_amd64.pyd'.
+execute_process(
+    COMMAND "${Python3_EXECUTABLE}" -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"
+    OUTPUT_VARIABLE PYIMATH_EXTENSION_SUFFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+#
 # PyImath and PyImathNumpy
 #
 

--- a/src/python/PyImath/CMakeLists.txt
+++ b/src/python/PyImath/CMakeLists.txt
@@ -16,8 +16,6 @@ set(PYIMATH_LIBRARY PyImath)
 
 message(STATUS "Configuring imath module and ${PYIMATH_LIBRARY} library")
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
-
 set(PYIMATH_SOURCES
     PyImath.cpp
     PyImathAutovectorize.cpp
@@ -169,15 +167,7 @@ set(PYIMATH_MODULE_SOURCES
 
 add_library(${PYIMATH_MODULE} MODULE ${PYIMATH_MODULE_SOURCES})
 
-# Ensure correct module extension on Windows
-if(WIN32)
-  set(extension_suffix ".pyd")
-else()
-  set(extension_suffix "${CMAKE_SHARED_MODULE_SUFFIX}")
-endif()
-# Add ABI tag to extension names, e.g. '.cp311-win_amd64'
-set_target_properties(${PYIMATH_MODULE} PROPERTIES SUFFIX ".${Python3_SOABI}${extension_suffix}")
-
+set_target_properties(${PYIMATH_MODULE} PROPERTIES SUFFIX "${PYIMATH_EXTENSION_SUFFIX}")
 set_target_properties(${PYIMATH_MODULE} PROPERTIES
     OUTPUT_NAME ${PYIMATH_MODULE_NAME} # override the _d suffix for Debug builds
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/python${Python3_VERSION_MAJOR}_${Python3_VERSION_MINOR}/"

--- a/src/python/PyImath/CMakeLists.txt
+++ b/src/python/PyImath/CMakeLists.txt
@@ -174,7 +174,7 @@ if(WIN32)
   set(extension_suffix ".pyd")
 else()
   set(extension_suffix "${CMAKE_SHARED_MODULE_SUFFIX}")
-  endif()
+endif()
 # Add ABI tag to extension names, e.g. '.cp311-win_amd64'
 set_target_properties(${PYIMATH_MODULE} PROPERTIES SUFFIX ".${Python3_SOABI}${extension_suffix}")
 

--- a/src/python/PyImath/CMakeLists.txt
+++ b/src/python/PyImath/CMakeLists.txt
@@ -16,6 +16,8 @@ set(PYIMATH_LIBRARY PyImath)
 
 message(STATUS "Configuring imath module and ${PYIMATH_LIBRARY} library")
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+
 set(PYIMATH_SOURCES
     PyImath.cpp
     PyImathAutovectorize.cpp
@@ -167,10 +169,14 @@ set(PYIMATH_MODULE_SOURCES
 
 add_library(${PYIMATH_MODULE} MODULE ${PYIMATH_MODULE_SOURCES})
 
+# Ensure correct module extension on Windows
 if(WIN32)
-    # Ensure correct module extension on Windows
-    set_target_properties(${PYIMATH_MODULE} PROPERTIES SUFFIX ".pyd")
-endif()
+  set(extension_suffix ".pyd")
+else()
+  set(extension_suffix "${CMAKE_SHARED_MODULE_SUFFIX}")
+  endif()
+# Add ABI tag to extension names, e.g. '.cp311-win_amd64'
+set_target_properties(${PYIMATH_MODULE} PROPERTIES SUFFIX ".${Python3_SOABI}${extension_suffix}")
 
 set_target_properties(${PYIMATH_MODULE} PROPERTIES
     OUTPUT_NAME ${PYIMATH_MODULE_NAME} # override the _d suffix for Debug builds

--- a/src/python/PyImathNumpy/CMakeLists.txt
+++ b/src/python/PyImathNumpy/CMakeLists.txt
@@ -25,7 +25,7 @@ if(WIN32)
   set(extension_suffix ".pyd")
 else()
   set(extension_suffix "${CMAKE_SHARED_MODULE_SUFFIX}")
-  endif()
+endif()
 # Add ABI tag to extension names, e.g. '.cp311-win_amd64'
 set_target_properties(${PYIMATHNUMPY_MODULE} PROPERTIES SUFFIX ".${Python3_SOABI}${extension_suffix}")
 

--- a/src/python/PyImathNumpy/CMakeLists.txt
+++ b/src/python/PyImathNumpy/CMakeLists.txt
@@ -11,6 +11,8 @@ set(PYIMATHNUMPY_MODULE imathnumpy)
 
 set(PYIMATHNUMPY_MODULE_SOURCES imathnumpymodule.cpp)
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+
 # Build "imathnumpy", not "imathnumpy_d" in Debug.
 # Note this must appear before add_library
 
@@ -20,8 +22,12 @@ add_library(${PYIMATHNUMPY_MODULE} MODULE ${PYIMATHNUMPY_MODULE_SOURCES})
 
 # Ensure correct module extension on Windows
 if(WIN32)
-    set_target_properties(${PYIMATHNUMPY_MODULE} PROPERTIES SUFFIX ".pyd")
-endif()
+  set(extension_suffix ".pyd")
+else()
+  set(extension_suffix "${CMAKE_SHARED_MODULE_SUFFIX}")
+  endif()
+# Add ABI tag to extension names, e.g. '.cp311-win_amd64'
+set_target_properties(${PYIMATHNUMPY_MODULE} PROPERTIES SUFFIX ".${Python3_SOABI}${extension_suffix}")
 
 set_target_properties(${PYIMATHNUMPY_MODULE} PROPERTIES
     PREFIX ""

--- a/src/python/PyImathNumpy/CMakeLists.txt
+++ b/src/python/PyImathNumpy/CMakeLists.txt
@@ -11,23 +11,13 @@ set(PYIMATHNUMPY_MODULE imathnumpy)
 
 set(PYIMATHNUMPY_MODULE_SOURCES imathnumpymodule.cpp)
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
-
 # Build "imathnumpy", not "imathnumpy_d" in Debug.
 # Note this must appear before add_library
 
 set(CMAKE_DEBUG_POSTFIX "") 
 
 add_library(${PYIMATHNUMPY_MODULE} MODULE ${PYIMATHNUMPY_MODULE_SOURCES})
-
-# Ensure correct module extension on Windows
-if(WIN32)
-  set(extension_suffix ".pyd")
-else()
-  set(extension_suffix "${CMAKE_SHARED_MODULE_SUFFIX}")
-endif()
-# Add ABI tag to extension names, e.g. '.cp311-win_amd64'
-set_target_properties(${PYIMATHNUMPY_MODULE} PROPERTIES SUFFIX ".${Python3_SOABI}${extension_suffix}")
+set_target_properties(${PYIMATHNUMPY_MODULE} PROPERTIES SUFFIX "${PYIMATH_EXTENSION_SUFFIX}")
 
 set_target_properties(${PYIMATHNUMPY_MODULE} PROPERTIES
     PREFIX ""


### PR DESCRIPTION
E.g. `imath.pyd` -> `imath.cp39-win_amd64.pyd` or `imathnumpy` -> `imathnumpy.cp39-win_amd64.pyd`.

Similar to how `pybind11_add_module` does it automatically for `pybindimath.cp39-win_amd64.pyd`.