### PR TITLE
Silence C++23 deprecation warning for numeric_limits<half>::has_denorm

### DIFF
--- a/config/ImathSetup.cmake
+++ b/config/ImathSetup.cmake
@@ -28,6 +28,7 @@ if(CMAKE_CXX_STANDARD)
 endif()
 set(IMATH_CXX_STANDARD "${tmp}" CACHE STRING "C++ standard to compile against")
 set(tmp)
+message(STATUS "Building against C++ Standard: ${IMATH_CXX_STANDARD}")
 
 # Namespace-related settings: allows one to customize the namespace
 # generated, and to version the namespaces.

--- a/src/Imath/half.h
+++ b/src/Imath/half.h
@@ -945,7 +945,24 @@ public:
     static constexpr bool               has_infinity      = true;
     static constexpr bool               has_quiet_NaN     = true;
     static constexpr bool               has_signaling_NaN = true;
-    static constexpr float_denorm_style has_denorm        = denorm_present;
+
+    // C++23 (P2614) deprecates std::float_denorm_style and
+    // std::denorm_present without a replacement; std::numeric_limits still
+    // requires has_denorm. Scoped pragmas silence deprecation for this line
+    // on C++23+ toolchains; they are a no-op for C++17 / C++20.
+#    if defined(__clang__) || defined(__GNUC__)
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#    elif defined(_MSC_VER)
+#        pragma warning(push)
+#        pragma warning(disable : 4996)
+#    endif
+    static constexpr float_denorm_style has_denorm = denorm_present;
+#    if defined(__clang__) || defined(__GNUC__)
+#        pragma GCC diagnostic pop
+#    elif defined(_MSC_VER)
+#        pragma warning(pop)
+#    endif
     static constexpr bool               has_denorm_loss   = false;
     static constexpr IMATH_INTERNAL_NAMESPACE::half               infinity () IMATH_NOEXCEPT
     {


### PR DESCRIPTION
In C++23, the type `float_denorm_style` and enumerator value `has_denorm` are deprecated but not yet replaced, but are still required by numeric_limits. This yields the warning:

```
  src/Imath/half.h:948:22: warning: 'float_denorm_style' is deprecated [-Wdeprecated-declarations]
  static constexpr float_denorm_style has_denorm        = denorm_present;

```
C++23 (P2614R2) deprecates the type `std::float_denorm_style`, and the `numeric_limits` members that use it (`has_denorm`, `has_denorm_loss`) but does not yet provide a replacement, so the warning can't be avoided. So silence it with a #pragma.

This also adds an informational message at configuration time reporting the C++ standard:

`  -- Building against C++ Standard: 23
`

Assisted by: Cursor