### PR TITLE
Replace =delete with SFINAE for invalid Vec integer methods

### DIFF
--- a/src/Imath/ImathTypeTraits.h
+++ b/src/Imath/ImathTypeTraits.h
@@ -30,6 +30,12 @@ using enable_if_t = typename std::enable_if<B, T>::type;
 #define IMATH_ENABLE_IF(...)                                                   \
     IMATH_INTERNAL_NAMESPACE::enable_if_t<(__VA_ARGS__), int> = 0
 
+/// A type trait that identifies types for which Vec length/normalize operations
+/// are meaningful. Defaults to std::is_floating_point, with a specialization
+/// for half.
+template <class T>
+struct is_float_like : public std::is_floating_point<T> {};
+
 #if IMATH_FOREIGN_VECTOR_INTEROP
 
 /// @{

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -1429,7 +1429,7 @@ Vec2<T>::lengthTiny () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline T
 Vec2<T>::length () const IMATH_NOEXCEPT
 {
@@ -1449,7 +1449,7 @@ Vec2<T>::length2 () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline const Vec2<T>&
 Vec2<T>::normalize () IMATH_NOEXCEPT
 {
@@ -1471,7 +1471,7 @@ Vec2<T>::normalize () IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 inline const Vec2<T>&
 Vec2<T>::normalizeExc ()
 {
@@ -1486,7 +1486,7 @@ Vec2<T>::normalizeExc ()
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline const Vec2<T>&
 Vec2<T>::normalizeNonNull () IMATH_NOEXCEPT
 {
@@ -1497,7 +1497,7 @@ Vec2<T>::normalizeNonNull () IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline Vec2<T>
 Vec2<T>::normalized () const IMATH_NOEXCEPT
 {
@@ -1509,7 +1509,7 @@ Vec2<T>::normalized () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 inline Vec2<T>
 Vec2<T>::normalizedExc () const
 {
@@ -1522,7 +1522,7 @@ Vec2<T>::normalizedExc () const
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline Vec2<T>
 Vec2<T>::normalizedNonNull () const IMATH_NOEXCEPT
 {
@@ -1917,7 +1917,7 @@ Vec3<T>::lengthTiny () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline T
 Vec3<T>::length () const IMATH_NOEXCEPT
 {
@@ -1937,7 +1937,7 @@ Vec3<T>::length2 () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline const Vec3<T>&
 Vec3<T>::normalize () IMATH_NOEXCEPT
 {
@@ -1960,7 +1960,7 @@ Vec3<T>::normalize () IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 inline const Vec3<T>&
 Vec3<T>::normalizeExc ()
 {
@@ -1976,7 +1976,7 @@ Vec3<T>::normalizeExc ()
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline const Vec3<T>&
 Vec3<T>::normalizeNonNull () IMATH_NOEXCEPT
 {
@@ -1988,7 +1988,7 @@ Vec3<T>::normalizeNonNull () IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline Vec3<T>
 Vec3<T>::normalized () const IMATH_NOEXCEPT
 {
@@ -2000,7 +2000,7 @@ Vec3<T>::normalized () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 inline Vec3<T>
 Vec3<T>::normalizedExc () const
 {
@@ -2013,7 +2013,7 @@ Vec3<T>::normalizedExc () const
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline Vec3<T>
 Vec3<T>::normalizedNonNull () const IMATH_NOEXCEPT
 {
@@ -2378,7 +2378,7 @@ Vec4<T>::lengthTiny () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline T
 Vec4<T>::length () const IMATH_NOEXCEPT
 {
@@ -2398,7 +2398,7 @@ Vec4<T>::length2 () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline const Vec4<T>&
 Vec4<T>::normalize () IMATH_NOEXCEPT
 {
@@ -2422,7 +2422,7 @@ Vec4<T>::normalize () IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 inline const Vec4<T>&
 Vec4<T>::normalizeExc ()
 {
@@ -2439,7 +2439,7 @@ Vec4<T>::normalizeExc ()
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline const Vec4<T>&
 Vec4<T>::normalizeNonNull () IMATH_NOEXCEPT
 {
@@ -2452,7 +2452,7 @@ Vec4<T>::normalizeNonNull () IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline Vec4<T>
 Vec4<T>::normalized () const IMATH_NOEXCEPT
 {
@@ -2464,7 +2464,7 @@ Vec4<T>::normalized () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 inline Vec4<T>
 Vec4<T>::normalizedExc () const
 {
@@ -2477,7 +2477,7 @@ Vec4<T>::normalizedExc () const
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<(is_float_like<S>::value), int>>
 IMATH_HOSTDEVICE inline Vec4<T>
 Vec4<T>::normalizedNonNull () const IMATH_NOEXCEPT
 {

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -36,6 +36,9 @@
 
 IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 
+/// Specialization so that Vec<half> supports length/normalize.
+template <> struct is_float_like<half> : public std::true_type {};
+
 template <class T> class Vec2;
 template <class T> class Vec3;
 template <class T> class Vec4;
@@ -280,7 +283,7 @@ public:
     /// @name Query and Manipulation
 
     /// Return the Euclidean norm
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE T length () const IMATH_NOEXCEPT;
 
     /// Return the square of the Euclidean norm, i.e. the dot product
@@ -288,33 +291,33 @@ public:
     IMATH_HOSTDEVICE constexpr T length2 () const IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, return a null vector.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE const Vec2& normalize () IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, throw an exception.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     const Vec2& normalizeExc ();
 
     /// Normalize without any checks for length()==0. Slightly faster
     /// than the other normalization routines, but if v.length() is
     /// 0.0, the result is undefined.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE const Vec2& normalizeNonNull () IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE Vec2<T> normalized () const IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this. Throw an
     /// exception if length()==0.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     Vec2<T> normalizedExc () const;
 
     /// Return a normalized vector. Does not modify *this, and does
     /// not check for length()==0. Slightly faster than the other
     /// normalization routines, but if v.length() is 0.0, the result
     /// is undefined.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE Vec2<T> normalizedNonNull () const IMATH_NOEXCEPT;
 
     /// @}
@@ -619,7 +622,7 @@ public:
     /// @name Query and Manipulation
 
     /// Return the Euclidean norm
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE T length () const IMATH_NOEXCEPT;
 
     /// Return the square of the Euclidean norm, i.e. the dot product
@@ -627,33 +630,33 @@ public:
     IMATH_HOSTDEVICE constexpr T length2 () const IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, return a null vector.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE const Vec3& normalize () IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, throw an exception.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     const Vec3& normalizeExc ();
 
     /// Normalize without any checks for length()==0. Slightly faster
     /// than the other normalization routines, but if v.length() is
     /// 0.0, the result is undefined.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE const Vec3& normalizeNonNull () IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE Vec3<T> normalized () const IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this. Throw an
     /// exception if length()==0.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     Vec3<T> normalizedExc () const;
 
     /// Return a normalized vector. Does not modify *this, and does
     /// not check for length()==0. Slightly faster than the other
     /// normalization routines, but if v.length() is 0.0, the result
     /// is undefined.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE Vec3<T> normalizedNonNull () const IMATH_NOEXCEPT;
 
     /// @}
@@ -939,7 +942,7 @@ public:
     /// @name Query and Manipulation
 
     /// Return the Euclidean norm
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE T length () const IMATH_NOEXCEPT;
 
     /// Return the square of the Euclidean norm, i.e. the dot product
@@ -947,33 +950,33 @@ public:
     IMATH_HOSTDEVICE constexpr T length2 () const IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, return a null vector.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE const Vec4& normalize () IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, throw an exception.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     const Vec4& normalizeExc ();
 
     /// Normalize without any checks for length()==0. Slightly faster
     /// than the other normalization routines, but if v.length() is
     /// 0.0, the result is undefined.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE const Vec4& normalizeNonNull () IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE Vec4<T> normalized () const IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this. Throw an
     /// exception if length()==0.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     Vec4<T> normalizedExc () const;
 
     /// Return a normalized vector. Does not modify *this, and does
     /// not check for length()==0. Slightly faster than the other
     /// normalization routines, but if v.length() is 0.0, the result
     /// is undefined.
-    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    template <typename S = T, IMATH_ENABLE_IF (is_float_like<S>::value)>
     IMATH_HOSTDEVICE Vec4<T> normalizedNonNull () const IMATH_NOEXCEPT;
 
     /// @}
@@ -1426,7 +1429,7 @@ Vec2<T>::lengthTiny () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline T
 Vec2<T>::length () const IMATH_NOEXCEPT
 {
@@ -1446,7 +1449,7 @@ Vec2<T>::length2 () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline const Vec2<T>&
 Vec2<T>::normalize () IMATH_NOEXCEPT
 {
@@ -1468,7 +1471,7 @@ Vec2<T>::normalize () IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 inline const Vec2<T>&
 Vec2<T>::normalizeExc ()
 {
@@ -1483,7 +1486,7 @@ Vec2<T>::normalizeExc ()
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline const Vec2<T>&
 Vec2<T>::normalizeNonNull () IMATH_NOEXCEPT
 {
@@ -1494,7 +1497,7 @@ Vec2<T>::normalizeNonNull () IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline Vec2<T>
 Vec2<T>::normalized () const IMATH_NOEXCEPT
 {
@@ -1506,7 +1509,7 @@ Vec2<T>::normalized () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 inline Vec2<T>
 Vec2<T>::normalizedExc () const
 {
@@ -1519,7 +1522,7 @@ Vec2<T>::normalizedExc () const
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline Vec2<T>
 Vec2<T>::normalizedNonNull () const IMATH_NOEXCEPT
 {
@@ -1914,7 +1917,7 @@ Vec3<T>::lengthTiny () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline T
 Vec3<T>::length () const IMATH_NOEXCEPT
 {
@@ -1934,7 +1937,7 @@ Vec3<T>::length2 () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline const Vec3<T>&
 Vec3<T>::normalize () IMATH_NOEXCEPT
 {
@@ -1957,7 +1960,7 @@ Vec3<T>::normalize () IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 inline const Vec3<T>&
 Vec3<T>::normalizeExc ()
 {
@@ -1973,7 +1976,7 @@ Vec3<T>::normalizeExc ()
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline const Vec3<T>&
 Vec3<T>::normalizeNonNull () IMATH_NOEXCEPT
 {
@@ -1985,7 +1988,7 @@ Vec3<T>::normalizeNonNull () IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline Vec3<T>
 Vec3<T>::normalized () const IMATH_NOEXCEPT
 {
@@ -1997,7 +2000,7 @@ Vec3<T>::normalized () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 inline Vec3<T>
 Vec3<T>::normalizedExc () const
 {
@@ -2010,7 +2013,7 @@ Vec3<T>::normalizedExc () const
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline Vec3<T>
 Vec3<T>::normalizedNonNull () const IMATH_NOEXCEPT
 {
@@ -2375,7 +2378,7 @@ Vec4<T>::lengthTiny () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline T
 Vec4<T>::length () const IMATH_NOEXCEPT
 {
@@ -2395,7 +2398,7 @@ Vec4<T>::length2 () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline const Vec4<T>&
 Vec4<T>::normalize () IMATH_NOEXCEPT
 {
@@ -2419,7 +2422,7 @@ Vec4<T>::normalize () IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 inline const Vec4<T>&
 Vec4<T>::normalizeExc ()
 {
@@ -2436,7 +2439,7 @@ Vec4<T>::normalizeExc ()
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline const Vec4<T>&
 Vec4<T>::normalizeNonNull () IMATH_NOEXCEPT
 {
@@ -2449,7 +2452,7 @@ Vec4<T>::normalizeNonNull () IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline Vec4<T>
 Vec4<T>::normalized () const IMATH_NOEXCEPT
 {
@@ -2461,7 +2464,7 @@ Vec4<T>::normalized () const IMATH_NOEXCEPT
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 inline Vec4<T>
 Vec4<T>::normalizedExc () const
 {
@@ -2474,7 +2477,7 @@ Vec4<T>::normalizedExc () const
 }
 
 template <class T>
-template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<is_float_like<S>::value, int>>
 IMATH_HOSTDEVICE inline Vec4<T>
 Vec4<T>::normalizedNonNull () const IMATH_NOEXCEPT
 {

--- a/src/Imath/ImathVec.h
+++ b/src/Imath/ImathVec.h
@@ -280,6 +280,7 @@ public:
     /// @name Query and Manipulation
 
     /// Return the Euclidean norm
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     IMATH_HOSTDEVICE T length () const IMATH_NOEXCEPT;
 
     /// Return the square of the Euclidean norm, i.e. the dot product
@@ -287,27 +288,33 @@ public:
     IMATH_HOSTDEVICE constexpr T length2 () const IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, return a null vector.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     IMATH_HOSTDEVICE const Vec2& normalize () IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, throw an exception.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     const Vec2& normalizeExc ();
 
     /// Normalize without any checks for length()==0. Slightly faster
     /// than the other normalization routines, but if v.length() is
     /// 0.0, the result is undefined.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     IMATH_HOSTDEVICE const Vec2& normalizeNonNull () IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     IMATH_HOSTDEVICE Vec2<T> normalized () const IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this. Throw an
     /// exception if length()==0.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     Vec2<T> normalizedExc () const;
 
     /// Return a normalized vector. Does not modify *this, and does
     /// not check for length()==0. Slightly faster than the other
     /// normalization routines, but if v.length() is 0.0, the result
     /// is undefined.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     IMATH_HOSTDEVICE Vec2<T> normalizedNonNull () const IMATH_NOEXCEPT;
 
     /// @}
@@ -612,6 +619,7 @@ public:
     /// @name Query and Manipulation
 
     /// Return the Euclidean norm
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     IMATH_HOSTDEVICE T length () const IMATH_NOEXCEPT;
 
     /// Return the square of the Euclidean norm, i.e. the dot product
@@ -619,28 +627,33 @@ public:
     IMATH_HOSTDEVICE constexpr T length2 () const IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, return a null vector.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     IMATH_HOSTDEVICE const Vec3& normalize () IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, throw an exception.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     const Vec3& normalizeExc ();
 
     /// Normalize without any checks for length()==0. Slightly faster
     /// than the other normalization routines, but if v.length() is
     /// 0.0, the result is undefined.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     IMATH_HOSTDEVICE const Vec3& normalizeNonNull () IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this.
-    IMATH_HOSTDEVICE Vec3<T>
-    normalized () const IMATH_NOEXCEPT; // does not modify *this
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    IMATH_HOSTDEVICE Vec3<T> normalized () const IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this. Throw an
     /// exception if length()==0.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     Vec3<T> normalizedExc () const;
 
     /// Return a normalized vector. Does not modify *this, and does
     /// not check for length()==0. Slightly faster than the other
     /// normalization routines, but if v.length() is 0.0, the result
     /// is undefined.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     IMATH_HOSTDEVICE Vec3<T> normalizedNonNull () const IMATH_NOEXCEPT;
 
     /// @}
@@ -926,6 +939,7 @@ public:
     /// @name Query and Manipulation
 
     /// Return the Euclidean norm
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     IMATH_HOSTDEVICE T length () const IMATH_NOEXCEPT;
 
     /// Return the square of the Euclidean norm, i.e. the dot product
@@ -933,28 +947,33 @@ public:
     IMATH_HOSTDEVICE constexpr T length2 () const IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, return a null vector.
-    IMATH_HOSTDEVICE const Vec4& normalize () IMATH_NOEXCEPT; // modifies *this
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    IMATH_HOSTDEVICE const Vec4& normalize () IMATH_NOEXCEPT;
 
     /// Normalize in place. If length()==0, throw an exception.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     const Vec4& normalizeExc ();
 
     /// Normalize without any checks for length()==0. Slightly faster
     /// than the other normalization routines, but if v.length() is
     /// 0.0, the result is undefined.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     IMATH_HOSTDEVICE const Vec4& normalizeNonNull () IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this.
-    IMATH_HOSTDEVICE Vec4<T>
-    normalized () const IMATH_NOEXCEPT; // does not modify *this
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
+    IMATH_HOSTDEVICE Vec4<T> normalized () const IMATH_NOEXCEPT;
 
     /// Return a normalized vector. Does not modify *this. Throw an
     /// exception if length()==0.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     Vec4<T> normalizedExc () const;
 
     /// Return a normalized vector. Does not modify *this, and does
     /// not check for length()==0. Slightly faster than the other
     /// normalization routines, but if v.length() is 0.0, the result
     /// is undefined.
+    template <typename S = T, IMATH_ENABLE_IF (std::is_floating_point<S>::value)>
     IMATH_HOSTDEVICE Vec4<T> normalizedNonNull () const IMATH_NOEXCEPT;
 
     /// @}
@@ -1083,178 +1102,6 @@ typedef Vec4<float> V4f;
 
 /// Vec4 of double
 typedef Vec4<double> V4d;
-
-//----------------------------------------------------------------------------
-// Specializations for VecN<short>, VecN<int>
-//
-// Normalize and length don't make sense for integer vectors, so disable them.
-//----------------------------------------------------------------------------
-
-/// @cond Doxygen_Suppress
-
-// Vec2<short>
-template <>
-IMATH_HOSTDEVICE short Vec2<short>::length () const IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE const Vec2<short>&
-                       Vec2<short>::normalize () IMATH_NOEXCEPT = delete;
-template <> const Vec2<short>& Vec2<short>::normalizeExc ()     = delete;
-template <>
-IMATH_HOSTDEVICE const Vec2<short>&
-                       Vec2<short>::normalizeNonNull () IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE Vec2<short>
-                 Vec2<short>::normalized () const IMATH_NOEXCEPT = delete;
-template <> Vec2<short> Vec2<short>::normalizedExc () const      = delete;
-template <>
-IMATH_HOSTDEVICE Vec2<short>
-Vec2<short>::normalizedNonNull () const IMATH_NOEXCEPT = delete;
-
-// Vec2<int>
-template <>
-IMATH_HOSTDEVICE int Vec2<int>::length () const IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE const       Vec2<int>&
-                             Vec2<int>::normalize () IMATH_NOEXCEPT = delete;
-template <> const Vec2<int>& Vec2<int>::normalizeExc ()             = delete;
-template <>
-IMATH_HOSTDEVICE const Vec2<int>&
-                       Vec2<int>::normalizeNonNull () IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE      Vec2<int>
-                      Vec2<int>::normalized () const IMATH_NOEXCEPT = delete;
-template <> Vec2<int> Vec2<int>::normalizedExc () const             = delete;
-template <>
-IMATH_HOSTDEVICE Vec2<int>
-                 Vec2<int>::normalizedNonNull () const IMATH_NOEXCEPT = delete;
-
-// Vec2<int64_t>
-template <>
-IMATH_HOSTDEVICE int64_t Vec2<int64_t>::length () const IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE const Vec2<int64_t>&
-                       Vec2<int64_t>::normalize () IMATH_NOEXCEPT = delete;
-template <> const Vec2<int64_t>& Vec2<int64_t>::normalizeExc ()   = delete;
-template <>
-IMATH_HOSTDEVICE const Vec2<int64_t>&
-Vec2<int64_t>::normalizeNonNull () IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE Vec2<int64_t>
-                 Vec2<int64_t>::normalized () const IMATH_NOEXCEPT = delete;
-template <> Vec2<int64_t> Vec2<int64_t>::normalizedExc () const    = delete;
-template <>
-IMATH_HOSTDEVICE Vec2<int64_t>
-Vec2<int64_t>::normalizedNonNull () const IMATH_NOEXCEPT = delete;
-
-// Vec3<short>
-template <>
-IMATH_HOSTDEVICE short Vec3<short>::length () const IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE const Vec3<short>&
-                       Vec3<short>::normalize () IMATH_NOEXCEPT = delete;
-template <> const Vec3<short>& Vec3<short>::normalizeExc ()     = delete;
-template <>
-IMATH_HOSTDEVICE const Vec3<short>&
-                       Vec3<short>::normalizeNonNull () IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE Vec3<short>
-                 Vec3<short>::normalized () const IMATH_NOEXCEPT = delete;
-template <> Vec3<short> Vec3<short>::normalizedExc () const      = delete;
-template <>
-IMATH_HOSTDEVICE Vec3<short>
-Vec3<short>::normalizedNonNull () const IMATH_NOEXCEPT = delete;
-
-// Vec3<int>
-template <>
-IMATH_HOSTDEVICE int Vec3<int>::length () const IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE const       Vec3<int>&
-                             Vec3<int>::normalize () IMATH_NOEXCEPT = delete;
-template <> const Vec3<int>& Vec3<int>::normalizeExc ()             = delete;
-template <>
-IMATH_HOSTDEVICE const Vec3<int>&
-                       Vec3<int>::normalizeNonNull () IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE      Vec3<int>
-                      Vec3<int>::normalized () const IMATH_NOEXCEPT = delete;
-template <> Vec3<int> Vec3<int>::normalizedExc () const             = delete;
-template <>
-IMATH_HOSTDEVICE Vec3<int>
-                 Vec3<int>::normalizedNonNull () const IMATH_NOEXCEPT = delete;
-
-// Vec3<int64_t>
-template <>
-IMATH_HOSTDEVICE int64_t Vec3<int64_t>::length () const IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE const Vec3<int64_t>&
-                       Vec3<int64_t>::normalize () IMATH_NOEXCEPT = delete;
-template <> const Vec3<int64_t>& Vec3<int64_t>::normalizeExc ()   = delete;
-template <>
-IMATH_HOSTDEVICE const Vec3<int64_t>&
-Vec3<int64_t>::normalizeNonNull () IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE Vec3<int64_t>
-                 Vec3<int64_t>::normalized () const IMATH_NOEXCEPT = delete;
-template <> Vec3<int64_t> Vec3<int64_t>::normalizedExc () const    = delete;
-template <>
-IMATH_HOSTDEVICE Vec3<int64_t>
-Vec3<int64_t>::normalizedNonNull () const IMATH_NOEXCEPT = delete;
-
-// Vec4<short>
-template <>
-IMATH_HOSTDEVICE short Vec4<short>::length () const IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE const Vec4<short>&
-                       Vec4<short>::normalize () IMATH_NOEXCEPT = delete;
-template <> const Vec4<short>& Vec4<short>::normalizeExc ()     = delete;
-template <>
-IMATH_HOSTDEVICE const Vec4<short>&
-                       Vec4<short>::normalizeNonNull () IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE Vec4<short>
-                 Vec4<short>::normalized () const IMATH_NOEXCEPT = delete;
-template <> Vec4<short> Vec4<short>::normalizedExc () const      = delete;
-template <>
-IMATH_HOSTDEVICE Vec4<short>
-Vec4<short>::normalizedNonNull () const IMATH_NOEXCEPT = delete;
-
-// Vec4<int>
-template <>
-IMATH_HOSTDEVICE int Vec4<int>::length () const IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE const       Vec4<int>&
-                             Vec4<int>::normalize () IMATH_NOEXCEPT = delete;
-template <> const Vec4<int>& Vec4<int>::normalizeExc ()             = delete;
-template <>
-IMATH_HOSTDEVICE const Vec4<int>&
-                       Vec4<int>::normalizeNonNull () IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE      Vec4<int>
-                      Vec4<int>::normalized () const IMATH_NOEXCEPT = delete;
-template <> Vec4<int> Vec4<int>::normalizedExc () const             = delete;
-template <>
-IMATH_HOSTDEVICE Vec4<int>
-                 Vec4<int>::normalizedNonNull () const IMATH_NOEXCEPT = delete;
-
-// Vec4<int64_t>
-template <>
-IMATH_HOSTDEVICE int64_t Vec4<int64_t>::length () const IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE const Vec4<int64_t>&
-                       Vec4<int64_t>::normalize () IMATH_NOEXCEPT = delete;
-template <> const Vec4<int64_t>& Vec4<int64_t>::normalizeExc ()   = delete;
-template <>
-IMATH_HOSTDEVICE const Vec4<int64_t>&
-Vec4<int64_t>::normalizeNonNull () IMATH_NOEXCEPT = delete;
-template <>
-IMATH_HOSTDEVICE Vec4<int64_t>
-                 Vec4<int64_t>::normalized () const IMATH_NOEXCEPT = delete;
-template <> Vec4<int64_t> Vec4<int64_t>::normalizedExc () const    = delete;
-template <>
-IMATH_HOSTDEVICE Vec4<int64_t>
-Vec4<int64_t>::normalizedNonNull () const IMATH_NOEXCEPT = delete;
-
-/// @endcond Doxygen_Suppress
 
 //------------------------
 // Implementation of Vec2:
@@ -1579,6 +1426,7 @@ Vec2<T>::lengthTiny () const IMATH_NOEXCEPT
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 IMATH_HOSTDEVICE inline T
 Vec2<T>::length () const IMATH_NOEXCEPT
 {
@@ -1598,6 +1446,7 @@ Vec2<T>::length2 () const IMATH_NOEXCEPT
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 IMATH_HOSTDEVICE inline const Vec2<T>&
 Vec2<T>::normalize () IMATH_NOEXCEPT
 {
@@ -1619,6 +1468,7 @@ Vec2<T>::normalize () IMATH_NOEXCEPT
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 inline const Vec2<T>&
 Vec2<T>::normalizeExc ()
 {
@@ -1633,6 +1483,7 @@ Vec2<T>::normalizeExc ()
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 IMATH_HOSTDEVICE inline const Vec2<T>&
 Vec2<T>::normalizeNonNull () IMATH_NOEXCEPT
 {
@@ -1643,6 +1494,7 @@ Vec2<T>::normalizeNonNull () IMATH_NOEXCEPT
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 IMATH_HOSTDEVICE inline Vec2<T>
 Vec2<T>::normalized () const IMATH_NOEXCEPT
 {
@@ -1654,6 +1506,7 @@ Vec2<T>::normalized () const IMATH_NOEXCEPT
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 inline Vec2<T>
 Vec2<T>::normalizedExc () const
 {
@@ -1666,6 +1519,7 @@ Vec2<T>::normalizedExc () const
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 IMATH_HOSTDEVICE inline Vec2<T>
 Vec2<T>::normalizedNonNull () const IMATH_NOEXCEPT
 {
@@ -2060,6 +1914,7 @@ Vec3<T>::lengthTiny () const IMATH_NOEXCEPT
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 IMATH_HOSTDEVICE inline T
 Vec3<T>::length () const IMATH_NOEXCEPT
 {
@@ -2079,6 +1934,7 @@ Vec3<T>::length2 () const IMATH_NOEXCEPT
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 IMATH_HOSTDEVICE inline const Vec3<T>&
 Vec3<T>::normalize () IMATH_NOEXCEPT
 {
@@ -2101,6 +1957,7 @@ Vec3<T>::normalize () IMATH_NOEXCEPT
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 inline const Vec3<T>&
 Vec3<T>::normalizeExc ()
 {
@@ -2116,6 +1973,7 @@ Vec3<T>::normalizeExc ()
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 IMATH_HOSTDEVICE inline const Vec3<T>&
 Vec3<T>::normalizeNonNull () IMATH_NOEXCEPT
 {
@@ -2127,6 +1985,7 @@ Vec3<T>::normalizeNonNull () IMATH_NOEXCEPT
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 IMATH_HOSTDEVICE inline Vec3<T>
 Vec3<T>::normalized () const IMATH_NOEXCEPT
 {
@@ -2138,6 +1997,7 @@ Vec3<T>::normalized () const IMATH_NOEXCEPT
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 inline Vec3<T>
 Vec3<T>::normalizedExc () const
 {
@@ -2150,6 +2010,7 @@ Vec3<T>::normalizedExc () const
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 IMATH_HOSTDEVICE inline Vec3<T>
 Vec3<T>::normalizedNonNull () const IMATH_NOEXCEPT
 {
@@ -2514,6 +2375,7 @@ Vec4<T>::lengthTiny () const IMATH_NOEXCEPT
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 IMATH_HOSTDEVICE inline T
 Vec4<T>::length () const IMATH_NOEXCEPT
 {
@@ -2533,7 +2395,8 @@ Vec4<T>::length2 () const IMATH_NOEXCEPT
 }
 
 template <class T>
-IMATH_HOSTDEVICE const inline Vec4<T>&
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+IMATH_HOSTDEVICE inline const Vec4<T>&
 Vec4<T>::normalize () IMATH_NOEXCEPT
 {
     T l = length ();
@@ -2556,7 +2419,8 @@ Vec4<T>::normalize () IMATH_NOEXCEPT
 }
 
 template <class T>
-const inline Vec4<T>&
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
+inline const Vec4<T>&
 Vec4<T>::normalizeExc ()
 {
     T l = length ();
@@ -2572,6 +2436,7 @@ Vec4<T>::normalizeExc ()
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 IMATH_HOSTDEVICE inline const Vec4<T>&
 Vec4<T>::normalizeNonNull () IMATH_NOEXCEPT
 {
@@ -2584,6 +2449,7 @@ Vec4<T>::normalizeNonNull () IMATH_NOEXCEPT
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 IMATH_HOSTDEVICE inline Vec4<T>
 Vec4<T>::normalized () const IMATH_NOEXCEPT
 {
@@ -2595,6 +2461,7 @@ Vec4<T>::normalized () const IMATH_NOEXCEPT
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 inline Vec4<T>
 Vec4<T>::normalizedExc () const
 {
@@ -2607,6 +2474,7 @@ Vec4<T>::normalizedExc () const
 }
 
 template <class T>
+template <typename S, IMATH_INTERNAL_NAMESPACE::enable_if_t<std::is_floating_point<S>::value, int>>
 IMATH_HOSTDEVICE inline Vec4<T>
 Vec4<T>::normalizedNonNull () const IMATH_NOEXCEPT
 {

--- a/src/ImathTest/testVec.cpp
+++ b/src/ImathTest/testVec.cpp
@@ -13,12 +13,340 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>
+#include <type_traits>
+#include <utility>
 
 // Include ImathForward *after* other headers to validate forward declarations
 #include <ImathForward.h>
 
 using namespace std;
 using namespace IMATH_INTERNAL_NAMESPACE;
+
+namespace
+{
+
+//
+// Compile-time detection of whether an expression is well-formed. This is
+// used to confirm that length(), normalize(), normalizeExc(),
+// normalizeNonNull(), normalized(), normalizedExc(), and
+// normalizedNonNull() are visible (via SFINAE) on Vec2/Vec3/Vec4 for
+// floating-point-like element types (float, double, half), and are not
+// visible at all for integer element types (short, int, int64_t).
+//
+
+#define IMATH_TEST_HAS_METHOD(name)                                            \
+    template <typename T, typename = void>                                     \
+    struct has_##name : std::false_type                                        \
+    {};                                                                        \
+    template <typename T>                                                      \
+    struct has_##name<                                                         \
+        T,                                                                     \
+        decltype ((void) std::declval<T> ().name ())> : std::true_type         \
+    {}
+
+IMATH_TEST_HAS_METHOD (length);
+IMATH_TEST_HAS_METHOD (normalize);
+IMATH_TEST_HAS_METHOD (normalizeExc);
+IMATH_TEST_HAS_METHOD (normalizeNonNull);
+IMATH_TEST_HAS_METHOD (normalized);
+IMATH_TEST_HAS_METHOD (normalizedExc);
+IMATH_TEST_HAS_METHOD (normalizedNonNull);
+
+#undef IMATH_TEST_HAS_METHOD
+
+// Confirm that the given VecN<T> supports all of length()/normalize()/etc.
+#define IMATH_STATIC_ASSERT_HAS_ALL(Vec, T)                                    \
+    static_assert (has_length<Vec<T>>::value, #Vec "<" #T ">::length");        \
+    static_assert (has_normalize<Vec<T>>::value, #Vec "<" #T ">::normalize");  \
+    static_assert (                                                            \
+        has_normalizeExc<Vec<T>>::value, #Vec "<" #T ">::normalizeExc");       \
+    static_assert (                                                            \
+        has_normalizeNonNull<Vec<T>>::value,                                   \
+        #Vec "<" #T ">::normalizeNonNull");                                    \
+    static_assert (                                                            \
+        has_normalized<Vec<T>>::value, #Vec "<" #T ">::normalized");           \
+    static_assert (                                                            \
+        has_normalizedExc<Vec<T>>::value, #Vec "<" #T ">::normalizedExc");     \
+    static_assert (                                                            \
+        has_normalizedNonNull<Vec<T>>::value,                                  \
+        #Vec "<" #T ">::normalizedNonNull")
+
+// Confirm that the given VecN<T> supports none of length()/normalize()/etc.
+#define IMATH_STATIC_ASSERT_HAS_NONE(Vec, T)                                   \
+    static_assert (!has_length<Vec<T>>::value, #Vec "<" #T ">::length");       \
+    static_assert (                                                            \
+        !has_normalize<Vec<T>>::value, #Vec "<" #T ">::normalize");            \
+    static_assert (                                                            \
+        !has_normalizeExc<Vec<T>>::value, #Vec "<" #T ">::normalizeExc");      \
+    static_assert (                                                            \
+        !has_normalizeNonNull<Vec<T>>::value,                                  \
+        #Vec "<" #T ">::normalizeNonNull");                                    \
+    static_assert (                                                            \
+        !has_normalized<Vec<T>>::value, #Vec "<" #T ">::normalized");          \
+    static_assert (                                                            \
+        !has_normalizedExc<Vec<T>>::value, #Vec "<" #T ">::normalizedExc");    \
+    static_assert (                                                            \
+        !has_normalizedNonNull<Vec<T>>::value,                                 \
+        #Vec "<" #T ">::normalizedNonNull")
+
+// Floating-point-like element types: length()/normalize()/etc. must be
+// present.
+IMATH_STATIC_ASSERT_HAS_ALL (Vec2, float);
+IMATH_STATIC_ASSERT_HAS_ALL (Vec2, double);
+IMATH_STATIC_ASSERT_HAS_ALL (Vec2, half);
+IMATH_STATIC_ASSERT_HAS_ALL (Vec3, float);
+IMATH_STATIC_ASSERT_HAS_ALL (Vec3, double);
+IMATH_STATIC_ASSERT_HAS_ALL (Vec3, half);
+IMATH_STATIC_ASSERT_HAS_ALL (Vec4, float);
+IMATH_STATIC_ASSERT_HAS_ALL (Vec4, double);
+IMATH_STATIC_ASSERT_HAS_ALL (Vec4, half);
+
+// Integer element types: length()/normalize()/etc. must not be present.
+IMATH_STATIC_ASSERT_HAS_NONE (Vec2, short);
+IMATH_STATIC_ASSERT_HAS_NONE (Vec2, int);
+IMATH_STATIC_ASSERT_HAS_NONE (Vec2, int64_t);
+IMATH_STATIC_ASSERT_HAS_NONE (Vec3, short);
+IMATH_STATIC_ASSERT_HAS_NONE (Vec3, int);
+IMATH_STATIC_ASSERT_HAS_NONE (Vec3, int64_t);
+IMATH_STATIC_ASSERT_HAS_NONE (Vec4, short);
+IMATH_STATIC_ASSERT_HAS_NONE (Vec4, int);
+IMATH_STATIC_ASSERT_HAS_NONE (Vec4, int64_t);
+
+//
+// An application-defined scalar class, analogous to `half`, that behaves
+// like a floating-point number but is not one of the builtin
+// floating-point types. An application that wants Vec2/Vec3/Vec4 of this
+// type to support length()/normalize()/etc. must specialize
+// Imath::is_float_like<> for it, exactly as Imath itself does for `half`.
+//
+class CustomFloat
+{
+public:
+    CustomFloat () IMATH_NOEXCEPT : _v (0.0) {}
+    CustomFloat (double v) IMATH_NOEXCEPT : _v (v) {}
+    operator double () const IMATH_NOEXCEPT { return _v; }
+
+    CustomFloat& operator+= (const CustomFloat& o) IMATH_NOEXCEPT
+    {
+        _v += o._v;
+        return *this;
+    }
+    CustomFloat& operator-= (const CustomFloat& o) IMATH_NOEXCEPT
+    {
+        _v -= o._v;
+        return *this;
+    }
+    CustomFloat& operator*= (const CustomFloat& o) IMATH_NOEXCEPT
+    {
+        _v *= o._v;
+        return *this;
+    }
+    CustomFloat& operator/= (const CustomFloat& o) IMATH_NOEXCEPT
+    {
+        _v /= o._v;
+        return *this;
+    }
+
+    friend CustomFloat
+    operator+ (CustomFloat a, const CustomFloat& b) IMATH_NOEXCEPT
+    {
+        a += b;
+        return a;
+    }
+    friend CustomFloat
+    operator- (CustomFloat a, const CustomFloat& b) IMATH_NOEXCEPT
+    {
+        a -= b;
+        return a;
+    }
+    friend CustomFloat
+    operator* (CustomFloat a, const CustomFloat& b) IMATH_NOEXCEPT
+    {
+        a *= b;
+        return a;
+    }
+    friend CustomFloat
+    operator/ (CustomFloat a, const CustomFloat& b) IMATH_NOEXCEPT
+    {
+        a /= b;
+        return a;
+    }
+    friend CustomFloat operator- (const CustomFloat& a) IMATH_NOEXCEPT
+    {
+        return CustomFloat (-a._v);
+    }
+
+    // Mixed CustomFloat/double overloads: without these, expressions like
+    // `customFloatValue * std::sqrt (x)` (which mixes CustomFloat with a
+    // plain double) are ambiguous, since both the implicit
+    // double-to-CustomFloat constructor and the implicit
+    // CustomFloat-to-double conversion operator are viable, equally-ranked
+    // conversions.
+    friend CustomFloat operator* (const CustomFloat& a, double b) IMATH_NOEXCEPT
+    {
+        return CustomFloat (a._v * b);
+    }
+    friend CustomFloat operator* (double a, const CustomFloat& b) IMATH_NOEXCEPT
+    {
+        return CustomFloat (a * b._v);
+    }
+
+    friend bool
+    operator== (const CustomFloat& a, const CustomFloat& b) IMATH_NOEXCEPT
+    {
+        return a._v == b._v;
+    }
+    friend bool
+    operator!= (const CustomFloat& a, const CustomFloat& b) IMATH_NOEXCEPT
+    {
+        return a._v != b._v;
+    }
+    friend bool
+    operator< (const CustomFloat& a, const CustomFloat& b) IMATH_NOEXCEPT
+    {
+        return a._v < b._v;
+    }
+    friend bool
+    operator> (const CustomFloat& a, const CustomFloat& b) IMATH_NOEXCEPT
+    {
+        return a._v > b._v;
+    }
+    friend bool
+    operator<= (const CustomFloat& a, const CustomFloat& b) IMATH_NOEXCEPT
+    {
+        return a._v <= b._v;
+    }
+    friend bool
+    operator>= (const CustomFloat& a, const CustomFloat& b) IMATH_NOEXCEPT
+    {
+        return a._v >= b._v;
+    }
+
+private:
+    double _v;
+};
+
+//
+// An application-defined scalar class for which length()/normalize()/etc.
+// should *not* be visible, because it does not represent a floating-point
+// quantity (e.g. some kind of identifier, index, or fixed-point count) and
+// the application does not specialize Imath::is_float_like<> for it.
+//
+class CustomNonFloat
+{
+public:
+    CustomNonFloat () IMATH_NOEXCEPT : _v (0) {}
+    CustomNonFloat (int v) IMATH_NOEXCEPT : _v (v) {}
+    operator int () const IMATH_NOEXCEPT { return _v; }
+
+    friend CustomNonFloat
+    operator+ (CustomNonFloat a, const CustomNonFloat& b) IMATH_NOEXCEPT
+    {
+        return CustomNonFloat (a._v + b._v);
+    }
+    friend CustomNonFloat
+    operator- (CustomNonFloat a, const CustomNonFloat& b) IMATH_NOEXCEPT
+    {
+        return CustomNonFloat (a._v - b._v);
+    }
+    friend CustomNonFloat
+    operator* (CustomNonFloat a, const CustomNonFloat& b) IMATH_NOEXCEPT
+    {
+        return CustomNonFloat (a._v * b._v);
+    }
+    friend bool operator== (
+        const CustomNonFloat& a, const CustomNonFloat& b) IMATH_NOEXCEPT
+    {
+        return a._v == b._v;
+    }
+
+private:
+    int _v;
+};
+
+} // namespace
+
+// Tell Imath that CustomFloat should be treated as float-like, exactly as
+// an application would do for its own custom scalar type. CustomNonFloat
+// is deliberately left unspecialized, so it defaults to
+// std::is_floating_point<CustomNonFloat>::value, i.e. false.
+IMATH_INTERNAL_NAMESPACE_SOURCE_ENTER
+template <> struct is_float_like<CustomFloat> : public std::true_type
+{};
+IMATH_INTERNAL_NAMESPACE_SOURCE_EXIT
+
+namespace
+{
+
+// Floating-point-like custom type: length()/normalize()/etc. must be
+// present.
+IMATH_STATIC_ASSERT_HAS_ALL (Vec2, CustomFloat);
+IMATH_STATIC_ASSERT_HAS_ALL (Vec3, CustomFloat);
+IMATH_STATIC_ASSERT_HAS_ALL (Vec4, CustomFloat);
+
+// Non-floating-point custom type: length()/normalize()/etc. must not be
+// present.
+IMATH_STATIC_ASSERT_HAS_NONE (Vec2, CustomNonFloat);
+IMATH_STATIC_ASSERT_HAS_NONE (Vec3, CustomNonFloat);
+IMATH_STATIC_ASSERT_HAS_NONE (Vec4, CustomNonFloat);
+
+#undef IMATH_STATIC_ASSERT_HAS_ALL
+#undef IMATH_STATIC_ASSERT_HAS_NONE
+
+void
+testCustomFloatLike ()
+{
+    const double e = 1e-9;
+
+    // Vec2<CustomFloat>
+    {
+        Vec2<CustomFloat> v (3, 4);
+        assert (
+            IMATH_INTERNAL_NAMESPACE::equal (double (v.length ()), 5.0, e));
+        assert (IMATH_INTERNAL_NAMESPACE::equal (
+            double (v.normalized ().length ()), 1.0, e));
+        v.normalize ();
+        assert (
+            IMATH_INTERNAL_NAMESPACE::equal (double (v.length ()), 1.0, e));
+    }
+
+    // Vec3<CustomFloat>
+    {
+        Vec3<CustomFloat> v (0, 3, 4);
+        assert (
+            IMATH_INTERNAL_NAMESPACE::equal (double (v.length ()), 5.0, e));
+        assert (IMATH_INTERNAL_NAMESPACE::equal (
+            double (v.normalized ().length ()), 1.0, e));
+        v.normalize ();
+        assert (
+            IMATH_INTERNAL_NAMESPACE::equal (double (v.length ()), 1.0, e));
+    }
+
+    // Vec4<CustomFloat>
+    {
+        Vec4<CustomFloat> v (0, 0, 3, 4);
+        assert (
+            IMATH_INTERNAL_NAMESPACE::equal (double (v.length ()), 5.0, e));
+        assert (IMATH_INTERNAL_NAMESPACE::equal (
+            double (v.normalized ().length ()), 1.0, e));
+        v.normalize ();
+        assert (
+            IMATH_INTERNAL_NAMESPACE::equal (double (v.length ()), 1.0, e));
+    }
+
+    // CustomNonFloat still supports ordinary Vec operations, such as
+    // arithmetic and equality, that are not gated by is_float_like<>.
+    {
+        Vec3<CustomNonFloat> a (1, 2, 3);
+        Vec3<CustomNonFloat> b (4, 5, 6);
+        Vec3<CustomNonFloat> c = a + b;
+        assert (int (c.x) == 5 && int (c.y) == 7 && int (c.z) == 9);
+        assert (a == a);
+        assert (!(a == b));
+    }
+}
+
+} // namespace
 
 namespace
 {
@@ -261,6 +589,8 @@ testVec ()
     testLength3T<double> ();
     testLength4T<float> ();
     testLength4T<double> ();
+
+    testCustomFloatLike ();
 
     cout << "ok\n" << endl;
 }

--- a/src/pybind11/PyBindImath/PyBindImathVec.h
+++ b/src/pybind11/PyBindImath/PyBindImathVec.h
@@ -387,13 +387,13 @@ template <class Vec>
 py::class_<Vec>
 register_vec_fp(py::class_<Vec> c)
 {
-    return c.def("length", &Vec::length, "return the magnitude of the vector")
-        .def("normalize", &Vec::normalize, "destructively normalizes v and returns a reference to it")
-        .def("normalizeExc", &Vec::normalizeExc, "destructively normalizes V and returns a reference to it, throwing an exception if length() == 0")
-        .def("normalizeNonNull",  &Vec::normalizeNonNull, "destructively normalizes V and returns a reference to it, faster if length() != 0")
-        .def("normalized", &Vec::normalized, "return a normalized copy of v")
-        .def("normalizedExc", &Vec::normalizedExc, "returnsa normalized copy of v, throwing an exception if length() == 0")
-        .def("normalizedNonNull", &Vec::normalizedNonNull, "return a normalized copy of v, faster if lngth() != 0")
+    return c.def("length", [](const Vec& self) { return self.length(); }, "return the magnitude of the vector")
+        .def("normalize", [](Vec& self) -> const Vec& { return self.normalize(); }, "destructively normalizes v and returns a reference to it")
+        .def("normalizeExc", [](Vec& self) -> const Vec& { return self.normalizeExc(); }, "destructively normalizes V and returns a reference to it, throwing an exception if length() == 0")
+        .def("normalizeNonNull",  [](Vec& self) -> const Vec& { return self.normalizeNonNull(); }, "destructively normalizes V and returns a reference to it, faster if length() != 0")
+        .def("normalized", [](const Vec& self) { return self.normalized(); }, "return a normalized copy of v")
+        .def("normalizedExc", [](const Vec& self) { return self.normalizedExc(); }, "returnsa normalized copy of v, throwing an exception if length() == 0")
+        .def("normalizedNonNull", [](const Vec& self) { return self.normalizedNonNull(); }, "return a normalized copy of v, faster if lngth() != 0")
         .def("orthogonal", orthogonal<Vec>, "return the vector that is perpendicular to this vector")
         .def("project", [](const Vec& self, const Vec& p) {
             // In C++/Imath it's a global function; in python it's a member:


### PR DESCRIPTION
## Summary

Fixes #559

Replace `= delete` template specializations with SFINAE using the existing `IMATH_ENABLE_IF` macro for `length()`, `normalize()`, `normalizeExc()`, `normalizeNonNull()`, `normalized()`, `normalizedExc()`, and `normalizedNonNull()` in Vec2, Vec3, and Vec4.

Removes the entire `Specializations for VecN<short>, VecN<int>` block  including the `@cond Doxygen_Suppress` wrapper which will no longer be needed when SFINAE makes the methods invisible to both the compiler and Doxygen for non-applicable types.

## Status

Draft PR. I will iterate based on feedback and open questions in #559