### PR TITLE
Add windows msys2-clang64 CI job

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -246,6 +246,12 @@ jobs:
             python: 'OFF' # TODO: conan won't build boost.python w/msys2, please help find why!
             IMATH_TEST_PYBIND11: 'OFF' # TODO: "import pybindimath" fails on Windows, please help find why!
             
+          - build: 10
+            label: msys2-clang64
+            msystem: CLANG64
+            python: 'OFF' # TODO: conan won't build boost.python w/msys2, please help find why!
+            IMATH_TEST_PYBIND11: 'OFF' # TODO: "import pybindimath" fails on Windows, please help find why!
+
           - build: 11
             label: clang
             cxx-compiler: clang++

--- a/share/ci/install_manifest/install_manifest.windows.10.txt
+++ b/share/ci/install_manifest/install_manifest.windows.10.txt
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) Contributors to the OpenEXR Project.
-# cmake -B . -S ..       -DCMAKE_INSTALL_PREFIX=../_install       -DCMAKE_BUILD_TYPE=Release       -DCMAKE_CXX_STANDARD=17       -DBUILD_SHARED_LIBS=OFF       -DIMATH_INSTALL_PKG_CONFIG=ON       -DBUILD_TESTING=ON       -DPYTHON=OFF       -DPYBIND11=OFF       -DCMAKE_VERBOSE_MAKEFILE=ON
+# cmake -B /d/a/Imath/Imath/_build -S /d/a/Imath/Imath -DCMAKE_INSTALL_PREFIX=/d/a/Imath/Imath/_install -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=14 -DBUILD_SHARED_LIBS=ON -DIMATH_INSTALL_PKG_CONFIG=ON -DIMATH_INSTALL_SYM_LINK=ON -DIMATH_BUILD_APPLE_FRAMEWORKS= -DBUILD_TESTING=ON -DPYTHON=OFF -DPYBIND11=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DPython3_EXECUTABLE=/c/hostedtoolcache/windows/Python/3.12.10/x64/python -DPYTHON_INSTALL_DIR=/d/a/Imath/Imath/_install/python -DIMATH_TEST_PYTHON=ON -DIMATH_TEST_PYBIND11=OFF -Dpybind11_DIR=/c/hostedtoolcache/windows/Python/3.12.10/x64/Lib/site-packages/pybind11/share/cmake/pybind11 -DCMAKE_POLICY_DEFAULT_CMP0091=NEW 
+bin/libImath-$MAJOR_$MINOR.dll
+bin/libImath.dll
+bin/libPyBindImath.dll
+bin/libPyBindImath_Python$PYTHONMAJOR_$PYTHONMINOR-$MAJOR_$MINOR.dll
 include/Imath/ImathBox.h
 include/Imath/ImathBoxAlgo.h
 include/Imath/ImathColor.h
@@ -33,12 +37,19 @@ include/Imath/ImathSphere.h
 include/Imath/ImathTypeTraits.h
 include/Imath/ImathVec.h
 include/Imath/ImathVecAlgo.h
+include/Imath/PyBindImath.h
+include/Imath/PyBindImathExport.h
 include/Imath/half.h
 include/Imath/halfFunction.h
 include/Imath/halfLimits.h
+lib/libImath-$MAJOR_$MINOR.dll.a
+lib/libPyBindImath_Python$PYTHONMAJOR_$PYTHONMINOR-$MAJOR_$MINOR.dll.a
 lib/cmake/Imath/ImathConfig.cmake
 lib/cmake/Imath/ImathConfigVersion.cmake
 lib/cmake/Imath/ImathTargets-release.cmake
 lib/cmake/Imath/ImathTargets.cmake
-lib/libImath-$MAJOR_$MINOR.a
+lib/cmake/Imath/PyBindImathTargets-release.cmake
+lib/cmake/Imath/PyBindImathTargets.cmake
 lib/pkgconfig/Imath.pc
+lib/pkgconfig/PyBindImath.pc
+python/pybindimath.cp$PYTHONMAJOR$PYTHONMINOR-win_amd64.pyd

--- a/src/pybind11/PyBindImath/PyBindImathExport.h
+++ b/src/pybind11/PyBindImath/PyBindImathExport.h
@@ -8,7 +8,7 @@
 #ifndef PYBINDIMATHEXPORT_H
 #define PYBINDIMATHEXPORT_H
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
     #if defined(IMATH_DLL)
         #if defined(PYBINDIMATH_BUILD)
             #define PYBINDIMATH_EXPORT __declspec(dllexport)


### PR DESCRIPTION
Windows build #10 - uses the MSYS2 CLANG64 environment, the non-Microsoft toolchain. 

Windows build #11 - MSVC's toolchain, but the compiler frontend is clang instead of cl.exe.

So, two entirely different clangs.

A previous build numbered "10" had been removed from the yml but the install manifest was still there, so this edits its in place.

This also fixes a clang64 build failure in PyBindImath.