### PR TITLE
Avoid installing ImathConfig.h twice

### DIFF
--- a/share/ci/install_manifest/install_manifest.linux.2.txt
+++ b/share/ci/install_manifest/install_manifest.linux.2.txt
@@ -6,7 +6,6 @@ include/Imath/ImathBoxAlgo.h
 include/Imath/ImathColor.h
 include/Imath/ImathColorAlgo.h
 include/Imath/ImathConfig.h
-include/Imath/ImathConfig.h
 include/Imath/ImathEuler.h
 include/Imath/ImathExport.h
 include/Imath/ImathForward.h

--- a/share/ci/install_manifest/install_manifest.windows.11.txt
+++ b/share/ci/install_manifest/install_manifest.windows.11.txt
@@ -10,7 +10,6 @@ include/Imath/ImathBoxAlgo.h
 include/Imath/ImathColor.h
 include/Imath/ImathColorAlgo.h
 include/Imath/ImathConfig.h
-include/Imath/ImathConfig.h
 include/Imath/ImathEuler.h
 include/Imath/ImathExport.h
 include/Imath/ImathForward.h

--- a/src/Imath/CMakeLists.txt
+++ b/src/Imath/CMakeLists.txt
@@ -51,8 +51,17 @@ set(IMATH_HEADERS
     ImathTypeTraits.h
     ImathVec.h
     ImathVecAlgo.h
-    ${IMATH_CONFIG_DIR}/ImathConfig.h
 )
+
+if (IMATH_BUILD_APPLE_FRAMEWORKS)
+    # config/CMakeLists.txt skips the explicit install() of
+    # ImathConfig.h for Apple framework builds, so it must be
+    # included here as a PUBLIC_HEADER so it ends up in
+    # Imath.framework/Headers. For non-framework builds,
+    # config/CMakeLists.txt installs it explicitly, so it must NOT
+    # be listed here too, or it gets installed twice.
+    list(APPEND IMATH_HEADERS ${IMATH_CONFIG_DIR}/ImathConfig.h)
+endif()
 
 if(BUILD_SHARED_LIBS)
 


### PR DESCRIPTION
ImathConfig.h was installed twice:
1. config/CMakeLists.txt explicitly includes it in `install(FILES ...)`
2. src/Imath/CMakeLists.txt also includes it in `IMATH_HEADERS`

The result is that it appears in the install manifest twice.

This removes it from `IMATH_HEADERS` in src/Imath/CMakeLists.txt