### PR TITLE
Fix broken links and roster identified in ASWF Health Check 2026

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ follows OpenEXR's governance and contribution policies.
 For a description of the roles and responsibilities of the various
 members of the OpenEXR community, see [GOVERNANCE](GOVERNANCE.md), and
 for further details, see the OpenEXR project's [Technical
-Charter](ASWF/charter/OpenEXR-Technical-Charter.md). Briefly,
+Charter](https://github.com/AcademySoftwareFoundation/openexr/blob/main/ASWF/charter/OpenEXR-Technical-Charter.md). Briefly,
 a "contributor" is anyone who submits content to the project, a
 "committer" reviews and approves such submissions, and the "Technical
 Steering Committee" provides general project oversight and governance.
@@ -40,7 +40,7 @@ There are two primary ways to connect with the Imath project:
 If you have trouble installing, building, or using the library, but
 there's not yet reason to suspect you've encountered a genuine bug,
 start by posting a question to the
-[openexr-dev](http://lists.aswf.io/openexr-dev) mailing list. This is
+[openexr-dev](https://lists.aswf.io/g/openexr-dev) mailing list. This is
 the place for question such has "How do I...".
 
 ### How to Report a Bug
@@ -236,7 +236,7 @@ who may discuss, offer constructive feedback, request changes, or approve
 the work.
 
 6. Upon receiving the required number of committer approvals (as
-outlined in [Required Approvals](#required-approvals)), a committer
+outlined in [Required Approvals](#code-review-and-required-approvals)), a committer
 other than the PR contributor may merge changes into the ``main``
 branch.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -76,7 +76,7 @@ info@openexr.com.
 
 The Technical Steering Committee (TSC) oversees the overall technical
 direction of OpenEXR, as defined in the project
-[charter](ASWF/charter/OpenEXR-Technical-Charter.md).  This
+[charter](https://github.com/AcademySoftwareFoundation/openexr/blob/main/ASWF/charter/OpenEXR-Technical-Charter.md).  This
 charter defines the TSC member terms and succession policies.
 
 The responsibilities of the TSC include:
@@ -115,7 +115,7 @@ represents the project at ASWF TAC meetings.
 * Kimball Thurston - Weta Digital, Ltd.
 * Nick Porcino - Pixar Animation Studios
 * Christina Tempelaar-Lietz - Industrial Light & Magic
-* Joseph Goldstone - ARRI
+* Joseph Goldstone - Lilliputian Pictures LLC
 * John Mertic - The Linux Foundation
 
 ### TSC Meetings

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ or numerical analysis package.
 
 OpenEXR is a project of the [Academy Software
 Foundation](https://www.aswf.io). See the project's [governance
-policies](GOVERNANCE.md), [contribution guidelines](CONTRIBzuTING.md), and [code of conduct](CODE_OF_CONDUCT)
+policies](GOVERNANCE.md), [contribution guidelines](CONTRIBUTING.md), and [code of conduct](CODE_OF_CONDUCT.md)
 for more information.
 
 The OpenEXR project is dedicated to promoting a harassment-free


### PR DESCRIPTION
README.md:
  - CONTRIBzuTING.md → CONTRIBUTING.md
  - CODE_OF_CONDUCT → CODE_OF_CONDUCT.md GOVERNANCE.md:
  - Joseph Goldstone affiliation: ARRI → Lilliputian Pictures LLC
  - Charter link: relative ASWF/ path → full GitHub URL (path doesn't exist in this repo) CONTRIBUTING.md:
  - Charter link: relative ASWF/ path → full GitHub URL
  - http://lists.aswf.io/openexr-dev → https://lists.aswf.io/g/openexr-dev
  - #required-approvals → #code-review-and-required-approvals